### PR TITLE
[googletest] & [trikRuntime] submodule update

### DIFF
--- a/global.pri
+++ b/global.pri
@@ -29,7 +29,7 @@ macx {
 
 CONFIG *= qt
 
-!win32:CONFIG *= ltcg use_gold_linker
+!win32:CONFIG *= use_gold_linker
 #CONFIG *= fat-lto
 
 #deal with mixed configurations


### PR DESCRIPTION
Fix build with `lupdate`/`git status` checks: problem was in trik-pythonqt (but in Qt's qt_functions.prf, actually)