### PR TITLE
Rotation, translations, old blocks and other fixes

### DIFF
--- a/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lightSensor.h
+++ b/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lightSensor.h
@@ -27,7 +27,7 @@ class ROBOTS_KIT_BASE_EXPORT LightSensor : public ScalarSensor
 	Q_OBJECT
 	Q_CLASSINFO("name", "light")
 	Q_CLASSINFO("friendlyName", tr("Light sensor"))
-	Q_CLASSINFO("simulated", "true")
+//	Q_CLASSINFO("simulated", "true")
 
 public:
 	/// Constructor, takes device type info and port on which this sensor is configured.

--- a/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/rangeSensor.h
+++ b/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/rangeSensor.h
@@ -28,7 +28,7 @@ class ROBOTS_KIT_BASE_EXPORT RangeSensor : public ScalarSensor
 	Q_OBJECT
 	Q_CLASSINFO("name", "sonar")
 	Q_CLASSINFO("friendlyName", tr("Range sensor"))
-	Q_CLASSINFO("simulated", "true")
+//	Q_CLASSINFO("simulated", "true")
 
 public:
 	/// Constructor, takes device type info and port on which this sensor is configured.

--- a/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/touchSensor.h
+++ b/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/touchSensor.h
@@ -28,7 +28,7 @@ class ROBOTS_KIT_BASE_EXPORT TouchSensor : public ScalarSensor
 	Q_OBJECT
 	Q_CLASSINFO("name", "touch")
 	Q_CLASSINFO("friendlyName", tr("Touch sensor"))
-	Q_CLASSINFO("simulated", "true")
+//	Q_CLASSINFO("simulated", "true")
 
 public:
 	/// Constructor, takes device type info and port on which this sensor is configured.

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikInfraredSensor.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikInfraredSensor.h
@@ -25,7 +25,7 @@ class TrikInfraredSensor : public kitBase::robotModel::robotParts::RangeSensor
 	Q_OBJECT
 	Q_CLASSINFO("name", "infrared")
 	Q_CLASSINFO("friendlyName", tr("Infrared Sensor"))
