### PR TITLE
Use of zorder option causes crash

### DIFF
--- a/plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui
+++ b/plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui
@@ -28,7 +28,6 @@
    </property>
    <item row="0" column="0">
     <widget class="qReal::ui::ImagePicker" name="robotImagePicker" native="true">
-     <zorder>bluetoothSettingsGroupBox</zorder>
     </widget>
    </item>
    <item row="1" column="0">

--- a/qrgraph/src/queries.cpp
+++ b/qrgraph/src/queries.cpp
@@ -127,7 +127,7 @@ QList<const Node *> Queries::immediateFollowers(const Node &node, uint edgeType)
 		}
 	}
 
-	return result.toList();
+	return result.values();
 }
 
 QList<const Node *> Queries::immediatePredecessors(const Node &node, uint edgeType)
@@ -140,12 +140,12 @@ QList<const Node *> Queries::immediatePredecessors(const Node &node, uint edgeTy
 		}
 	}
 
-	return result.toList();
+	return result.values();
 }
 
 QList<const Node *> Queries::reachableSet(const Node &node, uint edgeType)
 {
 	QSet<const Node *> result;
 	::dfs(node, [](const Node &) {return false;}, edgeType, result);
-	return result.toList();
+	return result.values();
 }

--- a/qrtext/src/core/types/typeVariable.cpp
+++ b/qrtext/src/core/types/typeVariable.cpp
@@ -32,7 +32,7 @@ TypeVariable::TypeVariable(const QSharedPointer<TypeExpression> &singleType)
 
 bool TypeVariable::isResolved() const
 {
-	return mAllowedTypes.size() == 1 && !mAllowedTypes.toList().first()->is<Any>();
+	return mAllowedTypes.size() == 1 && !mAllowedTypes.values().first()->is<Any>();
 }
 
 bool TypeVariable::isEmpty() const
@@ -42,17 +42,17 @@ bool TypeVariable::isEmpty() const
 
 QSharedPointer<TypeExpression> TypeVariable::finalType() const
 {
-	if (mAllowedTypes.size() == 0) {
+	if (mAllowedTypes.empty()) {
 		return QSharedPointer<TypeExpression>(new Any());
 	} else {
-		return mAllowedTypes.toList()[0].dynamicCast<TypeExpression>();
+		return mAllowedTypes.begin()->dynamicCast<TypeExpression>();
 	}
 }
 
 void TypeVariable::constrain(const QSharedPointer<TypeVariable> &other
 		, const GeneralizationsTableInterface &generalizationsTable)
 {
-	constrain(other->mAllowedTypes.toList(), generalizationsTable);
+	constrain(other->mAllowedTypes.values(), generalizationsTable);
 }
 
 void TypeVariable::constrain(const QList<QSharedPointer<TypeExpression>> &types

--- a/qrtranslations/fr/plugins/robots/ev3KitInterpreter_fr.ts
+++ b/qrtranslations/fr/plugins/robots/ev3KitInterpreter_fr.ts
@@ -25,7 +25,7 @@
         <translation type="vanished">Wi-Fi</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+22"/>
         <source>Robot&apos;s Folders</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/ev3KitInterpreter_ru.ts
+++ b/qrtranslations/ru/plugins/robots/ev3KitInterpreter_ru.ts
@@ -6,10 +6,10 @@
     <message>
         <location filename="../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="+14"/>
         <source>Form</source>
-        <translation>Настроки EV3</translation>
+        <translation>Настройки EV3</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+22"/>
         <source>Robot&apos;s Folders</source>
         <translation>Папки Робота</translation>
     </message>


### PR DESCRIPTION
because Qt's `uic` generates reordering call with access to uninitialized field
Closes #816 