### PR TITLE
Installer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "thirdparty/gamepad/gamepad"]
 	path = thirdparty/gamepad/gamepad
 	url = https://github.com/trikset/trik-desktop-gamepad
+[submodule "installer/nxt-tools"]
+	path = installer/nxt-tools
+	url = https://github.com/qreal/nxt-tools

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ install:
   - set PATH=%QTDIR%\bin;%MINGW%\bin;C:\msys64\usr\bin;%PATH%
 # need to reconfigure because it is anouther one git
   - git config --global core.autocrlf true
-  - pacman --verbose --noconfirm --sync ccache rsync curl
+  - pacman --verbose --noconfirm --sync ccache rsync curl unzip
 #--refresh --sysupgrade --ask=20
   - ccache.exe -V || appveyor DownloadFile "http://alam.srb2.org/ccache.exe" -FileName "ccache.exe" && xcopy /Y /V /I ccache.exe %MINGW%\bin && ccache -V
   - ccache -p || echo "Failed to print ccache config (missing -p option)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,9 @@ clone_script:
 
 
 install:
-  - set PATH=C:\Program Files\Git\cmd;%QTDIR%\bin;%MINGW%\bin;C:\msys64\usr\bin;%PATH%
+  - set PATH=%QTDIR%\bin;%MINGW%\bin;C:\msys64\usr\bin;%PATH%
+# need to reconfigure because it is anouther one git
+  - git config --global core.autocrlf true
   - pacman --verbose --noconfirm --sync ccache rsync curl
 #--refresh --sysupgrade --ask=20
   - ccache.exe -V || appveyor DownloadFile "http://alam.srb2.org/ccache.exe" -FileName "ccache.exe" && xcopy /Y /V /I ccache.exe %MINGW%\bin && ccache -V

--- a/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-common.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-common.sh
@@ -7,3 +7,8 @@ source $INSTALLER_ROOT/utils/common_utils.sh
 cd "$(dirname "$0")"
 rm -rf ../data
 mkdir -p $PWD/../data/
+
+if [ ! -d $INSTALLER_ROOT/nxt-tools ]
+then
+  git submodule update --init --recursive $INSTALLER_ROOT/nxt-tools
+fi

--- a/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-common.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-common.sh
@@ -6,7 +6,4 @@ source $INSTALLER_ROOT/utils/common_utils.sh
 
 cd "$(dirname "$0")"
 rm -rf ../data
-mkdir -p $PWD/../data/bin
-cd $PWD/../data/bin
-
-git clone  --depth 1 https://github.com/qreal/nxt-tools.git
+mkdir -p $PWD/../data/

--- a/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-linux-gnu.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-linux-gnu.sh
@@ -4,7 +4,6 @@ set -o errexit
 
 cd "$(dirname "$0")"
 source $INSTALLER_ROOT/utils/common_utils.sh
+mkdir $PWD/../data/bin
 cd $PWD/../data/bin
-mv nxt-tools tmp
-mv tmp/linux/nxt-tools -t .
-rm -rf tmp
+cp -rf $INSTALLER_ROOT/nxt-tools/linux/nxt-tools -t .

--- a/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-mac.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-mac.sh
@@ -4,7 +4,3 @@ set -o errexit
 
 cd "$(dirname "$0")"
 source $INSTALLER_ROOT/utils/common_utils.sh
-
-
-cd "$(dirname "$0")"/../data/bin
-rm -rf nxt-tools

--- a/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-win32.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-win32.sh
@@ -7,6 +7,7 @@ source $INSTALLER_ROOT/utils/common_utils.sh
 
 cd $PWD/../data
 
-mv bin/nxt-tools/win/nxt-tools -t .
+git submodule update --init --recursive
+cp -rf $INSTALLER_ROOT/nxt-tools/win/nxt-tools .
 dos2unix nxt-tools/compile.sh
 rm -rf bin

--- a/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-win32.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.nxt.tools/meta/prebuild-win32.sh
@@ -7,7 +7,6 @@ source $INSTALLER_ROOT/utils/common_utils.sh
 
 cd $PWD/../data
 
-git submodule update --init --recursive
 cp -rf $INSTALLER_ROOT/nxt-tools/win/nxt-tools .
 dos2unix nxt-tools/compile.sh
 rm -rf bin

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
@@ -24,28 +24,37 @@ cp    $BIN_DIR/vcruntime*.dll                                                   
 cp    $BIN_DIR/system.js                                                          $PWD/../data/bin/
 cp    $BIN_DIR/system.py                                                          $PWD/../data/bin/
 
-cache_dir=$(cygpath -m $APPDATA | xargs cygpath)/$PRODUCT/installer_cache
+winscp_ver=5.15
+putty_ver=0.71
+cache_dir=$(cygpath $APPDATA)/$PRODUCT/installer_cache
 # may be need anouther check about all winscp/putty files
