### PR TITLE
Fix items overlapping [AUTOZIP]

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp
@@ -54,9 +54,6 @@ WallItem *WallItem::clone() const
 	cloned->mCellNumbX2 = mCellNumbX2;
 	cloned->mCellNumbY2 = mCellNumbY2;
 
-	cloned->mOldX1 = mOldX1;
-	cloned->mOldY1 = mOldY1;
-	cloned->mOverlappedWithRobot = mOverlappedWithRobot;
 	cloned->mPath = mPath;
 	return cloned;
 }
@@ -80,38 +77,6 @@ void WallItem::setPrivateData()
 	brush.setStyle(Qt::SolidPattern);
 	brush.setTextureImage(mImage);
 	setBrush(brush);
-}
-
-void WallItem::handleReposition(const QPointF &pos)
-{
-	if (((flags() & ItemIsMovable) || mOverlappedWithRobot)) {
-		const QPointF deltaPos = pos - mOldPosition;
-		if (mathUtils::Geometry::eq(deltaPos, QPointF(0,0), twoDModel::lowPrecision)) {
-			return;
-		}
-
-		const qreal deltaX = (x1() - x2());
-		const qreal deltaY = (y1() - y2());
-		setX1(mOldX1 + deltaPos.x());
-		setX2(mOldX2 + deltaPos.x());
-		setY1(mOldY1 + deltaPos.y());
-		setY2(mOldY2 + deltaPos.y());
-
-		if (SettingsManager::value("2dShowGrid").toBool()) {
-			const int indexGrid = SettingsManager::value("2dGridCellSize").toInt();
-			reshapeBeginWithGrid(indexGrid);
-			mCellNumbX1 = static_cast<int>(x1() / indexGrid);
-			mCellNumbY1 = static_cast<int>(y1() / indexGrid);
-			mCellNumbX2 = static_cast<int>(x2() / indexGrid);
-			mCellNumbY2 = static_cast<int>(y2() / indexGrid);
-		}
-
-		setDraggedEnd(deltaX, deltaY);
-		setPos(mOldPosition);
-
-		const QRectF oldPos = QRectF(QPointF(mOldX1, mOldY1), QPointF(mOldX2, mOldY2));
-		emit wallDragged(this, realShape(), oldPos);
-	}
 }
 
 QPointF WallItem::begin() const
@@ -162,17 +127,7 @@ QVariant WallItem::itemChange(QGraphicsItem::GraphicsItemChange change, const QV
 {
 	if (change == QGraphicsItem::ItemScenePositionHasChanged) {
 		emit positionChanged(value.toPointF());
-		handleReposition(value.toPointF());
 		return pos();
-	}
-
-	if (change == QGraphicsItem::ItemSelectedHasChanged) {
-		mOldX1 = x1();
-		mOldY1 = y1();
-		mOldX2 = x2();
-		mOldY2 = y2();
-		mOldPosition = pos();
-		return value;
 	}
 
 	return AbstractItem::itemChange(change, value);
@@ -207,11 +162,6 @@ void WallItem::deserialize(const QDomElement &element)
 	}
 
 	recalculateBorders();
-}
-
-void WallItem::onOverlappedWithRobot(bool overlapped)
-{
-	mOverlappedWithRobot = overlapped;
 }
 
 QPainterPath WallItem::path() const

--- a/plugins/robots/common/twoDModel/src/engine/items/wallItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/items/wallItem.h
@@ -55,8 +55,6 @@ public:
 	QDomElement serialize(QDomElement &element) const override;
 	void deserialize(const QDomElement &element) override;
 
-	void onOverlappedWithRobot(bool overlapped = true);
-
 	QPainterPath path() const;
 
 	void resizeWithGrid(QGraphicsSceneMouseEvent *event, int indexGrid);
@@ -72,14 +70,8 @@ public:
 	qreal friction() const override;
 	BodyType bodyType() const override;
 
-signals:
-	void wallDragged(WallItem *item, const QPainterPath &shape, const QRectF &oldPos);
-
 protected:
 	void setPrivateData();
-
-private slots:
-	void handleReposition(const QPointF &pos);
 
 private:
 	void recalculateBorders();
@@ -91,14 +83,8 @@ private:
 
 	graphicsUtils::LineImpl mLineImpl;
 
-	bool mOverlappedWithRobot = false;
 	const QImage mImage;
 
