### PR TITLE
responseSlot accepts QVariant

### DIFF
--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForAccelerometerBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForAccelerometerBlock.h
@@ -30,7 +30,7 @@ public:
 	explicit WaitForAccelerometerSensorBlock(robotModel::RobotModelInterface &robotModel);
 
 protected slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 protected:
 	robotModel::DeviceInfo device() const override;

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForColorBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForColorBlock.h
@@ -30,7 +30,7 @@ public:
 	explicit WaitForColorBlock(robotModel::RobotModelInterface &robotModel);
 
 protected slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 private:
 	robotModel::DeviceInfo device() const override;

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForColorIntensityBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForColorIntensityBlock.h
@@ -30,7 +30,7 @@ public:
 	explicit WaitForColorIntensityBlock(robotModel::RobotModelInterface &robotModel);
 
 protected slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 };
 
 }

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForEncoderBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForEncoderBlock.h
@@ -37,7 +37,7 @@ public:
 
 private slots:
 	/// Called when new data from encoder ready, checks it against "TachoLimit" property.
-	void responseSlot(int reading);
+	void responseSlot(const QVariant &reading) override;
 
 private:
 	robotModel::DeviceInfo device() const override;

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForGyroscopeSensorBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForGyroscopeSensorBlock.h
@@ -30,7 +30,7 @@ public:
 	explicit WaitForGyroscopeSensorBlock(robotModel::RobotModelInterface &robotModel);
 
 protected slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 protected:
 	robotModel::DeviceInfo device() const override;

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForLightSensorBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForLightSensorBlock.h
@@ -30,7 +30,7 @@ public:
 	explicit WaitForLightSensorBlock(robotModel::RobotModelInterface &robotModel);
 
 protected slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 protected:
 	robotModel::DeviceInfo device() const override;

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForSensorBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForSensorBlock.h
@@ -43,7 +43,7 @@ protected:
 
 private:
 	/// Shall be reimplemented to do value check when new data from sensor is ready.
-	virtual void responseSlot(int reading) = 0;
+	virtual void responseSlot(const QVariant &reading) = 0;
 };
 
 }

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForSonarDistanceBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForSonarDistanceBlock.h
@@ -30,7 +30,7 @@ public:
 	WaitForSonarDistanceBlock(robotModel::RobotModelInterface &robotModel, const robotModel::DeviceInfo &device);
 
 protected slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 protected:
 	kitBase::robotModel::DeviceInfo device() const override;

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForSoundSensorBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForSoundSensorBlock.h
@@ -29,7 +29,7 @@ public:
 	explicit WaitForSoundSensorBlock(kitBase::robotModel::RobotModelInterface &robotModel);
 
 protected slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 protected:
 	kitBase::robotModel::DeviceInfo device() const override;

