### PR TITLE
Hack to switch on default robot model

### DIFF
--- a/plugins/robots/checker/twoDModelRunner/main.cpp
+++ b/plugins/robots/checker/twoDModelRunner/main.cpp
@@ -89,6 +89,11 @@ int main(int argc, char *argv[])
 	QLOG_INFO() << "Setting default locale to" << QLocale().name();
 	setDefaultLocale();
 
+	// Hack to switch on default robot model
+	for (QString kit : {"trikV62", "trikV6", "ev3", "nxt"}) {
+		qReal::SettingsManager::setValue("SelectedModelFor" + kit + "Kit", QVariant());
+	}
+
 	QCommandLineParser parser;
 	parser.setApplicationDescription(description);
 	parser.addHelpOption();

--- a/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
@@ -11,7 +11,7 @@ In background mode the session will be terminated just after the execution ended
         <translation>Émule le comportement du robot sur le modèle 2D TRIK Studio séparément de l&apos;environnement de programmation. Le fichier .qrs sera interprété comme si le bouton &apos;Executer&apos; était appuyé dans TRIK Studio.</translation>
     </message>
     <message>
-        <location line="+66"/>
+        <location line="+71"/>
         <source>Save file to be interpreted.</source>
         <translation>Le fichier de sauvegarde à interpréter.</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
@@ -17,7 +17,7 @@ In background mode the session will be terminated just after the execution ended
 </translation>
     </message>
     <message>
-        <location line="+66"/>
+        <location line="+71"/>
         <source>Save file to be interpreted.</source>
         <translation>Файл сохранения, который будет исполнен.</translation>
     </message>


### PR DESCRIPTION
Fixed
>Симуляция в 2DModel.exe не запускается, когда в студии стоит режим запуска на реальном роботе.

Аккуратно и красиво вытянуть инфу про комплекты не вышло, так что вот такой захардкоженный хак:(