-if [ ! -d $cache_dir/winscp ]
+if [ ! -d $cache_dir/PuTTY_$putty_ver ]
 then
-# download putty and winscp
-putty_server="https://the.earth.li/~sgtatham/putty/0.71/"
-winscp_file="https://sourceforge.net/projects/winscp/files/WinSCP/5.15/WinSCP-5.15-Portable.zip"
-mkdir -p $cache_dir/winscp/PuTTY
+# download putty
+putty_server="https://the.earth.li/~sgtatham/putty/$putty_ver/"
+mkdir -p $cache_dir/PuTTY_$putty_ver
 
 for file in putty puttygen pageant
 do
-  curl -L -s -o $cache_dir/winscp/PuTTY/$file.exe $putty_server/w32/$file.exe &
+  curl -L -s -o $cache_dir/PuTTY_$putty_ver/$file.exe $putty_server/w32/$file.exe &
 done
-curl -L -s -o $cache_dir/winscp/PuTTY/putty.chm $putty_server/putty.chm &
-
-curl -L -s -o $cache_dir/winscp.zip https://sourceforge.net/projects/winscp/files/WinSCP/5.15/WinSCP-5.15-Portable.zip
-unzip -o $cache_dir/winscp.zip -d $cache_dir/winscp
-rm -f $cache_dir/winscp.zip
-wait
-# end of download
+curl -L -s -o $cache_dir/PuTTY_$putty_ver/putty.chm $putty_server/putty.chm &
+# end of download winscp
 fi
 
+if [ ! -d $cache_dir/winscp_$winscp_ver ]
+then
+# download winscp
+winscp_zip="https://sourceforge.net/projects/winscp/files/WinSCP/$winscp_ver/WinSCP-$winscp_ver-Portable.zip"
+curl -L -s -o $cache_dir/winscp.zip $winscp_zip
+unzip -o $cache_dir/winscp.zip -d $cache_dir/winscp_$winscp_ver
+rm -f $cache_dir/winscp.zip
+# end of download winscp
+fi
+
+wait
+
 cd "$(dirname "$0")"/../data
-cp -r $cache_dir/winscp .
+cp -r $cache_dir/winscp_$winscp_ver winscp
+cp -r $cache_dir/PuTTY_$putty_ver winscp/PuTTY
 cp -f winscp/license.txt "$(dirname "$0")"/WinScp-license.txt

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
@@ -25,7 +25,17 @@ cp    $BIN_DIR/system.js                                                        
 cp    $BIN_DIR/system.py                                                          $PWD/../data/bin/
 
 cd "$(dirname "$0")"/../data
-rm -rf trik-runtime-builds
-git clone  --depth 1 https://github.com/qreal/trik-runtime-builds
-mv trik-runtime-builds/winscp .
-rm -rf trik-runtime-builds
+putty_server="https://the.earth.li/~sgtatham/putty/latest"
+mkdir -p winscp/PuTTY
+
+for file in putty puttygen pageant
+do
+  curl -L -s -o winscp/PuTTY/$file.exe $putty_server/w64/$file.exe &
+done
+curl -L -s -o winscp/PuTTY/putty.chm $putty_server/putty.chm &
+
+curl -L -s -o winscp.zip https://sourceforge.net/projects/winscp/files/WinSCP/5.15/WinSCP-5.15-Portable.zip
+unzip winscp.zip -d winscp
+rm -f winscp.zip
+
+wait

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
@@ -24,8 +24,11 @@ cp    $BIN_DIR/vcruntime*.dll                                                   
 cp    $BIN_DIR/system.js                                                          $PWD/../data/bin/
 cp    $BIN_DIR/system.py                                                          $PWD/../data/bin/
 
-# download putty and winscp
 cache_dir=$(cygpath -m $APPDATA | xargs cygpath)/$PRODUCT/installer_cache
+# may be need anouther check about all winscp/putty files
+if [ ! -d $cache_dir/winscp ]
+then
+# download putty and winscp
 putty_server="https://the.earth.li/~sgtatham/putty/0.71/"
 winscp_file="https://sourceforge.net/projects/winscp/files/WinSCP/5.15/WinSCP-5.15-Portable.zip"
 mkdir -p $cache_dir/winscp/PuTTY
@@ -41,6 +44,7 @@ unzip -o $cache_dir/winscp.zip -d $cache_dir/winscp
 rm -f $cache_dir/winscp.zip
 wait
 # end of download
+fi
 
 cd "$(dirname "$0")"/../data
 cp -r $cache_dir/winscp .

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
@@ -26,35 +26,39 @@ cp    $BIN_DIR/system.py                                                        
 
 winscp_ver=5.15
 putty_ver=0.71
