### PR TITLE
Fixes for undefined behaviour during script execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/object_script.*
 buildScripts/vera++/params
 buildScripts/.pyenv-*/
 .qmake.cache

--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/robotModel.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/robotModel.h
@@ -79,7 +79,7 @@ public:
 	void stopRobot();
 	void playSound(int timeInMs);
 
-	void setNewMotor(int speed, uint degrees, const kitBase::robotModel::PortInfo &port, bool breakMode);
+	Q_INVOKABLE void setNewMotor(int speed, uint degrees, const kitBase::robotModel::PortInfo &port, bool breakMode);
 
 	SensorsConfiguration &configuration();
 
@@ -92,8 +92,8 @@ public:
 	/// Returns a reference to external robot description.
 	robotModel::TwoDRobotModel &info() const;
 
-	int readEncoder(const kitBase::robotModel::PortInfo &port) const;
-	void resetEncoder(const kitBase::robotModel::PortInfo &port);
+	Q_INVOKABLE int readEncoder(const kitBase::robotModel::PortInfo &port) const;
+	Q_INVOKABLE void resetEncoder(const kitBase::robotModel::PortInfo &port);
 
 	QPointF position() const;
 	void setPosition(const QPointF &newPos);
@@ -135,10 +135,10 @@ public:
 	QGraphicsItem *startPositionMarker() const;
 
 	/// Returns accelerometer sensor data.
-	QVector<int> accelerometerReading() const;
+	Q_INVOKABLE QVector<int> accelerometerReading() const;
 
 	/// Returns gyroscope sensor data.
-	QVector<int> gyroscopeReading() const;
+	Q_INVOKABLE QVector<int> gyroscopeReading() const;
 
 	/// Returns a bounding path of robot and its sensors in scene coordinates.
 	QPainterPath robotBoundingPath() const;

--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/timeline.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/timeline.h
@@ -81,6 +81,7 @@ signals:
 private slots:
 	void onTimer();
 	void gotoNextFrame();
+	utils::AbstractTimer *produceTimerImpl();
 
 private:
 	static const int defaultRealTimeInterval = 0;

--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/worldModel.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/worldModel.h
@@ -58,7 +58,7 @@ public:
 	qreal pixelsInCm() const;
 
 	/// Measures the distance between robot and wall
-	int sonarReading(const QPointF &position, qreal direction) const;
+	Q_INVOKABLE int sonarReading(const QPointF &position, qreal direction) const;
 
 	/// Returns area which is seen by sonar sensor.
 	QPainterPath sonarScanningRegion(const QPointF &position, qreal direction, int range = 255) const;

--- a/plugins/robots/common/twoDModel/src/engine/model/modelTimer.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/modelTimer.cpp
@@ -27,6 +27,10 @@ ModelTimer::ModelTimer(const Timeline *timeline)
 	connect(timeline, SIGNAL(tick()), this, SLOT(onTick()));
 }
 
+ModelTimer::~ModelTimer()
+{
+}
+
 bool ModelTimer::isTicking() const
 {
 	return mListening;

--- a/plugins/robots/common/twoDModel/src/engine/model/modelTimer.h
+++ b/plugins/robots/common/twoDModel/src/engine/model/modelTimer.h
@@ -28,6 +28,7 @@ class ModelTimer : public utils::AbstractTimer
 
 public:
 	explicit ModelTimer(const Timeline *timeline /* Doesn`t take ownership */);
+	~ModelTimer() override;
 
 	bool isTicking() const override;
 	int interval() const override;

--- a/plugins/robots/common/twoDModel/src/engine/twoDModelEngineApi.h
+++ b/plugins/robots/common/twoDModel/src/engine/twoDModelEngineApi.h
@@ -30,9 +30,10 @@ class FakeScene;
 
 class TwoDModelEngineApi : public engine::TwoDModelEngineInterface
 {
+
 public:
 	TwoDModelEngineApi(model::Model &model, view::TwoDModelWidget &view);
-	~TwoDModelEngineApi();
+	~TwoDModelEngineApi() override;
 
 	void setNewMotor(int speed, uint degrees
 			, const kitBase::robotModel::PortInfo &port, bool breakMode) override;


### PR DESCRIPTION
The problem was that during each script execution robot drived different pathes. This was caused by incosistency of the next actions:
1. ModelTimer was created in other thread than Timeline.
2. Execution of engine methods (readEncoder, readSensor, etc) were provided in thread, where ScriptThread lives, instead of thread, where Timeline lives.
We understand that this way of method execution can increase the load, so in the future this code should be redesigned. 