-	Q_CLASSINFO("simulated", "true")
+//	Q_CLASSINFO("simulated", "true")
 
 public:
 	TrikInfraredSensor(const kitBase::robotModel::DeviceInfo &info

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLightSensor.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLightSensor.h
@@ -26,7 +26,7 @@ class TrikLightSensor : public kitBase::robotModel::robotParts::LightSensor
 	Q_OBJECT
 	Q_CLASSINFO("name", "light")
 	Q_CLASSINFO("friendlyName", tr("Light sensor"))
-	Q_CLASSINFO("simulated", "true")
+//	Q_CLASSINFO("simulated", "true")
 
 public:
 	TrikLightSensor(const kitBase::robotModel::DeviceInfo &info, const kitBase::robotModel::PortInfo &port);

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLineSensor.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLineSensor.h
@@ -26,7 +26,7 @@ class TrikLineSensor : public kitBase::robotModel::robotParts::VectorSensor
 	Q_OBJECT
 	Q_CLASSINFO("name", "trikLineSensor")
 	Q_CLASSINFO("friendlyName", tr("Line Sensor"))
-	Q_CLASSINFO("simulated", "true")
+//	Q_CLASSINFO("simulated", "true")
 
 public:
 	TrikLineSensor(const kitBase::robotModel::DeviceInfo &info

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikSonarSensor.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikSonarSensor.h
@@ -25,7 +25,7 @@ class TrikSonarSensor : public kitBase::robotModel::robotParts::RangeSensor
 	Q_OBJECT
 	Q_CLASSINFO("name", "sonar")
 	Q_CLASSINFO("friendlyName", tr("Sonic Sensor"))
-	Q_CLASSINFO("simulated", "true")
+//	Q_CLASSINFO("simulated", "true")
 
 public:
 	TrikSonarSensor(const kitBase::robotModel::DeviceInfo &info

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikTouchSensor.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikTouchSensor.h
@@ -26,7 +26,7 @@ class TrikTouchSensor : public kitBase::robotModel::robotParts::TouchSensor
 	Q_OBJECT
 	Q_CLASSINFO("name", "touch")
 	Q_CLASSINFO("friendlyName", tr("Touch sensor"))
-	Q_CLASSINFO("simulated", "true")
+//	Q_CLASSINFO("simulated", "true")
 
 public:
 	TrikTouchSensor(const kitBase::robotModel::DeviceInfo &info, const kitBase::robotModel::PortInfo &port);

--- a/plugins/robots/common/trikKit/src/blocks/trikV6BlocksFactory.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/trikV6BlocksFactory.cpp
@@ -47,5 +47,37 @@ qReal::IdList TrikV6BlocksFactory::providedBlocks() const
 		result << id("TrikTurnRight");
 		result << id("TrikTurnLeft");
 	}
+
+	// Drawing actions
+	result
+			<< id("TrikSetPainterColor")
+			<< id("TrikSetPainterWidth")
+			<< id("TrikDrawPixel")
+			<< id("TrikDrawLine")
+			<< id("TrikDrawRect")
+			<< id("TrikDrawEllipse")
+			<< id("TrikDrawArc")
+			<< id("TrikSmile")
+			<< id("TrikSadSmile")
+			<< id("TrikSetBackground")
+			;
+
+	// Robots actions
+	result
+			<< id("TrikSay")
+			<< id("TrikLed")
+			<< id("GetButtonCode")
+			<< id("TrikSendMessage")
+			;
+
+	// Wait for sensors
+	result
+			<< id("TrikWaitForTouchSensor")
+			<< id("TrikWaitForLight")
+			<< id("TrikWaitForIRDistance")
+			<< id("TrikWaitForSonarDistance")
+			<< id("TrikWaitForButton")
+			;
+
 	return result;
 }

--- a/plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp
@@ -93,7 +93,8 @@ void RobotModel::reinit()
 void RobotModel::moveCell(int n) {
 	const int gridSize = qReal::SettingsManager::value("2dGridCellSize").toInt();
 	auto shiftPos = QTransform().rotate(mAngle).map(QPointF(gridSize, 0));
-	for (int i = 0; i < n; i++) {
+	if (n < 0) shiftPos = -shiftPos;
+	for (int i = 0; i < abs(n); i++) {
 		auto moveLine = QLineF(rotationCenter(), rotationCenter() + shiftPos);
 		for (auto wall : mWorldModel->walls()) {
 			auto wallLine = QLineF(wall->begin(), wall->end());

--- a/plugins/robots/common/twoDModel/src/engine/model/sensorsConfiguration.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/sensorsConfiguration.cpp
@@ -52,7 +52,7 @@ void SensorsConfiguration::onDeviceConfigurationChanged(const QString &robotId
 QPointF SensorsConfiguration::defaultPosition() const
 {
 	/// @todo: Move it somewhere?
-	return QPointF(mRobotSize.width() * 3 / 2, mRobotSize.height() / 2);
+	return QPointF(mRobotSize.width(), mRobotSize.height() / 2);
 }
 
 QPointF SensorsConfiguration::position(const PortInfo &port) const

--- a/plugins/robots/editor/trik/generated/elements.h
+++ b/plugins/robots/editor/trik/generated/elements.h
@@ -112,9 +112,9 @@
 			: NodeElementType(metamodel)
 		{
 			setName("TrikBackwardOneCell");
-			setFriendlyName(QObject::tr("Backward one cell"));
+			setFriendlyName(QObject::tr("Backward"));
 			setDiagram("RobotsDiagram");
-			setDescription(QObject::tr("IKHONAKHBEEVA"));
+			setDescription(QObject::tr("Moves backward one cell."));
 			loadSdf(utils::xmlUtils::loadDocument(":/generated/shapes/TrikBackwardOneCellClass.sdf").documentElement());
 			setSize(QSizeF(50, 50));
 			initProperties();
@@ -681,9 +681,9 @@
 			: NodeElementType(metamodel)
 		{
 			setName("TrikForwardOneCell");
-			setFriendlyName(QObject::tr("Forward one cell"));
+			setFriendlyName(QObject::tr("Forward"));
 			setDiagram("RobotsDiagram");
-			setDescription(QObject::tr("IKHONAKHBEEVA"));
+			setDescription(QObject::tr("Moves forward one cell."));
 			loadSdf(utils::xmlUtils::loadDocument(":/generated/shapes/TrikForwardOneCellClass.sdf").documentElement());
 			setSize(QSizeF(50, 50));
 			initProperties();
@@ -1481,7 +1481,7 @@
 			setName("TrikTurnLeft");
 			setFriendlyName(QObject::tr("Turn left"));
 			setDiagram("RobotsDiagram");
-			setDescription(QObject::tr("IKHONAKHBEEVA"));
+			setDescription(QObject::tr("Rotates 90 degrees to the left."));
 			loadSdf(utils::xmlUtils::loadDocument(":/generated/shapes/TrikTurnLeftClass.sdf").documentElement());
 			setSize(QSizeF(50, 50));
 			initProperties();
@@ -1516,7 +1516,7 @@
 			setName("TrikTurnRight");
 			setFriendlyName(QObject::tr("Turn right"));
 			setDiagram("RobotsDiagram");
-			setDescription(QObject::tr("IKHONAKHBEEVA"));
+			setDescription(QObject::tr("Rotates 90 degrees to the right."));
 			loadSdf(utils::xmlUtils::loadDocument(":/generated/shapes/TrikTurnRightClass.sdf").documentElement());
 			setSize(QSizeF(50, 50));
 			initProperties();

--- a/plugins/robots/editor/trik/trikMetamodel.xml
+++ b/plugins/robots/editor/trik/trikMetamodel.xml
@@ -92,7 +92,7 @@
 					</generalizations>
 				</logic>
 			</node>
-			<node displayedName="Forward one cell" name="TrikForwardOneCell" description="IKHONAKHBEEVA">
+			<node displayedName="Forward" name="TrikForwardOneCell" description="Moves forward one cell.">
 				<graphics>
 					<picture sizex="50" sizey="50">
 						<image y1="0" name="images/forwardOneCellBlock.png" x1="0" y2="50" x2="50"/>
@@ -106,7 +106,7 @@
 					</generalizations>
 				</logic>
 			</node>
-			<node displayedName="Backward one cell" name="TrikBackwardOneCell" description="IKHONAKHBEEVA">
+			<node displayedName="Backward" name="TrikBackwardOneCell" description="Moves backward one cell.">
 				<graphics>
 					<picture sizex="50" sizey="50">
 						<image y1="0" name="images/backwardOneCellBlock.png" x1="0" y2="50" x2="50"/>
@@ -120,7 +120,7 @@
 					</generalizations>
 				</logic>
 			</node>
-			<node displayedName="Turn right" name="TrikTurnRight" description="IKHONAKHBEEVA">
+			<node displayedName="Turn right" name="TrikTurnRight" description="Rotates 90 degrees to the right.">
 				<graphics>
 					<picture sizex="50" sizey="50">
 						<image y1="0" name="images/turnRightBlock.png" x1="0" y2="50" x2="50"/>
@@ -134,7 +134,7 @@
 					</generalizations>
 				</logic>
 			</node>
-			<node displayedName="Turn left" name="TrikTurnLeft" description="IKHONAKHBEEVA">
+			<node displayedName="Turn left" name="TrikTurnLeft" description="Rotates 90 degrees to the left.">
 				<graphics>
 					<picture sizex="50" sizey="50">
 						<image y1="0" name="images/turnLeftBlock.png" x1="0" y2="50" x2="50"/>

--- a/plugins/robots/interpreters/interpreterCore/interpreterCoreDefaultSettings.ini
+++ b/plugins/robots/interpreters/interpreterCore/interpreterCoreDefaultSettings.ini
@@ -8,7 +8,7 @@ SelectedRobotKit=trikV62Kit
 
 2dFollowingRobot=true
 2dCursorType=1
-2dShowGrid=false
+2dShowGrid=true
 2dGridCellSize=50
 
 approximationLevel=12

--- a/qrkernel/settingsManager.cpp
+++ b/qrkernel/settingsManager.cpp
@@ -24,7 +24,7 @@ using namespace qReal;
 SettingsManager* SettingsManager::mInstance = nullptr;
 
 SettingsManager::SettingsManager()
-	: mSettings(QSettings::IniFormat, QSettings::UserScope, "CyberTech Labs", "TRIK Studio")
+	: mSettings(QSettings::IniFormat, QSettings::UserScope, "CyberTech Labs", "TRIK Studio Start")
 {
 	initDefaultValues();
 	load();

--- a/qrtranslations/fr/plugins/robots/trikMetamodel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikMetamodel_fr.ts
@@ -100,7 +100,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1410"/>
+        <location line="-1480"/>
+        <source>Backward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+70"/>
         <location line="+11"/>
         <source>Detect by Videocamera</source>
         <translation type="unfinished"></translation>
@@ -364,7 +369,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+71"/>
+        <source>Forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
         <location line="+11"/>
         <source>Initialize Videocamera</source>
         <translation type="unfinished"></translation>
@@ -475,20 +485,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-809"/>
-        <source>Backward one cell</source>
+        <location line="-807"/>
+        <source>Moves backward one cell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+569"/>
-        <location line="+798"/>
-        <location line="+35"/>
-        <source>IKHONAKHBEEVA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-1369"/>
+        <location line="+33"/>
         <source>Calibrate gyroscope</source>
         <translation type="unfinished"></translation>
     </message>
@@ -498,12 +500,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+532"/>
-        <source>Forward one cell</source>
+        <location line="+534"/>
+        <source>Moves forward one cell.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+73"/>
         <source>Draw stream</source>
         <translation type="unfinished"></translation>
     </message>
@@ -726,7 +728,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
+        <location line="-33"/>
+        <source>Rotates 90 degrees to the left.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Rotates 90 degrees to the right.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+75"/>
         <source>S1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -369,7 +369,7 @@
 <context>
     <name>twoDModel::model::RobotModel</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp" line="+101"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp" line="+102"/>
         <source>Movement is impossible!</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/robotsMetamodel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/robotsMetamodel_ru.ts
@@ -16,7 +16,7 @@
     <message>
         <location line="-125"/>
         <source>Iterations:</source>
-        <translation>Итераций:</translation>
+        <translation>Повторить:</translation>
     </message>
     <message>
         <source>Volume (%):</source>
@@ -931,7 +931,7 @@
     <message>
         <location line="+33"/>
         <source>Iterations</source>
-        <translation>Итерации</translation>
+        <translation>Повторить</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -1524,7 +1524,7 @@
     <message>
         <location filename="../../../../plugins/robots/editor/common/generated/elements.h" line="-928"/>
         <source>Expression</source>
-        <translation type="unfinished">Выражение</translation>
+        <translation>Выражение</translation>
     </message>
     <message>
         <location line="+568"/>

--- a/qrtranslations/ru/plugins/robots/trikMetamodel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikMetamodel_ru.ts
@@ -100,7 +100,12 @@
         <translation>Угол (градусы)</translation>
     </message>
     <message>
-        <location line="-1410"/>
+        <location line="-1480"/>
+        <source>Backward</source>
+        <translation>Назад</translation>
+    </message>
+    <message>
+        <location line="+70"/>
         <location line="+11"/>
         <source>Detect by Videocamera</source>
         <translation>Детектировать по камере</translation>
@@ -364,7 +369,12 @@
         <translation>Нарисовать на экране прямоугольник. В качестве параметров указываются координаты левого верхнего угла, ширина и высота прямоугольника.</translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+71"/>
+        <source>Forward</source>
+        <translation>Вперед</translation>
+    </message>
+    <message>
+        <location line="+35"/>
         <location line="+11"/>
         <source>Initialize Videocamera</source>
         <translation>Включить видеокамеру</translation>
@@ -475,20 +485,12 @@
         <translation>мс</translation>
     </message>
     <message>
-        <location line="-809"/>
-        <source>Backward one cell</source>
-        <translation type="unfinished"></translation>
+        <location line="-807"/>
+        <source>Moves backward one cell.</source>
+        <translation>Переместиться назад на одну клетку.</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+569"/>
-        <location line="+798"/>
-        <location line="+35"/>
-        <source>IKHONAKHBEEVA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-1369"/>
+        <location line="+33"/>
         <source>Calibrate gyroscope</source>
         <translation>Калибровка  гироскопа</translation>
     </message>
@@ -498,12 +500,12 @@
         <translation>Устанавливает гироскоп в 0 в текущей позиции.</translation>
     </message>
     <message>
-        <location line="+532"/>
-        <source>Forward one cell</source>
-        <translation type="unfinished"></translation>
+        <location line="+534"/>
+        <source>Moves forward one cell.</source>
+        <translation>Переместиться вперед на одну клетку.</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+73"/>
         <source>Draw stream</source>
         <translation>Вывести на экран</translation>
     </message>
@@ -718,12 +720,22 @@
     <message>
         <location line="+12"/>
         <source>Turn left</source>
-        <translation type="unfinished"></translation>
+        <translation>Налево</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Rotates 90 degrees to the left.</source>
+        <translation>Повернуться на 90 градусов влево.</translation>
     </message>
     <message>
         <location line="+35"/>
+        <source>Rotates 90 degrees to the right.</source>
+        <translation>Повернуться на 90 градусов вправо.</translation>
+    </message>
+    <message>
+        <location line="-2"/>
         <source>Turn right</source>
-        <translation type="unfinished"></translation>
+        <translation>Направо</translation>
     </message>
     <message>
         <location line="+77"/>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -641,7 +641,7 @@
 <context>
     <name>twoDModel::model::RobotModel</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp" line="+101"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp" line="+102"/>
         <source>Movement is impossible!</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrutils/graphicsUtils/rotateItem.cpp
+++ b/qrutils/graphicsUtils/rotateItem.cpp
@@ -13,6 +13,7 @@
  * limitations under the License. */
 
 #include "rotateItem.h"
+#include <QtCore/qmath.h>
 
 using namespace graphicsUtils;
 
@@ -72,4 +73,13 @@ void RotateItem::restorePos()
 {
 	AbstractItem::restorePos();
 	rotater().restorePos();
+}
+
+void RotateItem::setRotation(qreal angle) {
+	qreal rightAngle = 90;
+	qreal roundedAngle = (angle - fmod(angle, rightAngle));
+	if (qAbs(roundedAngle - angle) > qAbs(roundedAngle + rightAngle - angle)) {
+		roundedAngle += rightAngle;
+	}
+	QGraphicsItem::setRotation(roundedAngle);
 }

--- a/qrutils/graphicsUtils/rotateItem.h
+++ b/qrutils/graphicsUtils/rotateItem.h
@@ -34,6 +34,8 @@ public:
 	void savePos() override;
 	void restorePos() override;
 
+	void setRotation(qreal angle);
+
 protected:
 	/// Must be called in subclass to initialize rotater position and so on.
 	/// Can`t be called here in constructor because it uses virtual methods.

--- a/qrutils/graphicsUtils/rotater.cpp
+++ b/qrutils/graphicsUtils/rotater.cpp
@@ -150,15 +150,15 @@ void Rotater::calcResizeItem(QGraphicsSceneMouseEvent *event)
 	const qreal addAngle = deltaAngle > M_PI ? -2 * M_PI : deltaAngle < -M_PI ? 2 * M_PI : 0;
 	const qreal angle = mMaster->rotation() * M_PI / 180 + deltaAngle + addAngle;
 
-	if (event->modifiers() & Qt::ShiftModifier) {
-		qreal roundedAngle = (angle - fmod(angle, M_PI_4));
-		if (qAbs(roundedAngle - angle) > qAbs(roundedAngle + M_PI_4 - angle)) {
-			roundedAngle += M_PI_4;
-		}
-		mMaster->setRotation(roundedAngle * 180 / M_PI - masterAngleCompensation);
-	} else {
+//	if (event->modifiers() & Qt::ShiftModifier) {
+//		qreal roundedAngle = (angle - fmod(angle, M_PI_2));
+//		if (qAbs(roundedAngle - angle) > qAbs(roundedAngle + M_PI_2 - angle)) {
+//			roundedAngle += M_PI_2;
+//		}
+//		mMaster->setRotation(roundedAngle * 180 / M_PI - masterAngleCompensation);
+//	} else {
 		mMaster->setRotation(angle * 180 / M_PI - masterAngleCompensation);
-	}
+//	}
 }
 
 void Rotater::resizeItem(QGraphicsSceneMouseEvent *event)


### PR DESCRIPTION
Поворот только на кратные 90 градусам углы (в том числе коррекция при загрузке сейвов)
Исправлено отсутствие движения назад
Перемещены сенсоры, чтобы их считывающая часть находилась ровно на передней части робота, их визуальная симуляция при этом отключена
Файл настроек отделен от файла настроек оригинальной студии (теперь удобнее пользоваться на одном компе одновременно и оригинальной, и этой студией)
Включены обратно некоторые блоки (взаимодействие с коробкой робота, рисование на дисплее, ожидание сенсоров)
Сетка по дефолту включена
Добавлены описания и переводы новых блоков