### PR TITLE
Dependabot runs from root dir

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,7 @@ update_configs:
     allowed_updates:
       - match:
           dependency_name: "plugins/robots/thirdparty/trikRuntime/trikRuntime"
+          dependency_name: "thirdparty/gamepad/gamepad"
     default_reviewers:
       - "iakov"
 
@@ -16,3 +17,7 @@ update_configs:
     ignored_updates:
       - match:
           dependency_name: "plugins/robots/thirdparty/trikRuntime/trikRuntime"
+          dependency_name: "thirdparty/gamepad/gamepad"
+    automerged_updates:
+      - match:
+          dependency_name: "*"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,7 @@ update_configs:
     allowed_updates:
       - match:
           dependency_name: "plugins/robots/thirdparty/trikRuntime/trikRuntime"
+      - match:
           dependency_name: "thirdparty/gamepad/gamepad"
     default_reviewers:
       - "iakov"
@@ -17,6 +18,7 @@ update_configs:
     ignored_updates:
       - match:
           dependency_name: "plugins/robots/thirdparty/trikRuntime/trikRuntime"
+      - match:
           dependency_name: "thirdparty/gamepad/gamepad"
     automerged_updates:
       - match:

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,5 +4,15 @@ update_configs:
   - package_manager: "submodules"
     directory: "./"
     update_schedule: "weekly"
+    allowed_updates:
+      - match:
+          dependency_name: "plugins/robots/thirdparty/trikRuntime/trikRuntime"
     default_reviewers:
       - "iakov"
+
+  - package_manager: "submodules"
+    directory: "./"
+    update_schedule: "monthly"
+    ignored_updates:
+      - match:
+          dependency_name: "plugins/robots/thirdparty/trikRuntime/trikRuntime"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,35 +2,7 @@ version: 1
 
 update_configs:
   - package_manager: "submodules"
-    directory: "plugins/robots/thirdparty/trikRuntime/trikRuntime"
+    directory: "./"
     update_schedule: "weekly"
     default_reviewers:
       - "iakov"
-
-  - package_manager: "submodules"
-    directory: "qrtest/thirdparty/googletest/googletest"
-    update_schedule: "monthly"
-
-  - package_manager: "submodules"
-    directory: "qrgui/thirdparty/qt-solutions"
-    update_schedule: "monthly"
-
-  - package_manager: "submodules"
-    directory: "thirdparty/gamepad/gamepad"
-    update_schedule: "weekly"
-
-  - package_manager: "submodules"
-    directory: "installer/nxt-tools"
-    update_schedule: "weekly"
-
-  - package_manager: "submodules"
-    directory: "plugins/robots/thirdparty/hidapi"
-    update_schedule: "monthly"
-
-  - package_manager: "submodules"
-    directory: "thirdparty/quazip/quazip"
-    update_schedule: "monthly"
-
-  - package_manager: "submodules"
-    directory: "plugins/robots/thirdparty/Box2D/Box2D"
-    update_schedule: "monthly"


### PR DESCRIPTION
Fixes #655
Fixes #656 
Fixes #657
Fixes #658 
Fixes #659 
Fixes #660 
Fixes #661 
Fixes #662 

PR будет создаваться, только если сабмодуль требует обновления, иначе проверка просто посмотрит на наличие обновлений и ничего не будет трогать. Сабмодули рекурсивно обновляются.