-cache_dir=$(cygpath $APPDATA)/$PRODUCT/installer_cache
+cache_dir="$(cygpath $APPDATA)"/$PRODUCT/installer_cache
+mkdir -p "$cache_dir"
+cd "$cache_dir"
+
 # may be need anouther check about all winscp/putty files
-if [ ! -d $cache_dir/PuTTY_$putty_ver ]
+if [ ! -d PuTTY_$putty_ver ]
 then
 # download putty
 putty_server="https://the.earth.li/~sgtatham/putty/$putty_ver/"
-mkdir -p $cache_dir/PuTTY_$putty_ver
+mkdir -p PuTTY_$putty_ver
 
 for file in putty puttygen pageant
 do
-  curl -L -s -o $cache_dir/PuTTY_$putty_ver/$file.exe $putty_server/w32/$file.exe &
+  curl -L -s -o PuTTY_$putty_ver/$file.exe $putty_server/w32/$file.exe &
 done
-curl -L -s -o $cache_dir/PuTTY_$putty_ver/putty.chm $putty_server/putty.chm &
+curl -L -s -o PuTTY_$putty_ver/putty.chm $putty_server/putty.chm &
 # end of download winscp
 fi
 
-if [ ! -d $cache_dir/winscp_$winscp_ver ]
+if [ ! -d winscp_$winscp_ver ]
 then
 # download winscp
 winscp_zip="https://sourceforge.net/projects/winscp/files/WinSCP/$winscp_ver/WinSCP-$winscp_ver-Portable.zip"
-curl -L -s -o $cache_dir/winscp.zip $winscp_zip
-unzip -o $cache_dir/winscp.zip -d $cache_dir/winscp_$winscp_ver
-rm -f $cache_dir/winscp.zip
+
+curl -L -s -o winscp.zip $winscp_zip
+unzip -o winscp.zip -d winscp_$winscp_ver
+rm -f winscp.zip
 # end of download winscp
 fi
 
 wait
 
 cd "$(dirname "$0")"/../data
-cp -r $cache_dir/winscp_$winscp_ver winscp
-cp -r $cache_dir/PuTTY_$putty_ver winscp/PuTTY
+cp -r "$cache_dir"/winscp_$winscp_ver winscp
+cp -r "$cache_dir"/PuTTY_$putty_ver winscp/PuTTY
 cp -f winscp/license.txt "$(dirname "$0")"/WinScp-license.txt

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-win32.sh
@@ -24,18 +24,24 @@ cp    $BIN_DIR/vcruntime*.dll                                                   
 cp    $BIN_DIR/system.js                                                          $PWD/../data/bin/
 cp    $BIN_DIR/system.py                                                          $PWD/../data/bin/
 
-cd "$(dirname "$0")"/../data
-putty_server="https://the.earth.li/~sgtatham/putty/latest"
-mkdir -p winscp/PuTTY
+# download putty and winscp
+cache_dir=$(cygpath -m $APPDATA | xargs cygpath)/$PRODUCT/installer_cache
+putty_server="https://the.earth.li/~sgtatham/putty/0.71/"
+winscp_file="https://sourceforge.net/projects/winscp/files/WinSCP/5.15/WinSCP-5.15-Portable.zip"
+mkdir -p $cache_dir/winscp/PuTTY
 
 for file in putty puttygen pageant
 do
-  curl -L -s -o winscp/PuTTY/$file.exe $putty_server/w64/$file.exe &
+  curl -L -s -o $cache_dir/winscp/PuTTY/$file.exe $putty_server/w32/$file.exe &
 done
-curl -L -s -o winscp/PuTTY/putty.chm $putty_server/putty.chm &
+curl -L -s -o $cache_dir/winscp/PuTTY/putty.chm $putty_server/putty.chm &
 
-curl -L -s -o winscp.zip https://sourceforge.net/projects/winscp/files/WinSCP/5.15/WinSCP-5.15-Portable.zip
-unzip winscp.zip -d winscp
-rm -f winscp.zip
-
+curl -L -s -o $cache_dir/winscp.zip https://sourceforge.net/projects/winscp/files/WinSCP/5.15/WinSCP-5.15-Portable.zip
+unzip -o $cache_dir/winscp.zip -d $cache_dir/winscp
+rm -f $cache_dir/winscp.zip
 wait
+# end of download
+
+cd "$(dirname "$0")"/../data
+cp -r $cache_dir/winscp .
+cp -f winscp/license.txt "$(dirname "$0")"/WinScp-license.txt


### PR DESCRIPTION
winscp и putty кэшируются в памяти и nxt-tools подключены в качестве субмодуля, благодаря чему нет необходимости скачивать их каждый раз при сборке инсталлера