### PR TITLE
Draw trace with QGraphicsPathItem instead of QGraphicsLineItem

### DIFF
--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/worldModel.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/worldModel.h
@@ -238,7 +238,7 @@ private:
 	QMap<QString, items::RegionItem *> mRegions;
 	QMap<QString, Image*> mImages; // takes ownership
 	QMap<QString, int> mOrder;
-	QList<QGraphicsPathItem *> mRobotTrace;
+	QList<QGraphicsPathItem *> mRobotTrace; // Doesn`t take ownership.
 	Image *mBackgroundImage = nullptr;
 	QRect mBackgroundRect;
 	QScopedPointer<QDomDocument> mXmlFactory;

--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/worldModel.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/worldModel.h
@@ -19,7 +19,7 @@
 #include <QtCore/QPair>
 #include <QtGui/QPainterPath>
 #include <QtGui/QPolygon>
-#include <QtWidgets/QGraphicsLineItem>
+#include <QtWidgets/QGraphicsPathItem>
 #include <QtXml/QDomDocument>
 
 #include "twoDModel/engine/model/image.h"
@@ -89,7 +89,7 @@ public:
 	const QMap<QString, items::ImageItem *> &imageItems() const;
 
 	/// Returns a list of trace items on the floor.
-	const QList<QGraphicsLineItem *> &trace() const;
+	const QList<QGraphicsPathItem *> &trace() const;
 
 	/// Appends \a wall into world model.
 	void addWall(items::WallItem *wall);
@@ -207,7 +207,7 @@ signals:
 	void regionItemAdded(items::RegionItem *item);
 
 	/// Emitted each time when model is appended with some new item.
-	void traceItemAdded(QGraphicsLineItem *item);
+	void traceItemAddedOrChanged(QGraphicsPathItem *item);
 
 	/// Emitted each time when some item was removed from the 2D model world.
 	void itemRemoved(QGraphicsItem *item);
@@ -238,7 +238,7 @@ private:
 	QMap<QString, items::RegionItem *> mRegions;
 	QMap<QString, Image*> mImages; // takes ownership
 	QMap<QString, int> mOrder;
-	QList<QGraphicsLineItem *> mRobotTrace;
+	QList<QGraphicsPathItem *> mRobotTrace;
 	Image *mBackgroundImage = nullptr;
 	QRect mBackgroundRect;
 	QScopedPointer<QDomDocument> mXmlFactory;
@@ -248,4 +248,4 @@ private:
 }
 }
 
-Q_DECLARE_METATYPE(QGraphicsLineItem *)
+Q_DECLARE_METATYPE(QGraphicsPathItem *)

--- a/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
@@ -58,7 +58,7 @@ ConstraintsChecker::ConstraintsChecker(qReal::ErrorReporterInterface &errorRepor
 
 	bindToWorldModelObjects();
 	bindToRobotObjects();
-	mObjects["trace"] = new utils::ObjectsSet<QGraphicsLineItem *>(mModel.worldModel().trace(), this);
+	mObjects["trace"] = new utils::ObjectsSet<QGraphicsPathItem *>(mModel.worldModel().trace(), this);
 }
 
 ConstraintsChecker::~ConstraintsChecker()

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/fakeScene.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/fakeScene.cpp
@@ -33,14 +33,15 @@ FakeScene::FakeScene(const WorldModel &world)
 			addClone(item, item->clone());
 		}
 	});
-	connect(&world, &WorldModel::traceItemAdded, this, [=](QGraphicsLineItem *item) {
-		addClone(item, new QGraphicsLineItem(item->line()));
+	connect(&world, &WorldModel::traceItemAddedOrChanged, this, [=](QGraphicsPathItem *item) {
+		addClone(item, new QGraphicsPathItem(item->path()));
 	});
 	connect(&world, &WorldModel::itemRemoved, this, &FakeScene::deleteItem);
 }
 
 void FakeScene::addClone(QGraphicsItem * const original, QGraphicsItem * const cloned)
 {
+	deleteItem(original);
 	mClonedItems[original] = cloned;
 	addItem(cloned);
 
@@ -64,6 +65,7 @@ void FakeScene::addClone(QGraphicsItem * const original, QGraphicsItem * const c
 void FakeScene::deleteItem(QGraphicsItem * const original)
 {
 	if (mClonedItems.contains(original)) {
+		removeItem(mClonedItems[original]);
 		delete mClonedItems[original];
 		mClonedItems.remove(original);
 	}

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/fakeScene.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/fakeScene.cpp
@@ -34,6 +34,8 @@ FakeScene::FakeScene(const WorldModel &world)
 		}
 	});
 	connect(&world, &WorldModel::traceItemAddedOrChanged, this, [=](QGraphicsPathItem *item) {
+		// if traceItem was changed need delete old clone before adding new clone
+		deleteItem(item);
 		addClone(item, new QGraphicsPathItem(item->path()));
 	});
 	connect(&world, &WorldModel::itemRemoved, this, &FakeScene::deleteItem);
@@ -41,7 +43,6 @@ FakeScene::FakeScene(const WorldModel &world)
 
 void FakeScene::addClone(QGraphicsItem * const original, QGraphicsItem * const cloned)
 {
-	deleteItem(original);
 	mClonedItems[original] = cloned;
 	addItem(cloned);
 

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp
@@ -82,8 +82,8 @@ TwoDModelScene::TwoDModelScene(model::Model &model
 	connect(&mModel.worldModel(), &model::WorldModel::imageItemAdded, this, &TwoDModelScene::onImageItemAdded);
 	connect(&mModel.worldModel(), &model::WorldModel::regionItemAdded
 			, this, [=](items::RegionItem *item) { addItem(item); });
-	connect(&mModel.worldModel(), &model::WorldModel::traceItemAdded
-			, this, [=](QGraphicsLineItem *item) { addItem(item); });
+	connect(&mModel.worldModel(), &model::WorldModel::traceItemAddedOrChanged
+			, this, [=](QGraphicsPathItem *item) { addItem(item); });
 	connect(&mModel.worldModel(), &model::WorldModel::itemRemoved, this, &TwoDModelScene::onItemRemoved);
 
 	connect(&mModel, &model::Model::robotAdded, this, &TwoDModelScene::onRobotAdd);


### PR DESCRIPTION
Позволяет уменьшить количество QGraphicsItem на сцене, чтобы ускорить их удаление