### PR TITLE
TravisCI: use QtIFW 3.2 to build installer

### DIFF
--- a/buildScripts/travis/build_installer.sh
+++ b/buildScripts/travis/build_installer.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 QTBIN=${QTBIN:-$($EXECUTOR  bash -c "make qmake -n | sed 's#/qmake.*\$##g'")}
 case $TRAVIS_OS_NAME in
   osx)
-    QTIFWBIN=$QTBIN/../../../Tools/QtInstallerFramework/3.1/bin
+    QTIFWBIN=$QTBIN/../../../Tools/QtInstallerFramework/3.2/bin
     TSNAME=trik-studio-installer-mac-$TRAVIS_BRANCH.dmg
     ;;
   linux)


### PR DESCRIPTION
After docker image is updated, linux installer is built with QtIFW 3.2 too.