### PR TITLE
Removed ubsan sanitezers for vptr

### DIFF
--- a/global.pri
+++ b/global.pri
@@ -146,9 +146,9 @@ unix:!nosanitizers {
 		# They can change in some version of Qt, keep track of it.
 		# By the way, simply setting QMAKE_CFLAGS, QMAKE_CXXFLAGS and QMAKE_LFLAGS instead of those used below
 		# will not work due to arguments order ("-fsanitize=undefined" must be declared before "-fno-sanitize=vptr").
-#			QMAKE_SANITIZE_UNDEFINED_CFLAGS += -fno-sanitize=vptr
-#			QMAKE_SANITIZE_UNDEFINED_CXXFLAGS += -fno-sanitize=vptr
-#			QMAKE_SANITIZE_UNDEFINED_LFLAGS += -fno-sanitize=vptr
+			QMAKE_SANITIZE_UNDEFINED_CFLAGS += -fno-sanitize=vptr
+			QMAKE_SANITIZE_UNDEFINED_CXXFLAGS += -fno-sanitize=vptr
+			QMAKE_SANITIZE_UNDEFINED_LFLAGS += -fno-sanitize=vptr
 		}
 	}
 


### PR DESCRIPTION
Was done due to strange crashes about ModelTimer "ubsan_handle_dynamic_type_cache_miss" 