### PR TITLE
Check next line with invokeMethod

### DIFF
--- a/buildScripts/vera++/scripts/rules/NoOldInvokeMethod.tcl
+++ b/buildScripts/vera++/scripts/rules/NoOldInvokeMethod.tcl
@@ -14,11 +14,17 @@
 
 proc NoOldInvokeMethod { fileName } {
   set lineCount 1
-  foreach line [getAllLines $fileName] {
+  set allLines [getAllLines $fileName]
+  for {set x 0} {$x < [llength $allLines]} {incr x} {
+    set line [lindex $allLines $x]
     if { [regexp {invokeMethod} $line] } {
       if { [regexp {Q_ARG} $line]  || [regexp {Q_RETURN_ARG} $line] } {
-        report $fileName $lineCount "Passing method name as a literal string is forbidden, 
-        use Functor signature instead"
+        report $fileName $lineCount "Passing method name as a literal string is forbidden, use Functor signature instead"
+      } elseif {![regexp {;$} $line]} {
+        set line [lindex $allLines [expr { $x + 1 }]]
+        if { [regexp {Q_ARG} $line]  || [regexp {Q_RETURN_ARG} $line] } {
+          report $fileName $lineCount "Passing method name as a literal string is forbidden, use Functor signature instead"
+        }
       }
     }
     incr lineCount

--- a/buildScripts/vera++/scripts/rules/NoOldInvokeMethod.tcl
+++ b/buildScripts/vera++/scripts/rules/NoOldInvokeMethod.tcl
@@ -15,7 +15,7 @@
 proc NoOldInvokeMethod { fileName } {
   set lineCount 1
   foreach line [getAllLines $fileName] {
-    if { [regexp {Q_ARG} $line]  || [regexp {Q_RETURN_ARG} $line] } {
+    if { [regexp {Q_ARG} $line] || [regexp {Q_RETURN_ARG} $line] } {
       report $fileName $lineCount "Passing method name as a literal string is forbidden, use Functor signature instead"
     }
     incr lineCount

--- a/buildScripts/vera++/scripts/rules/NoOldInvokeMethod.tcl
+++ b/buildScripts/vera++/scripts/rules/NoOldInvokeMethod.tcl
@@ -14,18 +14,9 @@
 
 proc NoOldInvokeMethod { fileName } {
   set lineCount 1
-  set allLines [getAllLines $fileName]
-  for {set x 0} {$x < [llength $allLines]} {incr x} {
-    set line [lindex $allLines $x]
-    if { [regexp {invokeMethod} $line] } {
-      if { [regexp {Q_ARG} $line]  || [regexp {Q_RETURN_ARG} $line] } {
-        report $fileName $lineCount "Passing method name as a literal string is forbidden, use Functor signature instead"
-      } elseif {![regexp {;$} $line]} {
-        set line [lindex $allLines [expr { $x + 1 }]]
-        if { [regexp {Q_ARG} $line]  || [regexp {Q_RETURN_ARG} $line] } {
-          report $fileName $lineCount "Passing method name as a literal string is forbidden, use Functor signature instead"
-        }
-      }
+  foreach line [getAllLines $fileName] {
+    if { [regexp {Q_ARG} $line]  || [regexp {Q_RETURN_ARG} $line] } {
+      report $fileName $lineCount "Passing method name as a literal string is forbidden, use Functor signature instead"
     }
     incr lineCount
   }


### PR DESCRIPTION
There was a wrong check of invokeMethod style because if it was looking like this
``` cpp
QMetaObject::invokeMethod(this, "produceTimerImpl", connection 
                             , Q_RETURN_ARG(utils::AbstractTimer *, t));
```
 Vera could not find _Q_ARG_ pattern on the line and then the test had become passed.