### PR TITLE
Enable HiDPI support [INSTALLER]

### DIFF
--- a/plugins/robots/checker/twoDModelRunner/main.cpp
+++ b/plugins/robots/checker/twoDModelRunner/main.cpp
@@ -69,6 +69,7 @@ void initLogging()
 
 int main(int argc, char *argv[])
 {
+	qReal::PlatformInfo::enableHiDPISupport();
 	QApplication app(argc, argv);
 	QCoreApplication::setApplicationName("2D-model");
 	QCoreApplication::setApplicationVersion("1.0");

--- a/qrgui/mainWindow/main.cpp
+++ b/qrgui/mainWindow/main.cpp
@@ -82,6 +82,7 @@ static QString versionInfo()
 
 int main(int argc, char *argv[])
 {
+	PlatformInfo::enableHiDPISupport();
 	QRealApplication app(argc, argv);
 
 	if (app.arguments().contains("--clear-conf")) {

--- a/qrkernel/platformInfo.cpp
+++ b/qrkernel/platformInfo.cpp
@@ -14,12 +14,19 @@
 
 #include "platformInfo.h"
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QStandardPaths>
-#include <QtCore/QDir>
-#include <QtCore/QProcessEnvironment>
-
+#include <QCoreApplication>
+#include <QStandardPaths>
+#include <QDir>
+#include <QProcessEnvironment>
+#include <QGuiApplication>
+#include <QLibrary>
 #include <qrkernel/settingsManager.h>
+#include <QsLog.h>
+
+#ifdef Q_OS_WIN
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h> // for SetProcessDPIAware in PlaformInfo::enableHiDPISupport
+#endif
 
 using namespace qReal;
 
@@ -114,4 +121,29 @@ QString PlatformInfo::cpuArchitecture()
 bool PlatformInfo::isX64()
 {
 	return cpuArchitecture().contains("64");
+}
+
+void PlatformInfo::enableHiDPISupport()
+{
+	if (!qEnvironmentVariableIsSet("QT_DEVICE_PIXEL_RATIO")
+			&& !qEnvironmentVariableIsSet("QT_AUTO_SCREEN_SCALE_FACTOR")
+			&& !qEnvironmentVariableIsSet("QT_SCALE_FACTOR")
+			&& !qEnvironmentVariableIsSet("QT_SCREEN_SCALE_FACTORS")) {
+		// Only if there is no attempt to set from the system environment
+#ifdef Q_OS_WIN
+		typedef BOOL (WINAPI *SetProcessDPIAware_t)();
+		// Let Windows decide.
+		if(auto SetProcessDPIAware_ = (SetProcessDPIAware_t)QLibrary::resolve("user32", "SetProcessDPIAware")) {
+			if(SetProcessDPIAware_()) {
+				qputenv("QT_DEVICE_PIXEL_RATIO", QByteArray("1"));
+				QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+			} else {
+				auto err = GetLastError();
+				QLOG_ERROR() << "Failed to SetDpiAware() with error" << err;
+			}
+			return;
+		}
+#endif
+		QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	}
 }

--- a/qrkernel/platformInfo.h
+++ b/qrkernel/platformInfo.h
@@ -48,6 +48,9 @@ public:
 
 	/// Returns true if current OS and process architecture reported by currentCpuArchitecture contains '64'.
 	static bool isX64();
+
+	/// Designed to make an attempt to set proper flags for HiDPI screens
+	static void enableHiDPISupport();
 };
 
 }

--- a/qrtest/unitTests/mainTest.cpp
+++ b/qrtest/unitTests/mainTest.cpp
@@ -16,8 +16,11 @@
 
 #include <QtWidgets/QApplication>
 
+#include <qrkernel/platformInfo.h>
+
 int main(int argc, char *argv[])
 {
+	qReal::PlatformInfo::enableHiDPISupport();
 	::testing::InitGoogleTest(&argc, argv);
 
 	QApplication app(argc, argv);

--- a/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
@@ -11,7 +11,7 @@ In background mode the session will be terminated just after the execution ended
         <translation>Émule le comportement du robot sur le modèle 2D TRIK Studio séparément de l&apos;environnement de programmation. Le fichier .qrs sera interprété comme si le bouton &apos;Executer&apos; était appuyé dans TRIK Studio.</translation>
     </message>
     <message>
-        <location line="+51"/>
+        <location line="+52"/>
         <source>Save file to be interpreted.</source>
         <translation>Le fichier de sauvegarde à interpréter.</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
@@ -17,7 +17,7 @@ In background mode the session will be terminated just after the execution ended
 </translation>
     </message>
     <message>
-        <location line="+51"/>
+        <location line="+52"/>
         <source>Save file to be interpreted.</source>
         <translation>Файл сохранения, который будет исполнен.</translation>
     </message>


### PR DESCRIPTION
Enables HiDPI. But on macOS Mojave with FullHD monitor fonts became too small. What with other systems?
![Screenshot 2019-09-05 at 01 54 46](https://user-images.githubusercontent.com/706759/64299269-30ebc780-cf81-11e9-86de-401ccc039558.png)