### PR TITLE
Fix saving robot's position

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
@@ -119,6 +119,8 @@ TwoDModelWidget::TwoDModelWidget(Model &model, QWidget *parent)
 	mConnections << connect(&mModel.timeline(), &Timeline::started
 							, this, &TwoDModelWidget::setRunStopButtonsVisibility);
 	mConnections << connect(&mModel.timeline(), &Timeline::stopped
+							, this, &TwoDModelWidget::saveWorldModelToRepo);
+	mConnections << connect(&mModel.timeline(), &Timeline::stopped
 							, this, &TwoDModelWidget::setRunStopButtonsVisibility);
 	mConnections << connect(&mModel.timeline(), &Timeline::speedFactorChanged, this, [=](int value) {
 		const QPoint downCoords = mUi->speedDownButton->mapTo(this, mUi->speedDownButton->rect().bottomRight());
@@ -391,6 +393,7 @@ void TwoDModelWidget::returnToStartMarker()
 	for (items::BallItem *ball : mModel.worldModel().balls()) {
 		ball->returnToStartPosition();
 	}
+	saveWorldModelToRepo();
 }
 
 void TwoDModelWidget::trainingModeChanged(bool enabled)

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -666,7 +666,7 @@
 <context>
     <name>twoDModel::view::TwoDModelWidget</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+307"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+309"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
@@ -684,7 +684,7 @@
         <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location line="+91"/>
+        <location line="+92"/>
         <source>Training mode: solution will not be checked</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -1001,7 +1001,7 @@
 <context>
     <name>twoDModel::view::TwoDModelWidget</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+307"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+309"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
@@ -1019,7 +1019,7 @@
         <translation type="vanished">Отмена</translation>
     </message>
     <message>
-        <location line="+91"/>
+        <location line="+92"/>
         <source>Training mode: solution will not be checked</source>
         <translation>Режим тренировки: решение не будет проверяться</translation>
     </message>


### PR DESCRIPTION
Fixed
>Не считает изменениями и не сохраняет (ни про сто "сохранить", ни "сохранить как" ) изменения положения тележки, произошедшие вследствие движения тележки по программе (не важно) и нажатии кнопки "домой" (желательно).