--- a/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForTouchSensorBlock.h
+++ b/plugins/robots/common/kitBase/include/kitBase/blocksBase/common/waitForTouchSensorBlock.h
@@ -29,7 +29,7 @@ public:
 	explicit WaitForTouchSensorBlock(kitBase::robotModel::RobotModelInterface &robotModel);
 
 protected slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 protected:
 	kitBase::robotModel::DeviceInfo device() const override;

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForAccelerometerBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForAccelerometerBlock.cpp
@@ -25,11 +25,11 @@ WaitForAccelerometerSensorBlock::WaitForAccelerometerSensorBlock(RobotModelInter
 {
 }
 
-void WaitForAccelerometerSensorBlock::responseSlot(int reading)
+void WaitForAccelerometerSensorBlock::responseSlot(const QVariant &reading)
 {
 	int result = eval<int>("Acceleration");
 	if (!errorsOccured()) {
-		processResponce(reading, result);
+		processResponce(reading.toInt(), result);
 	}
 }
 

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForColorBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForColorBlock.cpp
@@ -24,11 +24,11 @@ WaitForColorBlock::WaitForColorBlock(kitBase::robotModel::RobotModelInterface &r
 {
 }
 
-void WaitForColorBlock::responseSlot(int reading)
+void WaitForColorBlock::responseSlot(const QVariant &reading)
 {
 	const QString targetColor = stringProperty("Color");
 	QString color;
-	switch (reading) {
+	switch (reading.toInt()) {
 	case 1: color = "black";
 		break;
 	case 2: color = "blue";

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForColorIntensityBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForColorIntensityBlock.cpp
@@ -22,10 +22,10 @@ WaitForColorIntensityBlock::WaitForColorIntensityBlock(kitBase::robotModel::Robo
 {
 }
 
-void WaitForColorIntensityBlock::responseSlot(int reading)
+void WaitForColorIntensityBlock::responseSlot(const QVariant &reading)
 {
 	const int result = eval<int>("Intensity");
 	if (!errorsOccured()) {
-		processResponce(reading, result);
+		processResponce(reading.toInt(), result);
 	}
 }

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForEncoderBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForEncoderBlock.cpp
@@ -29,11 +29,11 @@ WaitForEncoderBlock::WaitForEncoderBlock(RobotModelInterface &robotModel)
 	mActiveWaitingTimer->setInterval(1);
 }
 
-void WaitForEncoderBlock::responseSlot(int reading)
+void WaitForEncoderBlock::responseSlot(const QVariant &reading)
 {
 	const int result = eval<int>("TachoLimit");
 	if (!errorsOccured()) {
-		processResponce(reading, result);
+		processResponce(reading.toInt(), result);
 	}
 }
 

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForGyroscopeSensorBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForGyroscopeSensorBlock.cpp
@@ -25,11 +25,11 @@ WaitForGyroscopeSensorBlock::WaitForGyroscopeSensorBlock(kitBase::robotModel::Ro
 {
 }
 
-void WaitForGyroscopeSensorBlock::responseSlot(int reading)
+void WaitForGyroscopeSensorBlock::responseSlot(const QVariant &reading)
 {
 	const int result = eval<int>("Degrees");
 	if (!errorsOccured()) {
-		processResponce(reading, result);
+		processResponce(reading.toInt(), result);
 	}
 }
 

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForLightSensorBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForLightSensorBlock.cpp
@@ -25,11 +25,11 @@ WaitForLightSensorBlock::WaitForLightSensorBlock(kitBase::robotModel::RobotModel
 {
 }
 
-void WaitForLightSensorBlock::responseSlot(int reading)
+void WaitForLightSensorBlock::responseSlot(const QVariant &reading)
 {
 	const int result = eval<int>("Percents");
 	if (!errorsOccured()) {
-		processResponce(reading, result);
+		processResponce(reading.toInt(), result);
 	}
 }
 

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForSonarDistanceBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForSonarDistanceBlock.cpp
@@ -27,11 +27,11 @@ WaitForSonarDistanceBlock::WaitForSonarDistanceBlock(kitBase::robotModel::RobotM
 {
 }
 
-void WaitForSonarDistanceBlock::responseSlot(int reading)
+void WaitForSonarDistanceBlock::responseSlot(const QVariant &reading)
 {
 	const int targetDistance = eval<int>("Distance");
 	if (!errorsOccured()) {
-		processResponce(reading, targetDistance);
+		processResponce(reading.toInt(), targetDistance);
 	}
 }
 

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForSoundSensorBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForSoundSensorBlock.cpp
@@ -25,11 +25,11 @@ WaitForSoundSensorBlock::WaitForSoundSensorBlock(kitBase::robotModel::RobotModel
 {
 }
 
-void WaitForSoundSensorBlock::responseSlot(int reading)
+void WaitForSoundSensorBlock::responseSlot(const QVariant &reading)
 {
 	const int result = eval<int>("Volume");
 	if (!errorsOccured()) {
-		processResponce(reading, result);
+		processResponce(reading.toInt(), result);
 	}
 }
 

--- a/plugins/robots/common/kitBase/src/blocksBase/common/waitForTouchSensorBlock.cpp
+++ b/plugins/robots/common/kitBase/src/blocksBase/common/waitForTouchSensorBlock.cpp
@@ -25,7 +25,7 @@ WaitForTouchSensorBlock::WaitForTouchSensorBlock(kitBase::robotModel::RobotModel
 {
 }
 
-void WaitForTouchSensorBlock::responseSlot(int reading)
+void WaitForTouchSensorBlock::responseSlot(const QVariant &reading)
 {
 	if (reading > 0) {
 		stop();

--- a/plugins/robots/common/trikKit/src/blocks/details/waitForMotionBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitForMotionBlock.cpp
@@ -23,7 +23,7 @@ WaitForMotionBlock::WaitForMotionBlock(kitBase::robotModel::RobotModelInterface 
 {
 }
 
-void WaitForMotionBlock::responseSlot(int reading)
+void WaitForMotionBlock::responseSlot(const QVariant &reading)
 {
 	if (reading > 0) {
 		stop();

--- a/plugins/robots/common/trikKit/src/blocks/details/waitForMotionBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitForMotionBlock.h
@@ -26,7 +26,7 @@ public:
 	explicit WaitForMotionBlock(kitBase::robotModel::RobotModelInterface &robotModel);
 
 private slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 private:
 	QString port();

--- a/plugins/robots/common/trikKit/src/blocks/details/waitGamepadConnectBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitGamepadConnectBlock.cpp
@@ -23,7 +23,7 @@ WaitGamepadConnectBlock::WaitGamepadConnectBlock(kitBase::robotModel::RobotModel
 {
 }
 
-void WaitGamepadConnectBlock::responseSlot(int reading)
+void WaitGamepadConnectBlock::responseSlot(const QVariant &reading)
 {
 	if (reading  == 1) {
 		stop();

--- a/plugins/robots/common/trikKit/src/blocks/details/waitGamepadConnectBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitGamepadConnectBlock.h
@@ -29,7 +29,7 @@ public:
 	explicit WaitGamepadConnectBlock(kitBase::robotModel::RobotModelInterface &robotModel);
 
 private slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 private:
 	QString port() override;

--- a/plugins/robots/common/trikKit/src/blocks/details/waitGamepadDisconnectBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitGamepadDisconnectBlock.cpp
@@ -23,7 +23,7 @@ WaitGamepadDisconnectBlock::WaitGamepadDisconnectBlock(kitBase::robotModel::Robo
 {
 }
 
-void WaitGamepadDisconnectBlock::responseSlot(int reading)
+void WaitGamepadDisconnectBlock::responseSlot(const QVariant &reading)
 {
 	if (reading  == 0) {
 		stop();

--- a/plugins/robots/common/trikKit/src/blocks/details/waitGamepadDisconnectBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitGamepadDisconnectBlock.h
@@ -26,7 +26,7 @@ public:
 	explicit WaitGamepadDisconnectBlock(kitBase::robotModel::RobotModelInterface &robotModel);
 
 private slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 private:
 	QString port() override;

--- a/plugins/robots/common/trikKit/src/blocks/details/waitGamepadWheelBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitGamepadWheelBlock.cpp
@@ -23,11 +23,11 @@ WaitGamepadWheelBlock::WaitGamepadWheelBlock(kitBase::robotModel::RobotModelInte
 {
 }
 
-void WaitGamepadWheelBlock::responseSlot(int reading)
+void WaitGamepadWheelBlock::responseSlot(const QVariant &reading)
 {
 	const int result = eval<int>("Angle");
 	if (!errorsOccured()) {
-		processResponce(reading, result);
+		processResponce(reading.toInt(), result);
 	}
 }
 

--- a/plugins/robots/common/trikKit/src/blocks/details/waitGamepadWheelBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitGamepadWheelBlock.h
@@ -26,7 +26,7 @@ public:
 	explicit WaitGamepadWheelBlock(kitBase::robotModel::RobotModelInterface &robotModel);
 
 private slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 private:
 	QString port() override;

--- a/plugins/robots/common/trikKit/src/blocks/details/waitPadPressBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitPadPressBlock.cpp
@@ -23,7 +23,7 @@ WaitPadPressBlock::WaitPadPressBlock(kitBase::robotModel::RobotModelInterface &r
 {
 }
 
-void WaitPadPressBlock::responseSlot(int reading)
+void WaitPadPressBlock::responseSlot(const QVariant &reading)
 {
 	if (reading == 1) {
 		stop();

--- a/plugins/robots/common/trikKit/src/blocks/details/waitPadPressBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitPadPressBlock.h
@@ -26,7 +26,7 @@ public:
 	explicit WaitPadPressBlock(kitBase::robotModel::RobotModelInterface &robotModel);
 
 private slots:
-	void responseSlot(int reading) override;
+	void responseSlot(const QVariant &reading) override;
 
 private:
 	QString port() override;


### PR DESCRIPTION
Пока лучше так, потому что этот метод перегружают наследники. А наследники не могут быть шаблонами и метод не может быть шаблонным, потому что это всё про Q_OBJECT и слоты