### PR TITLE
Load start position with world model

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
@@ -520,9 +520,13 @@ void TwoDModelWidget::loadWorldModelWithoutRobot()
 	}
 
 	// TODO: Split saves and remove temporary hack
-	auto saveRoot = save.firstChildElement("root");
-	auto currentRoot = generateWorldModelXml().firstChildElement("root");
-	saveRoot.replaceChild(currentRoot.firstChildElement("robots"), saveRoot.firstChildElement("robots"));
+	auto saveRobot = save.firstChildElement("root").firstChildElement("robots").firstChildElement("robot");
+	auto currentRobot = generateWorldModelXml().firstChildElement("root")
+			.firstChildElement("robots").firstChildElement("robot");
+
+	saveRobot.replaceChild(saveRobot.firstChildElement("sensors"), currentRobot.firstChildElement("sensors"));
+	saveRobot.replaceChild(saveRobot.firstChildElement("wheels"), currentRobot.firstChildElement("wheels"));
+	saveRobot.setAttribute("id", currentRobot.attribute("id"));
 
 	auto command = new commands::LoadWorldCommand(*this, save);
 	if (mController) {

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -734,7 +734,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+334"/>
+        <location line="+338"/>
         <source>Hide details</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -1085,7 +1085,7 @@
         <translation type="vanished">Попытка загрузить слишком большое изображение может заморозить выполнение на некоторое время. Продолжить?</translation>
     </message>
     <message>
-        <location line="+334"/>
+        <location line="+338"/>
         <source>Hide details</source>
         <translation>Скрыть детали</translation>
     </message>


### PR DESCRIPTION
Fixed:

В новой версии при загрузке модели мира без конфигурации робота не грузится также точка старта и расположение робота. Это неправильно. Должны исключаться только следующие элементы:
- тип робота,
- состав датчиков и моторов, 
- расположение датчиков.