### PR TITLE
Add region folding and braces highlighting

### DIFF
--- a/plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp
+++ b/plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp
@@ -58,6 +58,7 @@ Ev3RbfGeneratorPlugin::Ev3RbfGeneratorPlugin()
 			, tr("EV3 Source Code language")
 			, true
 			, 4
+			, 2
 			, "//"
 			, QString()
 			, "/*"

--- a/plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp
+++ b/plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp
@@ -62,18 +62,6 @@ PioneerLuaGeneratorPlugin::PioneerLuaGeneratorPlugin()
 			, &PioneerLuaGeneratorPlugin::uploadProgram
 			, Qt::UniqueConnection
 	);
-
-	text::Languages::registerLanguage(text::LanguageInfo{ "lua"
-			, tr("Lua language")
-			, true
-			, 4
-			, "--"
-			, QString()
-			, "--[["
-			, "]]"
-			, nullptr
-			, {}
-	});
 }
 
 PioneerLuaGeneratorPlugin::~PioneerLuaGeneratorPlugin()

--- a/qrgui/textEditor/languageInfo.cpp
+++ b/qrgui/textEditor/languageInfo.cpp
@@ -21,8 +21,8 @@ QList<LanguageInfo> Languages::mUserDefinedLanguages;
 QList<LanguageInfo> Languages::knownLanguages()
 {
 	return mUserDefinedLanguages + QList<LanguageInfo>({
-			// Append here all languages declared in Languages class
-			c(), russianC(), python(), qtScript(), javaScript(), fSharp(), pascalABC()
+		// Append here all languages declared in Languages class
+		c(), russianC(), python(), qtScript(), javaScript(), fSharp(), pascalABC(), lua()
 	});
 }
 

--- a/qrgui/textEditor/languageInfo.h
+++ b/qrgui/textEditor/languageInfo.h
@@ -44,6 +44,9 @@ struct LanguageInfo
 	/// A size of the tab indent used in editor (in spaces).
 	int tabSize;
 
+	/// A margin to fold or negative (-1) if folding is disabled.
+	int foldingMargin;
+
 	/// The comments view for the current language.
 	QString lineCommentStart;
 	QString lineCommentEnd;
@@ -88,6 +91,7 @@ public:
 				, QObject::tr("Text File")                                   /* extension description */
 				, true                                                       /* tabs indentation */
 				, 8                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, QString()                                                  /* line comment start */
 				, QString()                                                  /* line comment end */
 				, QString()                                                  /* multiline comment start */
@@ -104,6 +108,7 @@ public:
 				, QObject::tr("C Language Source File")                      /* extension description */
 				, true                                                       /* tabs indentation */
 				, 8                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, "//"                                                       /* line comment start */
 				, QString()                                                  /* line comment end */
 				, "/*"                                                       /* multiline comment start */
@@ -120,6 +125,7 @@ public:
 				, QObject::tr("Russian Algorithmic Language Source File")    /* extension description */
 				, true                                                       /* tabs indentation */
 				, 8                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, "//"                                                       /* line comment start */
 				, QString()                                                  /* line comment end */
 				, "/*"                                                       /* multiline comment start */
@@ -137,6 +143,7 @@ public:
 				, QObject::tr("Python Source File")                          /* extension description */
 				, false                                                      /* tabs indentation */
 				, 2                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, "#"                                                        /* line comment start */
 				, QString()                                                  /* line comment end */
 				, "\"\"\""                                                   /* multiline comment start */
@@ -153,6 +160,7 @@ public:
 				, QObject::tr("Java Script Language Source File")            /* extension description */
 				, true                                                       /* tabs indentation */
 				, 4                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, "//"                                                       /* line comment start */
 				, QString()                                                  /* line comment end */
 				, "/*"                                                       /* multiline comment start */
@@ -169,6 +177,7 @@ public:
 				, QObject::tr("QtScript Language Source File")               /* extension description */
 				, true                                                       /* tabs indentation */
 				, 8                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, "//"                                                       /* line comment start */
 				, QString()                                                  /* line comment end */
 				, "/*"                                                       /* multiline comment start */
@@ -185,6 +194,7 @@ public:
 				, QObject::tr("F# Language Source File")                     /* extension description */
 				, false                                                      /* tabs indentation */
 				, 4                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, "//"                                                       /* line comment start */
 				, QString()                                                  /* line comment end */
 				, "(*"                                                       /* multiline comment start */
@@ -202,6 +212,7 @@ public:
 				, QObject::tr("PascalABC Language Source File")              /* extension description */
 				, false                                                      /* tabs indentation */
 				, 4                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, "--"                                                       /* line comment start */
 				, QString()                                                  /* line comment end */
 				, "{*"                                                       /* multiline comment start */
