### PR TITLE
Fix QVariant newData signal connection issue

### DIFF
--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikEmulation/trikGyroscopeAdapter.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikEmulation/trikGyroscopeAdapter.cpp
@@ -54,7 +54,9 @@ TrikGyroscopeAdapter::TrikGyroscopeAdapter(kitBase::robotModel::robotParts::Gyro
 	, mStartTime(getTimeValue(model.data()))
 	, mLastUpdateTimeStamp(getTimeValue(model.data()))
 {
-	connect(gyro, SIGNAL(newData(QVector<int>)), this, SLOT(countTilt(QVector<int>)));
+	using namespace std::placeholders;
+	connect(mGyro, &kitBase::robotModel::robotParts::GyroscopeSensor::newData,
+			this, std::bind(&TrikGyroscopeAdapter::countTilt, this, std::bind(&QVariant::value<QVector<int>>,_1)));
 }
 
 QVector<int> TrikGyroscopeAdapter::read() const


### PR DESCRIPTION
Signal/slot mismatch
```text
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
This plugin does not support propagateSizeHints()
This plugin does not support propagateSizeHints()
QObject::connect: No such signal twoDModel::robotModel::parts::Gyroscope::newData(QVector<int>)
Ошибка: Программа работала слишком долго
This plugin does not support propagateSizeHints()
This plugin does not support propagateSizeHints()
QThread: Destroyed while thread is still running
```