### PR TITLE
Naive approach to fix crash/pause when stopping from 2d model [INSTALLER]

### DIFF
--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
@@ -313,7 +313,7 @@ void TrikKitInterpreterPluginBase::init(const kitBase::KitPluginConfigurator &co
 	});
 
 	connect(&configurer.interpreterControl()
-			, &kitBase::InterpreterControlInterface::stopAllInterpretation
+			, &kitBase::InterpreterControlInterface::stopped
 			, this
 			, [this](qReal::interpretation::StopReason reason) {
 		if (mTextualInterpreter->isRunning()) {

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
@@ -313,6 +313,8 @@ void TrikKitInterpreterPluginBase::init(const kitBase::KitPluginConfigurator &co
 	});
 
 	connect(&configurer.interpreterControl()
+// Naive approach to fix crash/pause when stopping from 2d model.
+// Changed from `stopAllInterpretation` to `stopped`, see git blame and corresponding PR
 			, &kitBase::InterpreterControlInterface::stopped
 			, this
 			, [this](qReal::interpretation::StopReason reason) {

--- a/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
@@ -215,7 +215,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+185"/>
+        <location line="+187"/>
         <source>Enter robot`s IP-address here...</source>
         <translation type="unfinished">Tapez l&apos;adresse IP du robot ici...</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
@@ -272,7 +272,7 @@
         <translation>Остановить программу</translation>
     </message>
     <message>
-        <location line="+185"/>
+        <location line="+187"/>
         <source>Enter robot`s IP-address here...</source>
         <translation>Введите IP-адрес робота...</translation>
     </message>


### PR DESCRIPTION
In case of calling "Stop" button in left bottom corner in case of TRIK textual interretation we get two calls from signal "stopAllInterpretation":
https://github.com/trikset/trik-studio/blob/79faf02868a19ec67f0079220d49fb301e630c51/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp#L315
https://github.com/trikset/trik-studio/blob/5e8d5743cf91c15039915af87ce532d50343148e/plugins/robots/common/kitBase/include/kitBase/interpreterControlInterface.h#L30 
Both of them generate "interpretationStopped" signal and as result method "onStopInterpretation" is called twice -- https://github.com/trikset/trik-studio/blob/99d5d0f907cbc33b2c4f43852e51516ebf7379ab/plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp#L187

**Proposed solution avoids double call of "onStopInterpretation" and make these calls consequent.
TODO: understand why double call produces error.**