@@ -217,7 +228,8 @@ public:
 		return LanguageInfo{"lua"                                            /* extension */
 				, QObject::tr("Lua Language Source File")                    /* extension description */
 				, true                                                       /* tabs indentation */
-				, 8                                                          /* tab size */
+				, 4                                                          /* tab size */
+				, 2                                                          /* folding margin */
 				, "--"                                                       /* line comment start */
 				, QString()                                                  /* line comment end */
 				, "--[["                                                     /* multiline comment start */

--- a/qrgui/textEditor/qscintillaTextEdit.cpp
+++ b/qrgui/textEditor/qscintillaTextEdit.cpp
@@ -60,6 +60,8 @@ void QScintillaTextEdit::setCurrentLanguage(const LanguageInfo &language)
 	mLanguage = language;
 	setIndentationsUseTabs(mLanguage.tabIndentation);
 	setTabWidth(mLanguage.tabSize);
+	if (mLanguage.foldingMargin >= 0)
+		setFolding(FoldStyle::BoxedTreeFoldStyle, mLanguage.foldingMargin);
 	setFont(mFont);
 	setLexer(mLanguage.lexer);
 

--- a/qrgui/textEditor/qscintillaTextEdit.cpp
+++ b/qrgui/textEditor/qscintillaTextEdit.cpp
@@ -62,6 +62,11 @@ void QScintillaTextEdit::setCurrentLanguage(const LanguageInfo &language)
 	setTabWidth(mLanguage.tabSize);
 	if (mLanguage.foldingMargin >= 0)
 		setFolding(FoldStyle::BoxedTreeFoldStyle, mLanguage.foldingMargin);
+
+	setBraceMatching(QsciScintilla::SloppyBraceMatch);
+	setMatchedBraceBackgroundColor(Qt::lightGray);
+	setUnmatchedBraceBackgroundColor(Qt::red);
+
 	setFont(mFont);
 	setLexer(mLanguage.lexer);
 
@@ -176,10 +181,10 @@ void QScintillaTextEdit::setDefaultSettings()
 	// Whitespaces visibility
 	setWhitespaceVisibility(QsciScintilla::WsInvisible);
 
-	// Show margin with line numbers (up to 1000)
+	// Show margin with line numbers (up to 9999)
 	setMarginsBackgroundColor(QColor("gainsboro"));
 	setMarginLineNumbers(1, true);
-	setMarginWidth(1, QString("1000"));
+	setMarginWidth(1, QString("9999"));
 
 	// Autocompletion of lexems
 	setAutoCompletionSource(QsciScintilla::AcsAll);
@@ -194,7 +199,7 @@ void QScintillaTextEdit::setDefaultSettings()
 	setUnmatchedBraceForegroundColor(Qt::blue);
 
 	// EOL symbol
-#if defined Q_OS_X11
+#if defined Q_OS_LINUX
 	setEolMode(QsciScintilla::EolUnix);
 #elif defined Q_OS_WIN
 	setEolMode(QsciScintilla::EolWindows);

--- a/qrgui/textEditor/qscintillaTextEdit.cpp
+++ b/qrgui/textEditor/qscintillaTextEdit.cpp
@@ -151,7 +151,7 @@ void QScintillaTextEdit::find()
 void QScintillaTextEdit::init()
 {
 	// For some reason c++11-style connections do not work here!
-	connect(this, SIGNAL(textChanged()), this, SLOT(emitTextWasModified()));
+	connect(this, &QScintillaTextEdit::textChanged, this, &QScintillaTextEdit::emitTextWasModified);
 	initFindModeConnections();
 	setDefaultSettings();
 	setCurrentLanguage(Languages::textFileInfo("*.txt"));

--- a/qrtranslations/ru/plugins/robots/ev3RbfGenerator_ru.ts
+++ b/qrtranslations/ru/plugins/robots/ev3RbfGenerator_ru.ts
@@ -70,7 +70,7 @@
         <translation>Файл с байткодом EV3</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+30"/>
         <source>Generate Ev3 Robot Byte Code File</source>
         <translation>Сгенерировать в байткод EV3</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/pioneerLuaGenerator_ru.ts
+++ b/qrtranslations/ru/plugins/robots/pioneerLuaGenerator_ru.ts
@@ -285,12 +285,11 @@
         <translation type="vanished">Остановить программу, исполняемую на квадрокоптере</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Lua language</source>
-        <translation>Язык Lua</translation>
+        <translation type="vanished">Язык Lua</translation>
     </message>
     <message>
-        <location line="+50"/>
+        <location line="+49"/>
         <source>Generate Lua script for Pioneer Quadcopter</source>
         <translation>Генерировать скрипт на Lua для квадрокоптера &quot;Пионер&quot;</translation>
     </message>


### PR DESCRIPTION
Add region folding to text editor
Fixes #64 -- adds text folding in the editor
Partially fixes #62 -- highlights unmatched braces under cursor
![Screenshot from 2019-11-09 20-41-57](https://user-images.githubusercontent.com/706759/68532677-910c3a80-0331-11ea-9bd9-f612272c92b8.png)
