### PR TITLE
Customizable font size for dock windows [AUTOZIP]

### DIFF
--- a/qrgui/editor/propertyEditorView.cpp
+++ b/qrgui/editor/propertyEditorView.cpp
@@ -36,6 +36,11 @@ PropertyEditorView::PropertyEditorView(QWidget *parent)
 		, mButtonFactory(nullptr)
 		, mController(nullptr)
 {
+	bool ok;
+	auto size = qReal::SettingsManager::value("CustomDockTextSize").toInt(&ok);
+	if (ok) {
+		mPropertyEditor->setStyleSheet("QTreeWidget { font-size: " + QString::number(size) + "pt; }");
+	}
 	mPropertyEditor->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 }
 

--- a/qrgui/mainWindow/errorListWidget.cpp
+++ b/qrgui/mainWindow/errorListWidget.cpp
@@ -29,7 +29,7 @@ ErrorListWidget::ErrorListWidget(QWidget *parent)
 	connect(this, &ErrorListWidget::itemDoubleClicked, this, &ErrorListWidget::highlightElement);
 
 	bool ok;
-	auto size = qReal::SettingsManager::value("ErrorWindowFontSize").toInt(&ok);
+	auto size = qReal::SettingsManager::value("CustomDockTextSize").toInt(&ok);
 	if (ok) {
 		auto f = font();
 		f.setPointSize(size);

--- a/qrtranslations/fr/qrgui_editor_fr.ts
+++ b/qrtranslations/fr/qrgui_editor_fr.ts
@@ -247,7 +247,7 @@
 <context>
     <name>qReal::gui::editor::PropertyEditorView</name>
     <message>
-        <location filename="../../qrgui/editor/propertyEditorView.cpp" line="+310"/>
+        <location filename="../../qrgui/editor/propertyEditorView.cpp" line="+315"/>
         <source>Specify directory:</source>
         <translation type="unfinished">Choisissez le répertoire :</translation>
     </message>

--- a/qrtranslations/fr/qrutils_fr.ts
+++ b/qrtranslations/fr/qrutils_fr.ts
@@ -379,7 +379,7 @@
 <context>
     <name>qReal::ui::ConsoleDock</name>
     <message>
-        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+43"/>
+        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+50"/>
         <source>Reset shell</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/qrgui_editor_ru.ts
+++ b/qrtranslations/ru/qrgui_editor_ru.ts
@@ -251,7 +251,7 @@
 <context>
     <name>qReal::gui::editor::PropertyEditorView</name>
     <message>
-        <location filename="../../qrgui/editor/propertyEditorView.cpp" line="+310"/>
+        <location filename="../../qrgui/editor/propertyEditorView.cpp" line="+315"/>
         <source>Specify directory:</source>
         <translation>Выберите каталог:</translation>
     </message>

--- a/qrtranslations/ru/qrutils_ru.ts
+++ b/qrtranslations/ru/qrutils_ru.ts
@@ -487,7 +487,7 @@
 <context>
     <name>qReal::ui::ConsoleDock</name>
     <message>
-        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+43"/>
+        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+50"/>
         <source>Reset shell</source>
         <translation>Очистить консоль</translation>
     </message>

--- a/qrutils/watchListWindow.cpp
+++ b/qrutils/watchListWindow.cpp
@@ -14,7 +14,7 @@
 
 #include "watchListWindow.h"
 #include "ui_watchListWindow.h"
-
+#include "qrkernel/settingsManager.h"
 #include <QtGui/QClipboard>
 #include <functional>
 
@@ -67,6 +67,13 @@ void WatchListWindow::updateVariables()
 
 	auto sortedIdentifiers = identifiers();
 	std::sort(sortedIdentifiers.begin(), sortedIdentifiers.end());
+	auto f = mUi->watchListTableWidget->font();
+	bool ok;
+	auto fontSize = qReal::SettingsManager::value("CustomDockTextSize").toInt(&ok);
+	if (ok) {
+		f.setPointSize(fontSize);
+	}
+
 	for (auto &&identifier : sortedIdentifiers) {
 		if (mHiddenVariables.contains(identifier)) {
 			continue;
@@ -76,6 +83,8 @@ void WatchListWindow::updateVariables()
 			mUi->watchListTableWidget->insertRow(row);
 			mUi->watchListTableWidget->setItem(row, 0, new QTableWidgetItem());
 			mUi->watchListTableWidget->setItem(row, 1, new QTableWidgetItem());
+			mUi->watchListTableWidget->item(row, 0)->setFont(f);
+			mUi->watchListTableWidget->item(row, 1)->setFont(f);
 		}
 
 		mUi->watchListTableWidget->item(row, 0)->setText(identifier);

--- a/qrutils/widgets/consoleDock.cpp
+++ b/qrutils/widgets/consoleDock.cpp
@@ -13,6 +13,7 @@
  * limitations under the License. */
 
 #include "consoleDock.h"
+#include "qrkernel/settingsManager.h"
 
 #include <QtWidgets/QPlainTextEdit>
 #include <QtWidgets/QScrollBar>
@@ -31,8 +32,14 @@ ConsoleDock::ConsoleDock(const QString &title, QWidget *parent)
 {
 	QFont font("Monospace");
 	font.setStyleHint(QFont::Monospace);
+	bool ok;
+	auto size = qReal::SettingsManager::value("CustomDockTextSize").toInt(&ok);
+	if (ok) {
+		font.setPointSize(size);
+	}
+
 	mOutput->setFont(font);
-	if (!QFontInfo(font).fixedPitch()) {
+	if (!QFontInfo(mOutput->font()).fixedPitch()) {
 		QLOG_ERROR() << "Not monospaced font was choosen " << font.toString();
 	}
 	setWidget(mOutput);


### PR DESCRIPTION
* Watchlist
* Robot console
* Errors window
* Property editor

One can set CustomDockTextSize=18 for better presentation experience