### PR TITLE
Fix walls moving

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp
@@ -80,12 +80,12 @@ void WallItem::setPrivateData()
 
 QPointF WallItem::begin() const
 {
-	return QPointF(x1(), y1()) + mPos;
+	return QPointF(x1(), y1()) + scenePos();
 }
 
 QPointF WallItem::end() const
 {
-	return QPointF(x2(), y2()) + mPos;
+	return QPointF(x2(), y2()) + scenePos();
 }
 
 QRectF WallItem::boundingRect() const
@@ -153,8 +153,9 @@ QDomElement WallItem::serialize(QDomElement &parent) const
 	QDomElement wallNode = AbstractItem::serialize(parent);
 	wallNode.setTagName("wall");
 	setPenBrushToElement(wallNode, "wall");
-	mLineImpl.serialize(wallNode, x1() + mPos.x(), y1() + mPos.y()
-			, x2() + mPos.x(), y2() + mPos.y());
+	auto pos = scenePos();
+	mLineImpl.serialize(wallNode, x1() + pos.x(), y1() + pos.y()
+			, x2() + pos.x(), y2() + pos.y());
 	return wallNode;
 }
 
@@ -165,8 +166,7 @@ void WallItem::deserialize(const QDomElement &element)
 	const QPointF begin = points.first;
 	const QPointF end = points.second;
 
-	mPos = QPointF();
-	setPos(mPos);
+	setPos(QPointF());
 	setX1(begin.x());
 	setY1(begin.y());
 	setX2(end.x());
@@ -271,9 +271,9 @@ void WallItem::resizeWithGrid(QGraphicsSceneMouseEvent *event, int indexGrid)
 	} else {
 		const int coefX = static_cast<int>(pos().x()) / indexGrid;
 		const int coefY = static_cast<int>(pos().y()) / indexGrid;
-		mPos = QPointF(alignedCoordinate(pos().x(), coefX, indexGrid),
+		auto newPos = QPointF(alignedCoordinate(pos().x(), coefX, indexGrid),
 				alignedCoordinate(pos().y(), coefY, indexGrid));
-		setPos(mPos);
+		setPos(newPos);
 		update();
 	}
 }

--- a/plugins/robots/common/twoDModel/src/engine/items/wallItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/items/wallItem.h
@@ -91,8 +91,6 @@ private:
 	int mCellNumbX2 = 0;
 	int mCellNumbY2 = 0;
 
-	QPointF mPos;
-
 	QPainterPath mPath;
 	int mWallWidth;
 };


### PR DESCRIPTION
Fixed
>Робот упирается в стену там, где она была раньше, а потом ее переставили. Может проехать сквозь стену. После повторного открытия документа стена оказывается на старом месте. Перестановка не сохраняется.

(Баг 57 от САФа)