-	qreal mOldX1 = 0;
-	qreal mOldY1 = 0;
-	qreal mOldX2 = 0;
-	qreal mOldY2 = 0;
-	QPointF mOldPosition = QPointF(0, 0);
 	int mCellNumbX1 = 0;
 	int mCellNumbY1 = 0;
 	int mCellNumbX2 = 0;

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.h
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.h
@@ -152,8 +152,6 @@ signals:
 	void robotListChanged(RobotItem *robotItem);
 
 private slots:
-	void handleNewRobotPosition(RobotItem *robotItem);
-
 	void handleBackgroundImageItem(items::ImageItem *backgroundImageItem);
 
 	/// Called after robot model was added and create new robot item
@@ -209,8 +207,6 @@ private:
 	void drawBackground(QPainter *painter, const QRectF &rect) override;
 	void keyPressEvent(QKeyEvent *event) override;
 
-	void reshapeItem(QGraphicsSceneMouseEvent *event);
-
 	void deleteSelectedItems();
 	void deleteWithCommand(const QStringList &worldItems
 			, const QList<QPair<model::RobotModel *, kitBase::robotModel::PortInfo>> &sensors
@@ -225,9 +221,11 @@ private:
 
 	void registerInUndoStack(graphicsUtils::AbstractItem *item);
 	void subscribeItem(graphicsUtils::AbstractItem *item);
-	void worldWallDragged(items::WallItem *wall, const QPainterPath &shape, const QRectF &oldPos);
 
 	void handleMouseInteractionWithSelectedItems();
+
+	bool hasIntersect(const graphicsUtils::AbstractItem *item1, const graphicsUtils::AbstractItem *item2) const;
+	bool isCorrectScene(const QList<QGraphicsItem *> checkItems) const;
 
 	qreal currentZoom() const;
 

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -340,7 +340,7 @@
 <context>
     <name>twoDModel::items::WallItem</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+66"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+63"/>
         <source>Wall (W)</source>
         <translation>Mur (W)</translation>
     </message>
@@ -615,7 +615,7 @@
 <context>
     <name>twoDModel::view::TwoDModelScene</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+640"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+659"/>
         <source>Select image</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/qrutils_fr.ts
+++ b/qrtranslations/fr/qrutils_fr.ts
@@ -88,7 +88,7 @@
         <translation>Division entière par zéro</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphicsUtils/abstractItem.cpp" line="+525"/>
+        <location filename="../../qrutils/graphicsUtils/abstractItem.cpp" line="+544"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -612,7 +612,7 @@
 <context>
     <name>twoDModel::items::WallItem</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+66"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+63"/>
         <source>Wall (W)</source>
         <translation>Стена (W)</translation>
     </message>
@@ -946,7 +946,7 @@
 <context>
     <name>twoDModel::view::TwoDModelScene</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+640"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+659"/>
         <source>Select image</source>
         <translation>Выберите картинку</translation>
     </message>

--- a/qrtranslations/ru/qrutils_ru.ts
+++ b/qrtranslations/ru/qrutils_ru.ts
@@ -92,7 +92,7 @@
         <translation>Целичисленное деление на ноль</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphicsUtils/abstractItem.cpp" line="+525"/>
+        <location filename="../../qrutils/graphicsUtils/abstractItem.cpp" line="+544"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>

--- a/qrutils/graphicsUtils/abstractItem.cpp
+++ b/qrutils/graphicsUtils/abstractItem.cpp
@@ -38,6 +38,7 @@ AbstractItem::AbstractItem(QGraphicsItem* parent)
 {
 	setFlags(ItemIsSelectable | ItemIsMovable | ItemSendsGeometryChanges);
 	mBrush.setColor(mPen.color());
+	savePos();
 }
 
 QRectF AbstractItem::calcNecessaryBoundingRect() const
@@ -353,6 +354,24 @@ void AbstractItem::setY2(qreal y2)
 	}
 }
 
