### PR TITLE
Fix twoD model world in no-qrs projects and some warnings

### DIFF
--- a/plugins/robots/common/kitBase/src/robotModel/commonRobotModel.cpp
+++ b/plugins/robots/common/kitBase/src/robotModel/commonRobotModel.cpp
@@ -58,7 +58,10 @@ QString CommonRobotModel::kitId() const
 void CommonRobotModel::init()
 {
 	rereadSettings();
-	configureKnownDevices();
+	// We don't need to configure non configurable sensors for generation
+	if (!name().contains("Gen")) {
+		configureKnownDevices();
+	}
 }
 
 void CommonRobotModel::connectToRobot()
@@ -200,7 +203,8 @@ void CommonRobotModel::configureDevice(const PortInfo &port, const DeviceInfo &d
 	if (device) {
 		mConfiguration.configureDevice(device);
 	} else {
-		QLOG_WARN() << "Can not create device" << deviceInfo.toString() << "for port" << port.toString();
+		QLOG_WARN() << "Can not create device" << deviceInfo.toString()
+				<< "for port" << port.toString() << "on" << name();
 	}
 	/// @todo Handle error
 }

--- a/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
@@ -703,6 +703,11 @@ Model &TwoDModelWidget::model() const
 void TwoDModelWidget::setController(ControllerInterface &controller)
 {
 	mController = &controller;
+
+	// Clearing 2D model undo stack...
+	mController->moduleClosed(editorId());
+	mController->moduleOpened(editorId());
+
 	mScene->setController(controller);
 
 	auto setItemsProperty = [=](const QStringList &items, const QString &property, const QVariant &value) {

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -713,7 +713,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+314"/>
+        <location line="+319"/>
         <source>Hide details</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -1044,7 +1044,7 @@
         <translation>Попытка загрузить слишком большое изображение может заморозить выполнение на некоторое время. Продолжить?</translation>
     </message>
     <message>
-        <location line="+314"/>
+        <location line="+319"/>
         <source>Hide details</source>
         <translation>Скрыть детали</translation>
     </message>


### PR DESCRIPTION
Fixed
> если при запуске Студии сразу открыть .js файл и пробовать загрузить карту - карта не грузится ... если тут же добавлять объекты на карту (стены, банки, линии и т.д.) - то они не удаляются
НО, если потом добавить "Новый проект", достаточно пустого, то карта загружается и с рисованием/объектами становится все норм.

> Смотрю логи qreal. Там куча  "Can not create device"