### PR TITLE
Use default TRIK_PYTHONPATH on linux [WIP]

### DIFF
--- a/installer/platform/trik-studio
+++ b/installer/platform/trik-studio
@@ -5,4 +5,9 @@
 set -o errexit
 
 cd "$(dirname "$0")"
-bin/trik-studio "$@"
+
+if which python3 >/dev/null 2>&1 && [[ ! -v TRIK_PYTHONPATH ]] ; then
+export TRIK_PYTHONPATH=$(python3 -c 'import os; import sys; print(os.pathsep.join(sys.path))')
+fi
+
+exec bin/trik-studio "$@"


### PR DESCRIPTION
Can cause problems with versions mismatch. F.e. Xenial has 3.5
Maybe this workaround must be documented somehow, or correct python libs should be packed into installer.