### PR TITLE
Wait for gyro angle instead of speed on trik

### DIFF
--- a/plugins/robots/common/trikKit/src/blocks/details/trikWaitForGyroscopeBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/trikWaitForGyroscopeBlock.cpp
@@ -25,7 +25,7 @@ void TrikWaitForGyroscopeBlock::responseSlot(const QVariant &reading)
 {
 	const int result = eval<int>("Degrees");
 	if (!errorsOccured()) {
-		processResponce(reading.value<QVector<int>>()[2], result);
+		processResponce(reading.value<QVector<int>>()[6]/1000, result);
 	}
 }
 

--- a/plugins/robots/common/trikKit/src/blocks/trikBlocksFactoryBase.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/trikBlocksFactoryBase.cpp
@@ -264,7 +264,6 @@ qReal::IdList TrikBlocksFactoryBase::blocksToDisable() const
 				;
 	} else {
 		result
-				<< id("TrikWaitForGyroscope")
 				<< id("TrikCalibrateGyroscope")
 				;
 	}

--- a/plugins/robots/editor/trik/generated/elements.h
+++ b/plugins/robots/editor/trik/generated/elements.h
@@ -1986,14 +1986,14 @@
 			setName("TrikWaitForGyroscope");
 			setFriendlyName(QObject::tr("Wait for Gyroscope"));
 			setDiagram("RobotsDiagram");
-			setDescription(QObject::tr("Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the 'milliDegrees/sec' parameter value."));
+			setDescription(QObject::tr("Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the 'Degrees' parameter value."));
 			qReal::LabelProperties label_1(1, 1.1, 1.2, "Degrees", false, 0);
 			label_1.setBackground(Qt::white);
 			label_1.setScalingX(false);
 			label_1.setScalingY(false);
 			label_1.setHard(false);
 			label_1.setPlainTextMode(false);
-			label_1.setPrefix(QObject::tr("milliDegrees/sec:"));
+			label_1.setPrefix(QObject::tr("Degrees:"));
 			addLabel(label_1);
 			qReal::LabelProperties label_2(2, 1.1, 1.8, "Sign", false, 0);
 			label_2.setBackground(Qt::white);
@@ -2026,7 +2026,7 @@
 
 		void initProperties()
 		{
-			addProperty("Degrees", "string", QObject::tr("0"), QObject::tr("milliDegrees/sec"), QObject::tr(""), false);
+			addProperty("Degrees", "string", QObject::tr("0"), QObject::tr("Degrees"), QObject::tr(""), false);
 			addProperty("Sign", "DistanceSign", QString::fromUtf8("greater"), QObject::tr("Sign"), QObject::tr(""), false);
 		}
 	};

--- a/plugins/robots/editor/trik/trikMetamodel.xml
+++ b/plugins/robots/editor/trik/trikMetamodel.xml
@@ -621,13 +621,13 @@
 				</logic>
 			</node>
 
-			<node displayedName="Wait for Gyroscope" path="101, 106 : 212, 106 :  | 156, 183 : 156, 107 :  | 12, 183 : 156, 183 :  | 12, 12 : 12, 183 :  | 12, 12 : 164, 12 : " name="TrikWaitForGyroscope" description="Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the 'milliDegrees/sec' parameter value.">
+			<node displayedName="Wait for Gyroscope" path="101, 106 : 212, 106 :  | 156, 183 : 156, 107 :  | 12, 183 : 156, 183 :  | 12, 12 : 12, 183 :  | 12, 12 : 164, 12 : " name="TrikWaitForGyroscope" description="Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the 'Degrees' parameter value.">
 				<graphics>
 					<picture sizex="50" sizey="50">
 						<image y1="0" name="images/waitForGyroscopeBlock.png" x1="0" y2="50" x2="50"/>
 					</picture>
 					<labels>
-						<label x="55" y="60" textBinded="Degrees" prefix="milliDegrees/sec:"/>
+						<label x="55" y="60" textBinded="Degrees" prefix="Degrees:"/>
 						<label x="55" y="90" textBinded="Sign" prefix="Sign:"/>
 					</labels>
 					<nonResizeable/>
@@ -635,7 +635,7 @@
 				<logic>
 					<container/>
 					<properties>
-						<property displayedName="milliDegrees/sec" type="string" name="Degrees">
+						<property displayedName="Degrees" type="string" name="Degrees">
 							<default>0</default>
 						</property>
 						<property displayedName="Sign" type="DistanceSign" name="Sign">

