### PR TITLE
Fix moving item after deletion

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp
@@ -928,6 +928,7 @@ void TwoDModelScene::registerInUndoStack(AbstractItem *item)
 void TwoDModelScene::subscribeItem(AbstractItem *item)
 {
 	connect(item, &AbstractItem::mouseInteractionStarted, this, [=]() {
+		item->savePos();
 		if (mDrawingAction == none) {
 			QStringList selectedIds;
 			for (const QGraphicsItem *item : selectedItems()) {


### PR DESCRIPTION
Если удалить стену, а потом отменить удаление и попытаться переместить стену на мяч, стенка схлопывалась в центр экрана