### PR TITLE
Fixes unresponsiveness with while(true) { print(1) }

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,5 +13,5 @@ pull_request_rules:
 
     actions:
       merge:
-        method: merge
+        method: squash
         strict: smart  # less CI build time when a lot of PRs

--- a/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui
+++ b/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui
@@ -482,51 +482,11 @@
             </property>
             <item>
              <widget class="twoDModel::view::DetailsTab" name="detailsTab">
-              <property name="palette">
-               <palette>
-                <active>
-                 <colorrole role="Base">
-                  <brush brushstyle="SolidPattern">
-                   <color alpha="0">
-                    <red>191</red>
-                    <green>64</green>
-                    <blue>64</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
-                </active>
-                <inactive>
-                 <colorrole role="Base">
-                  <brush brushstyle="SolidPattern">
-                   <color alpha="0">
-                    <red>191</red>
-                    <green>64</green>
-                    <blue>64</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
-                </inactive>
-                <disabled>
-                 <colorrole role="Base">
-                  <brush brushstyle="SolidPattern">
-                   <color alpha="255">
-                    <red>239</red>
-                    <green>239</green>
-                    <blue>239</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
-                </disabled>
-               </palette>
-              </property>
               <property name="focusPolicy">
                <enum>Qt::NoFocus</enum>
               </property>
-              <property name="autoFillBackground">
-               <bool>true</bool>
-              </property>
               <property name="frameShape">
-               <enum>QFrame::NoFrame</enum>
+               <enum>QFrame::StyledPanel</enum>
               </property>
               <property name="frameShadow">
                <enum>QFrame::Plain</enum>

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
@@ -51,7 +51,7 @@ const QString jsOverrides = "script.random = brick.random;script.wait = brick.wa
 		"} else {res += arguments[i].toString();}"
 		"};"
 		"brick.log(res);"
-		"script.wait(0);"
+		"brick.wait(0);"
 		"return res;"
 	"};"
 	"script.system = function() {print('system is disabled in the interpreter');};";

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
@@ -51,11 +51,12 @@ const QString jsOverrides = "script.random = brick.random;script.wait = brick.wa
 		"} else {res += arguments[i].toString();}"
 		"};"
 		"brick.log(res);"
+		"script.wait(0);"
 		"return res;"
 	"};"
 	"script.system = function() {print('system is disabled in the interpreter');};";
 
-const QString pyOverrides ="\ndef print(args): brick.log(args);"
+const QString pyOverrides ="\ndef print(args): script.wait(0); brick.log(args);"
 			   "script.random = brick.random;"
 			   "script.wait = brick.wait;"
 			   "script.time = brick.time;"

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp
@@ -154,13 +154,13 @@ void TrikBrick::reinitImitationCamera()
 void TrikBrick::say(const QString &msg) {
 	using namespace kitBase::robotModel;
 	using namespace trik::robotModel;
-	parts::TrikShell* sh = RobotModelUtils::findDevice<parts::TrikShell>(*mTwoDRobotModel, "ShellPort");
+	auto* sh = RobotModelUtils::findDevice<parts::TrikShell>(*mTwoDRobotModel, "ShellPort");
 	if (sh == nullptr) {
 		emit error(tr("2d model shell part was not found"));
 		return;
 	}
 
-	QMetaObject::invokeMethod(sh, "say", Q_ARG(const QString &, msg));
+	QMetaObject::invokeMethod(sh, [sh, msg](){sh->say(msg);});
 }
 
 void TrikBrick::stop() {

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp
@@ -34,6 +34,7 @@
 #include <qrkernel/platformInfo.h>
 #include <src/qtCameraImplementation.h>
 #include <src/imitationCameraImplementation.h>
+#include <QApplication>
 
 ///todo: temporary
 #include <trikKitInterpreterCommon/robotModel/twoD/parts/twoDDisplay.h>
@@ -400,7 +401,9 @@ void TrikBrick::wait(int milliseconds)
 	connect(timeline, &twoDModel::model::Timeline::beforeStop, &loop, &QEventLoop::quit);
 	connect(timeline, &twoDModel::model::Timeline::stopped, &loop, &QEventLoop::quit);
 
-	if (timeline->isStarted()) {
+	if (milliseconds == 0) {
+		QApplication::processEvents();
+	} else if (timeline->isStarted()) {
 		t->start(milliseconds);
 		loop.exec();
 	}

--- a/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+191"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+192"/>
         <source>Bogus input values</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
@@ -98,19 +98,19 @@
 <context>
     <name>trik::TrikBrick</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+95"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+96"/>
         <location line="+63"/>
         <source>2d model shell part was not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-30"/>
-        <location line="+296"/>
+        <location line="+298"/>
         <source>Trying to read from file %1 failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-241"/>
+        <location line="-243"/>
         <source>No configured motor on port: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -207,7 +207,7 @@
         <translation>Augmenter la vitesse</translation>
     </message>
     <message>
-        <location line="+256"/>
+        <location line="+216"/>
         <source>Left wheel:</source>
         <translation>Roue gauche :</translation>
     </message>

--- a/qrtranslations/fr/qrutils_fr.ts
+++ b/qrtranslations/fr/qrutils_fr.ts
@@ -379,7 +379,7 @@
 <context>
     <name>qReal::ui::ConsoleDock</name>
     <message>
-        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+44"/>
+        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+43"/>
         <source>Reset shell</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+191"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+192"/>
         <source>Bogus input values</source>
         <translation>Неподходящие значения аргументов</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
@@ -158,19 +158,19 @@
 <context>
     <name>trik::TrikBrick</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+95"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+96"/>
         <location line="+63"/>
         <source>2d model shell part was not found</source>
         <translation>Консоль 2d модели не найдена</translation>
     </message>
     <message>
         <location line="-30"/>
-        <location line="+296"/>
+        <location line="+298"/>
         <source>Trying to read from file %1 failed</source>
         <translation>Не удалось открыть файл %1</translation>
     </message>
     <message>
-        <location line="-241"/>
+        <location line="-243"/>
         <source>No configured motor on port: %1</source>
         <translation>Не найден сконфигурированный  мотор на порту: %1</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -417,7 +417,7 @@
         <translation>Увеличить скорость</translation>
     </message>
     <message>
-        <location line="+256"/>
+        <location line="+216"/>
         <source>Left wheel:</source>
         <translation>Левое колесо:</translation>
     </message>

--- a/qrtranslations/ru/qrutils_ru.ts
+++ b/qrtranslations/ru/qrutils_ru.ts
@@ -487,7 +487,7 @@
 <context>
     <name>qReal::ui::ConsoleDock</name>
     <message>
-        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+44"/>
+        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+43"/>
         <source>Reset shell</source>
         <translation>Очистить консоль</translation>
     </message>


### PR DESCRIPTION
AKA https://github.com/trikset/trikRuntime/issues/478
The heavy and slow ConsoleDock window in the UI thread is being DoSed from script thread with `print(...)` from `while` loop. The main hack is to use `script.wait(0)` to call processEvents from script execution thread.

Also fixed rare newline char in the robot console log window.
