### PR TITLE
Checker: support Python

### DIFF
--- a/plugins/robots/checker/patcher/main.cpp
+++ b/plugins/robots/checker/patcher/main.cpp
@@ -18,6 +18,8 @@
 
 #include <qrrepo/repoApi.h>
 
+#include <QFileInfo>
+
 const QString description = QObject::tr("Patcher for save files, replaces world model "
 		"with contents of a given XML world model");
 
@@ -25,7 +27,7 @@ int main(int argc, char *argv[])
 {
 	QCoreApplication app(argc, argv);
 	QCoreApplication::setApplicationName("Patcher");
-	QCoreApplication::setApplicationVersion("1.0");
+	QCoreApplication::setApplicationVersion("2.0");
 
 	QCommandLineParser parser;
 	parser.setApplicationDescription(description);
@@ -67,8 +69,7 @@ int main(int argc, char *argv[])
 		const QString scriptContent = scriptFile.readAll();
 		repo.setMetaInformation("activeCode", scriptContent);
 
-		// this value should be changed in case of other script language
-		repo.setMetaInformation("activeCodeLanguageExtension", "js");
+		repo.setMetaInformation("activeCodeLanguageExtension", QFileInfo(scriptFile).suffix().toLower());
 
 		scriptFile.close();
 	}

--- a/plugins/robots/checker/scripts/check-solution.sh
+++ b/plugins/robots/checker/scripts/check-solution.sh
@@ -62,7 +62,7 @@ MODE="diagram"
 log $runmode
 
 if [ -e $runmode ]; then
-	MODE="js"
+	MODE="script"
 fi
 
 log "$MODE"

--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -83,7 +83,7 @@ bool Runner::interpret(const QString &saveFile, bool background)
 	if (background) {
 		connect(&mPluginFacade.eventsForKitPlugins(), &kitBase::EventsForKitPluginInterface::interpretationStopped
 				, this, [this]() {
-				QTimer::singleShot(0, this, SLOT(close()));
+				QTimer::singleShot(0, this, &Runner::close);
 		});
 	}
 
@@ -97,7 +97,7 @@ bool Runner::interpret(const QString &saveFile, bool background)
 	}
 
 	mReporter.onInterpretationStart();
-	if (mMode == "js") {
+	if (mMode == "script") {
 		return mPluginFacade.interpretCode(mInputsFile);
 	} else if (mMode == "diagram") {
 		mPluginFacade.actionsManager().runAction().trigger();


### PR DESCRIPTION
Fixes #504 
 - change -mode option to script/diagram instead of js/diagram
 - allow to `run` any text file