### PR TITLE
Fix some bugs with pictures [AUTOZIP]

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp
@@ -17,6 +17,7 @@
 #include <QtCore/QUuid>
 #include <QtXml/QDomElement>
 #include <QtGui/QPainter>
+#include <qrutils/graphicsUtils/abstractItem.h>
 
 const QColor defaultColor = QColor(135, 206, 250);
 const QSizeF defaultSize = QSizeF(200, 200);
@@ -31,6 +32,7 @@ RegionItem::RegionItem(QGraphicsItem *parent)
 	, mColor(defaultColor)
 	, mSize(defaultSize)
 {
+	setZValue(graphicsUtils::AbstractItem::ZValue::Region);
 }
 
 QString RegionItem::id() const

--- a/plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp
@@ -114,6 +114,7 @@ QWidget *ImageItemPopup::initMemorizationPicker()
 {
 	auto *box = new QCheckBox(this);
 	mMemorizationPicker = box;
+	box->setChecked(true);
 	box->setIcon(QIcon(":/icons/2d_save.png"));
 	updateMemorizationToolTip();
 	box->setFocusPolicy(Qt::NoFocus);

--- a/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
@@ -197,7 +197,7 @@ void TwoDModelWidget::initWidget()
 
 	connect(mColorFieldItemPopup, &ColorItemPopup::propertyChanged, this, &TwoDModelWidget::saveWorldModelToRepo);
 
-	connect(mImageItemPopup, &ImageItemPopup::somethingChanged, this, [=]() {
+	connect(mImageItemPopup, &ImageItemPopup::propertyChanged, this, [=]() {
 		saveBlobsToRepo();
 		saveWorldModelToRepo();
 	});

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -571,7 +571,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+91"/>
         <source>Change image...</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -906,7 +906,7 @@
         <translation>Изображение будет на переднем плане. Предупреждение: робот видит это изображение с помощью сенсоров.</translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+91"/>
         <source>Change image...</source>
         <translation>Изменить картинку...</translation>
     </message>

--- a/qrutils/graphicsUtils/abstractItem.h
+++ b/qrutils/graphicsUtils/abstractItem.h
@@ -44,6 +44,7 @@ public:
 
 	enum ZValue {
 		Background
+		, Region
 		, Picture
 		, Shape
 		, Wall

--- a/qrutils/graphicsUtils/itemPopup.h
+++ b/qrutils/graphicsUtils/itemPopup.h
@@ -74,10 +74,6 @@ protected slots:
 	/// Default implementation clears items memorized last time.
 	virtual void detach();
 
-signals:
-	/// Emitted when user modifies some property or a group of properties via this popup window.
-	void somethingChanged();
-
 private slots:
 	void onMousePressedScene();
 	void onMouseReleasedScene();


### PR DESCRIPTION
Fixed :
> В xml не изменяется флаг isBackground при выставлении/убирании галочки с фоном

> Если загрузить картинку после старта студии, то текст будет со словом not, хотя галочка стоит. Если пощёлкать галочкой, то всё встанет на место. Это путает при подкладывании полей.

Add feature:
> А можно сделать, чтобы регионы в 2D были поверх картинки.