--- a/plugins/robots/generators/trik/trikPythonGeneratorLibrary/templates.qrc
+++ b/plugins/robots/generators/trik/trikPythonGeneratorLibrary/templates.qrc
@@ -231,5 +231,6 @@
         <file>templates/videosensors/stoplineSensor.t</file>
         <file>templates/videosensors/stopobjectSensor.t</file>
         <file>templates/videosensors/stopVideoStreaming.t</file>
+        <file>templates/wait/gyroscope.t</file>
     </qresource>
 </RCC>

--- a/plugins/robots/generators/trik/trikPythonGeneratorLibrary/templates/wait/gyroscope.t
+++ b/plugins/robots/generators/trik/trikPythonGeneratorLibrary/templates/wait/gyroscope.t
@@ -1,0 +1,2 @@
+while not (brick.gyroscope().read()[6]/1000 @@SIGN@@ @@DEGREES@@):
+  script.wait(10)

--- a/plugins/robots/generators/trik/trikQtsGeneratorLibrary/templates.qrc
+++ b/plugins/robots/generators/trik/trikQtsGeneratorLibrary/templates.qrc
@@ -236,5 +236,6 @@
         <file>templates/switch/head_switch.t</file>
         <file>templates/switch/middle_switch.t</file>
         <file>templates/switch/oneCase_switch.t</file>
+        <file>templates/wait/gyroscope.t</file>
     </qresource>
 </RCC>

--- a/plugins/robots/generators/trik/trikQtsGeneratorLibrary/templates/wait/gyroscope.t
+++ b/plugins/robots/generators/trik/trikQtsGeneratorLibrary/templates/wait/gyroscope.t
@@ -1,0 +1,3 @@
+while (!(brick.gyroscope().read()[6]/1000 @@SIGN@@ @@DEGREES@@)) {
+	script.wait(10);
+}

--- a/qrtranslations/fr/plugins/robots/trikMetamodel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikMetamodel_fr.ts
@@ -904,17 +904,17 @@
     </message>
     <message>
         <location line="+2"/>
-        <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;milliDegrees/sec&apos; parameter value.</source>
+        <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;Degrees&apos; parameter value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>milliDegrees/sec:</source>
+        <source>Degrees:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+33"/>
-        <source>milliDegrees/sec</source>
+        <source>Degrees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qrtranslations/ru/plugins/robots/trikMetamodel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikMetamodel_ru.ts
@@ -904,22 +904,34 @@
     </message>
     <message>
         <location line="+2"/>
+        <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;Degrees&apos; parameter value.</source>
+        <translation>Ждать, пока значение, возвращаемое гиродатчиком на указанном порту, не будет сравнимо с указанным в значении параметра &apos;Градусы&apos;.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Degrees:</source>
+        <translation>Градусы:</translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Degrees</source>
+        <translation>Градусы</translation>
+    </message>
+    <message>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;milliDegrees/sec&apos; parameter value.</source>
-        <translation>Ждать, пока значение, возвращаемое гиродатчиком на указанном порту, не будет сравнимо с указанным в значении параметра &apos;миллиГрадусы/сек&apos;.</translation>
+        <translation type="vanished">Ждать, пока значение, возвращаемое гиродатчиком на указанном порту, не будет сравнимо с указанным в значении параметра &apos;миллиГрадусы/сек&apos;.</translation>
     </message>
     <message>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;Degrees/sec&apos; parameter value.</source>
         <translation type="vanished">Ждать, пока значение, возвращаемое гиродатчиком на указанном порту, не будет сравнимо с указанным в значении параметра &apos;Градусы/сек&apos;.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>milliDegrees/sec:</source>
-        <translation>миллиГрадусы/сек:</translation>
+        <translation type="vanished">миллиГрадусы/сек:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>milliDegrees/sec</source>
-        <translation>миллиГрадусы/сек</translation>
+        <translation type="vanished">миллиГрадусы/сек</translation>
     </message>
     <message>
         <source>Degrees/sec:</source>


### PR DESCRIPTION
Fixed:
> Оказалось, что в модели ТРИК блок "Ждать гиродатчик" ждет угловую скорость миллиградусы\сек, а в ЕВ3 угол в градусах. Зачем в ТРИКе ждать угловую скорость в визуальном языке? Давайте сделаем тоже ждать угол, который gyroscope[6] и сразу в градусах.