### PR TITLE
Hack to input ev3-gyro data to array

### DIFF
--- a/plugins/robots/generators/ev3/ev3RbfGenerator/templates/sensors/gyroscope.t
+++ b/plugins/robots/generators/ev3/ev3RbfGenerator/templates/sensors/gyroscope.t
@@ -1,2 +1,4 @@
 INPUT_DEVICE(READY_SI, 0, @@PORT@@, 0, 0, 1, _temp_sensor_value_f)
-MOVEF_32(_temp_sensor_value_f, @@RESULT@@)
+DATA32 tmp32_@@RANDOM_ID@@
+MOVEF_32(_temp_sensor_value_f, tmp32_@@RANDOM_ID@@)
+ARRAY_WRITE(@@RESULT@@, 0, tmp32_@@RANDOM_ID@@)


### PR DESCRIPTION
Для вывода на печать данных с ev3-гироскопа (подключенного к порту 1) надо вбивать sensor1[0] после переделывания гироскопа из скалярного к векторный тип. Исправлена генерация кода для считывания соответствующих данных.