### PR TITLE
Fix sensors data

### DIFF
--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/robotModel.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/robotModel.h
@@ -135,7 +135,7 @@ public:
 	void markerUp();
 
 	/// Returns a position of the center of the robot in scene coordinates.
-	QPointF rotationCenter() const;
+	QPointF robotCenter() const;
 
 	/// Returns the item whose scene position will determine robot`s start position.
 	/// Transfers ownership.

--- a/plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp
@@ -121,7 +121,7 @@ Condition ConditionsFactory::inside(const QString &objectId, const QString &regi
 		}
 
 		if (model::RobotModel * const robotModel = dynamic_cast<model::RobotModel *>(object)) {
-			return region->containsPoint(robotModel->rotationCenter());
+			return region->containsPoint(robotModel->robotCenter());
 		}
 
 		if (kitBase::robotModel::robotParts::Device * const device
@@ -140,9 +140,9 @@ Condition ConditionsFactory::inside(const QString &objectId, const QString &regi
 			if (model::RobotModel * const robotModel = dynamic_cast<model::RobotModel *>(mObjects[robotId])) {
 				const QPointF devicePosition = robotModel->configuration().position(device->port());
 				const QPointF deviceRelativeToCenter = devicePosition
-						+ robotModel->position() - robotModel->rotationCenter();
+						+ robotModel->position() - robotModel->robotCenter();
 				const QPointF realDevicePosition = QTransform().rotate(robotModel->rotation())
-						.map(deviceRelativeToCenter) + robotModel->rotationCenter();
+						.map(deviceRelativeToCenter) + robotModel->robotCenter();
 
 				return region->containsPoint(realDevicePosition);
 			}

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp
@@ -106,7 +106,7 @@ bool Box2DPhysicsEngine::itemTracked(QGraphicsItem * const item)
 void Box2DPhysicsEngine::addRobot(model::RobotModel * const robot)
 {
 	PhysicsEngineBase::addRobot(robot);
-	addRobot(robot, robot->rotationCenter(), robot->rotation());
+	addRobot(robot, robot->robotCenter(), robot->rotation());
 
 	mPrevPosition = mBox2DRobots[robot]->getBody()->GetPosition();
 	mPrevAngle = mBox2DRobots[robot]->getBody()->GetAngle();

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DRobot.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DRobot.cpp
@@ -171,10 +171,10 @@ void Box2DRobot::reinitSensor(const twoDModel::view::SensorItem &sensor)
 	QPolygonF collidingPolygon = sensor.collidingPolygon();
 	QPointF localCenter = collidingPolygon.boundingRect().center();
 
-	QPointF deltaToCenter = mModel->rotationCenter() - mModel->position();
+	QPointF deltaToCenter = mModel->robotCenter() - mModel->position();
 	QPointF localPos = sensor.pos() - deltaToCenter;
 	QTransform transform;
-	QPointF dif = mModel->rotationCenter();
+	QPointF dif = mModel->robotCenter();
 	transform.translate(-dif.x(), -dif.y());
 	transform.rotate(mModel->rotation());
 	localPos = transform.map(localPos);
@@ -182,7 +182,7 @@ void Box2DRobot::reinitSensor(const twoDModel::view::SensorItem &sensor)
 	transform.translate(dif.x(), dif.y());
 	localPos = transform.map(localPos);
 
-	const b2Vec2 pos = mEngine->positionToBox2D(localPos - localCenter + mModel->rotationCenter());
+	const b2Vec2 pos = mEngine->positionToBox2D(localPos - localCenter + mModel->robotCenter());
 	// IMPORTANT: we connect every sensor with box2d circle item.
 	// So rotation of sensor doesn't matter, we set rotation corresponding to robot.
 	// if in future it will be changed, you'll see some strange behavior, because of joints. See connectSensor method.

--- a/plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp
@@ -238,9 +238,9 @@ QPointF RobotModel::averageAcceleration() const
 					- mPosStamps.nthFromHead(1) + mPosStamps.head()) / mPosStamps.size());
 }
 
-QPointF RobotModel::rotationCenter() const
+QPointF RobotModel::robotCenter() const
 {
-	return mPos + mRobotModel.rotationCenter();
+	return mPos + mRobotModel.robotCenter();
 }
 
 QPainterPath RobotModel::robotBoundingPath() const

--- a/plugins/robots/common/twoDModel/src/engine/twoDModelEngineApi.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/twoDModelEngineApi.cpp
@@ -315,10 +315,10 @@ uint TwoDModelEngineApi::spoilLight(const uint color) const
 QPair<QPointF, qreal> TwoDModelEngineApi::countPositionAndDirection(const PortInfo &port) const
 {
 	RobotModel * const robotModel = mModel.robotModels()[0];
-	const QPointF rotationCenter = robotModel->info().rotationCenter();
-	const QVector2D sensorVector = QVector2D(robotModel->configuration().position(port) - rotationCenter);
+	const QPointF robotCenter = robotModel->info().robotCenter();
+	const QVector2D sensorVector = QVector2D(robotModel->configuration().position(port) - robotCenter);
 	const QPointF rotatedVector = mathUtils::Geometry::rotateVector(sensorVector, robotModel->rotation()).toPointF();
-	const QPointF position = robotModel->position() + rotationCenter + rotatedVector;
+	const QPointF position = robotModel->position() + robotCenter + rotatedVector;
 	const qreal direction = robotModel->configuration().direction(port) + robotModel->rotation();
 	return { position, direction };
 }


### PR DESCRIPTION
Fixed:
>В этой версии что-то не так. Много раз проверенная в 2020.2 программа в 2020.3 работает иначе: робот едет на стену в лабиринте, его заносит на поворотах на линии, он крутится перед кегельрингом, заезжает в круг в полтора раза больше, чем требуется.