+void AbstractItem::savePos()
+{
+	mOldX1 = mX1;
+	mOldY1 = mY1;
+	mOldX2 = mX2;
+	mOldY2 = mY2;
+	mOldPos = pos();
+}
+
+void AbstractItem::restorePos()
+{
+	setX1(mOldX1);
+	setX2(mOldX2);
+	setY1(mOldY1);
+	setY2(mOldY2);
+	setPos(mOldPos);
+}
+
 void AbstractItem::setXandY(QDomElement& dom, const QRectF &rect)
 {
 	dom.setAttribute("y1", QString::number(rect.top()));
@@ -562,6 +581,7 @@ void AbstractItem::copyTo(AbstractItem * const other) const
 	other->mY2 = mY2;
 	other->mEditable = mEditable;
 	other->setPos(pos());
+	other->savePos();
 	connect(this, &AbstractItem::positionChanged
 			, other, static_cast<void(AbstractItem::*)(const QPointF &)>(&AbstractItem::setPos));
 	connect(this, &AbstractItem::x1Changed, other, &AbstractItem::setX1);

--- a/qrutils/graphicsUtils/abstractItem.h
+++ b/qrutils/graphicsUtils/abstractItem.h
@@ -102,6 +102,9 @@ public:
 	virtual void resizeItem(QGraphicsSceneMouseEvent *event);
 	void reverseOldResizingItem(const QPointF &begin, const QPointF &end);
 
+	virtual void restorePos();
+	virtual void savePos();
+
 	//for save to xml
 	virtual void setXandY(QDomElement& dom, const QRectF &rect);
 	QDomElement setPenBrushToDoc(QDomDocument &document, const QString &domName) const;
@@ -120,6 +123,8 @@ public:
 	void setEditable(bool editable);
 	bool editable() const;
 
+	void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+
 signals:
 	/// Emitted when QGraphicsItem has repositioned.
 	void positionChanged(const QPointF &pos);
@@ -127,13 +132,13 @@ signals:
 	/// Emitted when the x-coorinate of the first item`s end modified for some reason.
 	void x1Changed(qreal x1);
 
-	/// Emitted when the x-coorinate of the first item`s end modified for some reason.
+	/// Emitted when the y-coorinate of the first item`s end modified for some reason.
 	void y1Changed(qreal y1);
 
-	/// Emitted when the x-coorinate of the first item`s end modified for some reason.
+	/// Emitted when the x-coorinate of the second item`s end modified for some reason.
 	void x2Changed(qreal x2);
 
-	/// Emitted when the x-coorinate of the first item`s end modified for some reason.
+	/// Emitted when the y-coorinate of the second item`s end modified for some reason.
 	void y2Changed(qreal y2);
 
 	/// Emitted when item`s pen changed somehow.
@@ -156,9 +161,14 @@ protected:
 	QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
 	void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
-	void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 
 	void copyTo(AbstractItem * const other) const;
+
+	QPointF mOldPos;
+	qreal mOldX1;
+	qreal mOldY1;
+	qreal mOldX2;
+	qreal mOldY2;
 
 private:
 	DragState mDragState;

--- a/qrutils/graphicsUtils/abstractScene.cpp
+++ b/qrutils/graphicsUtils/abstractScene.cpp
@@ -83,20 +83,13 @@ void AbstractScene::setX2andY2(QGraphicsSceneMouseEvent *event)
 
 void AbstractScene::reshapeItem(QGraphicsSceneMouseEvent *event)
 {
-	setX2andY2(event);
-	if (mGraphicsItem && mGraphicsItem->editable()) {
-		if (mGraphicsItem->dragState() != graphicsUtils::AbstractItem::None) {
-			mView->setDragMode(QGraphicsView::NoDrag);
-		}
-
-		mGraphicsItem->resizeItem(event);
-	}
+	reshapeItem(event, mGraphicsItem);
 }
 
-void AbstractScene::reshapeItem(QGraphicsSceneMouseEvent *event,graphicsUtils::AbstractItem *item)
+void AbstractScene::reshapeItem(QGraphicsSceneMouseEvent *event, graphicsUtils::AbstractItem *item)
 {
 	setX2andY2(event);
-	if (item) {
+	if (item && item->editable()) {
 		if (item->dragState() != graphicsUtils::AbstractItem::None) {
 			mView->setDragMode(QGraphicsView::NoDrag);
 		}


### PR DESCRIPTION
Fix #391 

Выделена проверка корректности сцены в isCorrectScene, теперь достаточно добавлять проверку туда, чтобы она происходила каждый раз при добавлении и передвижении (ручном) итемов

Стенка теперь при перетаскивании и изменении размеров не скачет на место до перетаскивания.