### PR TITLE
Item class refactoring to avoid object slicing

### DIFF
--- a/qrgui/mainWindow/shapeEdit/arch.cpp
+++ b/qrgui/mainWindow/shapeEdit/arch.cpp
@@ -33,30 +33,6 @@ Arch::Arch(QRectF rect, int startAngle, int spanAngle, Item* parent = nullptr)
 	mRect = rect;
 }
 
-Arch::Arch(const Arch &other)
-	:Item()
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = pictureType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mSpanAngle = other.mSpanAngle;
-	mStartAngle = other.mStartAngle;
-	mRect = other.mRect;
-	mListScalePoint = other.mListScalePoint;
-	setPos(other.x(), other.y());
-}
-
-Item* Arch::clone()
-{
-	Arch* item = new Arch(*this);
-	return item;
-}
-
 int Arch::startAngle() const
 {
 	return mStartAngle;

--- a/qrgui/mainWindow/shapeEdit/arch.h
+++ b/qrgui/mainWindow/shapeEdit/arch.h
@@ -21,10 +21,9 @@
 
 class Arch : public Item
 {
+	Q_DISABLE_COPY(Arch)
 public:
 	Arch(QRectF rect, int startAngle, int spanAngle, Item* parent);
-	Arch(const Arch &other);
-	virtual Item* clone();
 	int startAngle() const;
 	int spanAngle() const;
 	void setStartAngle(int start);

--- a/qrgui/mainWindow/shapeEdit/curve.cpp
+++ b/qrgui/mainWindow/shapeEdit/curve.cpp
@@ -31,29 +31,6 @@ Curve::Curve(const QPointF &start, const QPointF &end, const QPointF &c1)
 	mCurvePath->quadTo(mC1, QPointF(x2(), y2()));
 }
 
-Curve::Curve(const Curve &other)
-		: Path(QPainterPath())
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = Item::pictureType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mC1 = other.mC1;
-	mCurvePath = other.mCurvePath;
-	mListScalePoint = other.mListScalePoint;
-	setPos(other.x(), other.y());
-}
-
-Item* Curve::clone()
-{
-	Curve* item = new Curve(*this);
-	return item;
-}
-
 QPainterPath Curve::shape() const
 {
 	QPainterPath path;

--- a/qrgui/mainWindow/shapeEdit/curve.h
+++ b/qrgui/mainWindow/shapeEdit/curve.h
@@ -21,10 +21,9 @@
 
 class Curve : public Path
 {
+	Q_DISABLE_COPY(Curve)
 public:
 	Curve(const QPointF &start, const QPointF &end, const QPointF &c1);
-	Curve(const Curve &other);
-	virtual Item* clone();
 	void  setCXandCY(qreal x, qreal y);
 	QRectF searchMaxMinCoord() const;
 	virtual QRectF boundingRect() const;

--- a/qrgui/mainWindow/shapeEdit/ellipse.cpp
+++ b/qrgui/mainWindow/shapeEdit/ellipse.cpp
@@ -15,7 +15,8 @@
 #include "ellipse.h"
 
 QRealEllipse::QRealEllipse(qreal x1, qreal y1, qreal x2, qreal y2, Item* parent)
-		: Item(parent), mRectangleImpl()
+		: Item(parent)
+		, mRectangleImpl()
 {
 	mNeedScalingRect = true;
 	setPen(QPen(Qt::blue));
@@ -25,27 +26,6 @@ QRealEllipse::QRealEllipse(qreal x1, qreal y1, qreal x2, qreal y2, Item* parent)
 	setY1(y1);
 	setX2(x2);
 	setY2(y2);
-}
-
-QRealEllipse::QRealEllipse(const QRealEllipse &other)
-	 : Item(), mRectangleImpl()
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = pictureType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mListScalePoint = other.mListScalePoint;
-	setPos(other.x(), other.y());
-}
-
-Item* QRealEllipse::clone()
-{
-	QRealEllipse* item = new QRealEllipse(*this);
-	return item;
 }
 
 QRectF QRealEllipse::boundingRect() const

--- a/qrgui/mainWindow/shapeEdit/ellipse.h
+++ b/qrgui/mainWindow/shapeEdit/ellipse.h
@@ -22,10 +22,9 @@
 
 class QRealEllipse : public Item
 {
+	Q_DISABLE_COPY(QRealEllipse)
 public:
 	QRealEllipse(qreal x1, qreal y1, qreal x2, qreal y2, Item* parent = nullptr);
-	QRealEllipse(const QRealEllipse &other);
-	virtual Item* clone();
 	virtual QRectF boundingRect() const;
 	virtual void drawItem(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr);
 

--- a/qrgui/mainWindow/shapeEdit/image.cpp
+++ b/qrgui/mainWindow/shapeEdit/image.cpp
@@ -33,30 +33,6 @@ Image::Image(const QString &fileName, qreal x, qreal y, Item* parent)
 	setY2(y + pixmap->height());
 }
 
-Image::Image(const Image &other)
-	:Item(), mRectangleImpl()
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = pictureType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mListScalePoint = other.mListScalePoint;
-	mPixmapItem = other.mPixmapItem;
-	mFileName = other.mFileName;
-	mImage = other.mImage;
-	setPos(other.x(), other.y());
-}
-
-Item* Image::clone()
-{
-	Image* item = new Image(*this);
-	return item;
-}
-
 QRectF Image::boundingRect() const
 {
 	return mRectangleImpl.boundingRect(x1(), y1(), x2(), y2(), scalingDrift);

--- a/qrgui/mainWindow/shapeEdit/image.h
+++ b/qrgui/mainWindow/shapeEdit/image.h
@@ -20,10 +20,9 @@
 
 class Image : public Item
 {
+	Q_DISABLE_COPY(Image)
 public:
 	Image(const QString &fileName, qreal x, qreal y, Item* parent = nullptr);
-	Image(const Image &other);
-	virtual Item* clone();
 	virtual QRectF boundingRect() const;
 	virtual void drawItem(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr);
 	virtual void setItemZValue(int zValue);

--- a/qrgui/mainWindow/shapeEdit/item.h
+++ b/qrgui/mainWindow/shapeEdit/item.h
@@ -59,7 +59,6 @@ public:
 	};
 
 	Item(graphicsUtils::AbstractItem* parent = nullptr);
-	virtual Item* clone() = 0;
 	virtual void setItemZValue(int zValue);
 	int itemZValue();
 	static int sign(int x);

--- a/qrgui/mainWindow/shapeEdit/line.cpp
+++ b/qrgui/mainWindow/shapeEdit/line.cpp
@@ -33,26 +33,6 @@ Line::Line(qreal x1, qreal y1, qreal x2, qreal y2, Item* parent):Item(parent), m
 	setY2(y2);
 }
 
-Line::Line(const Line &other):Item(), mLineImpl()
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = pictureType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mListScalePoint = other.mListScalePoint;
-	setPos(other.x(), other.y());
-}
-
-Item* Line::clone()
-{
-	Line* item = new Line(*this);
-	return item;
-}
-
 QRectF Line::boundingRect() const
 {
 	return mLineImpl.boundingRect(x1(), y1(), x2(), y2(), pen().width(), drift);

--- a/qrgui/mainWindow/shapeEdit/line.h
+++ b/qrgui/mainWindow/shapeEdit/line.h
@@ -21,10 +21,9 @@
 class Line : public Item
 {
 	Q_INTERFACES(AbstractItem)
+	Q_DISABLE_COPY(Line)
 public:
 	Line(qreal x1, qreal y1, qreal x2, qreal y2, Item* parent = nullptr);
-	Line(const Line &other);
-	virtual Item* clone();
 	QLineF line() const;
 	QPainterPath shape() const;
 	virtual QRectF boundingRect() const;

--- a/qrgui/mainWindow/shapeEdit/linePort.cpp
+++ b/qrgui/mainWindow/shapeEdit/linePort.cpp
@@ -26,28 +26,6 @@ LinePort::LinePort(qreal x1, qreal y1, qreal x2, qreal y2, Line* parent)
 	setY2(y2);
 }
 
-LinePort::LinePort(const LinePort &other)
-	:Line(other)
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = portType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mListScalePoint = other.mListScalePoint;
-	mType = other.mType;
-	setPos(other.x(), other.y());
-}
-
-Item* LinePort::clone()
-{
-	LinePort* item = new LinePort(*this);
-	return item;
-}
-
 QPair<QDomElement, Item::DomElementTypes> LinePort::generateItem(QDomDocument &document, const QPoint &topLeftPicture)
 {
 	QDomElement linePort = document.createElement("linePort");

--- a/qrgui/mainWindow/shapeEdit/linePort.h
+++ b/qrgui/mainWindow/shapeEdit/linePort.h
@@ -19,10 +19,9 @@
 
 class LinePort : public Line
 {
+	Q_DISABLE_COPY(LinePort)
 public:
 	LinePort(qreal x1, qreal y1, qreal x2, qreal y2, Line* parent = nullptr);
-	LinePort(const LinePort &other);
-	virtual Item* clone();
 
 	virtual QPair<QDomElement, Item::DomElementTypes> generateItem(QDomDocument &document
 			, const QPoint &topLeftPicture);

--- a/qrgui/mainWindow/shapeEdit/path.cpp
+++ b/qrgui/mainWindow/shapeEdit/path.cpp
@@ -23,28 +23,6 @@ Path::Path(const QPainterPath &path) : Item(nullptr)
 	mDomElementType = Item::pictureType;
 }
 
-Path::Path(const Path &other)
-	:Item()
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = Item::pictureType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mPath = other.mPath;
-	mListScalePoint = other.mListScalePoint;
-	setPos(other.x(), other.y());
-}
-
-Item* Path::clone()
-{
-	Path* item = new Path(*this);
-	return item;
-}
-
 QRectF Path::boundingRect() const
 {
 	return mPath.boundingRect();

--- a/qrgui/mainWindow/shapeEdit/path.h
+++ b/qrgui/mainWindow/shapeEdit/path.h
@@ -20,10 +20,9 @@
 
 class Path : public Item
 {
+	Q_DISABLE_COPY(Path)
 public:
 	Path(const QPainterPath &path);
-	Path(const Path &other);
-	virtual Item* clone();
 	virtual QRectF boundingRect() const;
 	virtual void drawItem(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) ;
 	virtual QPair<QDomElement, Item::DomElementTypes> generateItem(QDomDocument &document

--- a/qrgui/mainWindow/shapeEdit/pointPort.cpp
+++ b/qrgui/mainWindow/shapeEdit/pointPort.cpp
@@ -30,29 +30,6 @@ PointPort::PointPort(qreal x, qreal y, Item *parent) : Item(parent), mPointImpl(
 	mDomElementType = portType;
 }
 
-PointPort::PointPort(const PointPort &other)
-	:Item(), mPointImpl()
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = portType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mRadius = other.mRadius;
-	mListScalePoint = other.mListScalePoint;
-	mType = other.mType;
-	setPos(other.x(), other.y());
-}
-
-Item* PointPort::clone()
-{
-	PointPort* item = new PointPort(*this);
-	return item;
-}
-
 QRectF PointPort::boundingRect() const
 {
 	return mPointImpl.boundingRect(x1() + mUnrealRadius, y1() + mUnrealRadius, mRadius, scalingDrift);

--- a/qrgui/mainWindow/shapeEdit/pointPort.h
+++ b/qrgui/mainWindow/shapeEdit/pointPort.h
@@ -21,10 +21,9 @@
 
 class PointPort : public Item
 {
+	Q_DISABLE_COPY(PointPort)
 public:
 	PointPort(qreal x, qreal y, Item *parent = nullptr);
-	PointPort(const PointPort &other);
-	virtual Item* clone();
 	virtual QRectF boundingRect() const;
 	virtual void drawItem(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr);
 	virtual void drawExtractionForItem(QPainter* painter);

--- a/qrgui/mainWindow/shapeEdit/rectangle.cpp
+++ b/qrgui/mainWindow/shapeEdit/rectangle.cpp
@@ -27,27 +27,6 @@ QRealRectangle::QRealRectangle(qreal x1, qreal y1, qreal x2, qreal y2, Item* par
 	setY2(y2);
 }
 
-QRealRectangle::QRealRectangle(const QRealRectangle &other)
-	:Item(), mRectangleImpl()
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = pictureType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mListScalePoint = other.mListScalePoint;
-	setPos(other.x(), other.y());
-}
-
-Item* QRealRectangle::clone()
-{
-	QRealRectangle* item = new QRealRectangle(*this);
-	return item;
-}
-
 QRectF QRealRectangle::boundingRect() const
 {
 	return mRectangleImpl.boundingRect(x1(), y1(), x2(), y2(), scalingDrift);

--- a/qrgui/mainWindow/shapeEdit/rectangle.h
+++ b/qrgui/mainWindow/shapeEdit/rectangle.h
@@ -22,10 +22,9 @@
 
 class QRealRectangle : public Item
 {
+	Q_DISABLE_COPY(QRealRectangle)
 public:
 	QRealRectangle(qreal x1, qreal y1, qreal x2, qreal y2, Item* parent = nullptr);
-	QRealRectangle(const QRealRectangle &other);
-	virtual Item* clone();
 	virtual QRectF boundingRect() const;
 	virtual void drawItem(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr);
 

--- a/qrgui/mainWindow/shapeEdit/scene.cpp
+++ b/qrgui/mainWindow/shapeEdit/scene.cpp
@@ -47,8 +47,7 @@ Scene::Scene(graphicsUtils::AbstractView *view, QObject * parent)
 QRectF Scene::selectedItemsBoundingRect() const
 {
 	QRectF resBoundRect;
-	auto list = mListSelectedItemsForPaste;
-	for (auto graphicsItem : list)
+	for (auto &&graphicsItem : mListSelectedItemsForPaste)
 		resBoundRect |= graphicsItem->sceneBoundingRect();
 	return resBoundRect;
 }
@@ -129,7 +128,7 @@ void Scene::setZValue(Item* item)
 void Scene::setZValueSelectedItems()
 {
 	mListSelectedItems = selectedItems();
-	for (auto graphicsItem : mListSelectedItems) {
+	for (auto &&graphicsItem : mListSelectedItems) {
 		Item* item = dynamic_cast<Item*>(graphicsItem);
 		item->setZValue(mZValue);
 		mZValue++;
@@ -138,7 +137,7 @@ void Scene::setZValueSelectedItems()
 
 void Scene::setNullZValueItems()
 {
-	for (auto graphicsItem : mListSelectedItems) {
+	for (auto &&graphicsItem : mListSelectedItems) {
 		Item* item = dynamic_cast<Item*>(graphicsItem);
 		item->setZValue(item->itemZValue());
 	}
@@ -147,16 +146,15 @@ void Scene::setNullZValueItems()
 
 QPair<bool, Item *> Scene::checkOnResize(qreal x, qreal y)
 {
-	QList<QSharedPointer<Item>> list = selectedSceneItems();
-	for (auto item : list) {
+	for (auto &&item : selectedSceneItems()) {
 		item->changeDragState(x, y);
 		item->changeScalingPointState(x, y);
 		if (item->dragState() != Item::None)  {
 			mView->setDragMode(QGraphicsView::NoDrag);
-			return QPair<bool, Item *>(true, item.data());
+			return {true, item.data()};
 		}
 	}
-	return QPair<bool, Item *>(false, nullptr);
+	return {false, nullptr};
 }
 
 void Scene::mousePressEvent(QGraphicsSceneMouseEvent *event)
@@ -374,7 +372,7 @@ void Scene::keyPressEvent(QKeyEvent *keyEvent)
 		QPointF topLeftSelection(selectedItemsBoundingRect().topLeft());
 		switch (mCopyPaste) {
 		case copy:
-			for(auto item: mListSelectedItemsForPaste) {
+			for(auto &&item: mListSelectedItemsForPaste) {
 				auto newItem = item;
 				newItem->setPos(posCursor - topLeftSelection + item->scenePos());
 				addItem(newItem.data());
@@ -382,7 +380,7 @@ void Scene::keyPressEvent(QKeyEvent *keyEvent)
 			}
 			break;
 		case cut:
-			for(auto item: mListSelectedItemsForPaste) {
+			for(auto &&item: mListSelectedItemsForPaste) {
 				item->setPos(posCursor - topLeftSelection + item->scenePos());
 				setZValue(item.data());
 				mListSelectedItemsForPaste.clear();
@@ -480,7 +478,7 @@ void Scene::addImage(const QString &fileName)
 void Scene::deleteItem()
 {
 	QList<QGraphicsItem *> list = selectedItems();
-	for (auto graphicsItem : list) {
+	for (auto &&graphicsItem : list) {
 		removeItem(graphicsItem);
 		delete graphicsItem;
 	}
@@ -498,7 +496,7 @@ QList<QSharedPointer<Item>> Scene::selectedSceneItems()
 {
 	QList<QSharedPointer<Item>> resList;
 	mListSelectedItems = selectedItems();
-	for (auto graphicsItem : mListSelectedItems) {
+	for (auto &&graphicsItem : mListSelectedItems) {
 		QSharedPointer<Item> item(dynamic_cast<Item*>(graphicsItem));
 		if (item != nullptr)
 			resList.push_back(item);
@@ -511,7 +509,7 @@ QList<QSharedPointer<TextPicture>> Scene::selectedTextPictureItems()
 {
 	QList<QSharedPointer<TextPicture>> resList;
 	mListSelectedItems = selectedItems();
-	for (auto graphicsItem : mListSelectedItems) {
+	for (auto &&graphicsItem : mListSelectedItems) {
 		QSharedPointer<TextPicture> item(dynamic_cast<TextPicture*>(graphicsItem));
 		if (item != nullptr)
 			resList.push_back(item);
@@ -522,7 +520,7 @@ QList<QSharedPointer<TextPicture>> Scene::selectedTextPictureItems()
 void Scene::changePenStyle(const QString &text)
 {
 	mPenStyleItems = text;
-	for (auto item : selectedSceneItems())
+	for (auto &&item : selectedSceneItems())
 		item->setPenStyle(text);
 	update();
 }
@@ -530,7 +528,7 @@ void Scene::changePenStyle(const QString &text)
 void Scene::changePenWidth(int width)
 {
 	mPenWidthItems = width;
-	for (auto item : selectedSceneItems())
+	for (auto &&item : selectedSceneItems())
 		item->setPenWidth(width);
 	update();
 }
@@ -538,7 +536,7 @@ void Scene::changePenWidth(int width)
 void Scene::changePenColor(const QString &text)
 {
 	mPenColorItems = text;
-	for (auto item : selectedSceneItems())
+	for (auto &&item : selectedSceneItems())
 		item->setPenColor(text);
 	update();
 }
@@ -546,7 +544,7 @@ void Scene::changePenColor(const QString &text)
 void Scene::changeBrushStyle(const QString &text)
 {
 	mBrushStyleItems = text;
-	for (auto item : selectedSceneItems())
+	for (auto &&item : selectedSceneItems())
 		item->setBrushStyle(text);
 	update();
 }
@@ -554,7 +552,7 @@ void Scene::changeBrushStyle(const QString &text)
 void Scene::changeBrushColor(const QString &text)
 {
 	mBrushColorItems = text;
-	for (auto item : selectedSceneItems())
+	for (auto &&item : selectedSceneItems())
 		item->setBrushColor(text);
 	update();
 }
@@ -563,7 +561,7 @@ void Scene::changePortsType(const QString &type)
 {
 	mPortType = type;
 
-	for (auto item : selectedItems()) {
+	for (auto &&item : selectedItems()) {
 		PointPort *point = dynamic_cast<PointPort *>(item);
 		if (point) {
 			point->setType(type);
@@ -604,7 +602,7 @@ void Scene::changeFontPalette()
 	if (mListSelectedTextPictureItems.isEmpty())
 		emit noSelectedTextPictureItems();
 	else {
-		auto item = mListSelectedTextPictureItems.back();
+		const auto &item = mListSelectedTextPictureItems.back();
 		if (item != nullptr) {
 			QPen penItem = item->pen();
 			QFont fontItem = item->font();
@@ -615,7 +613,7 @@ void Scene::changeFontPalette()
 
 void Scene::changePortsComboBox()
 {
-	for (auto item : selectedItems()) {
+	for (auto &&item : selectedItems()) {
 		PointPort *point = dynamic_cast<PointPort *>(item);
 		if (point) {
 			emit existSelectedPortItems(point->getType());
@@ -632,49 +630,49 @@ void Scene::changePortsComboBox()
 
 void Scene::changeFontFamily(const QFont& font)
 {
-	for (auto item : selectedTextPictureItems())
+	for (auto &&item : selectedTextPictureItems())
 		item->setFontFamily(font);
 	update();
 }
 
 void Scene::changeFontPixelSize(int size)
 {
-	for (auto item : selectedTextPictureItems())
+	for (auto &&item : selectedTextPictureItems())
 		item->setFontPixelSize(size);
 	update();
 }
 
 void Scene::changeFontColor(const QString &text)
 {
-	for (auto item : selectedTextPictureItems())
+	for (auto &&item : selectedTextPictureItems())
 		item->setFontColor(text);
 	update();
 }
 
 void Scene::changeFontItalic(bool isChecked)
 {
-	for (auto item : selectedTextPictureItems())
+	for (auto &&item : selectedTextPictureItems())
 		item->setFontItalic(isChecked);
 	update();
 }
 
 void Scene::changeFontBold(bool isChecked)
 {
-	for (auto item : selectedTextPictureItems())
+	for (auto &&item : selectedTextPictureItems())
 		item->setFontBold(isChecked);
 	update();
 }
 
 void Scene::changeFontUnderline(bool isChecked)
 {
-	for (auto item : selectedTextPictureItems())
+	for (auto &&item : selectedTextPictureItems())
 		item->setFontUnderline(isChecked);
 	update();
 }
 
 void Scene::changeTextName(const QString &name)
 {
-	for (auto item : selectedTextPictureItems())
+	for (auto &&item : selectedTextPictureItems())
 		item->setTextName(name);
 	update();
 }

--- a/qrgui/mainWindow/shapeEdit/scene.cpp
+++ b/qrgui/mainWindow/shapeEdit/scene.cpp
@@ -495,12 +495,12 @@ void Scene::clearScene()
 	mZValue = 0;
 }
 
-QList<Item *> Scene::selectedSceneItems()
+QList<QSharedPointer<Item>> Scene::selectedSceneItems()
 {
-	QList<Item *> resList;
+	QList<QSharedPointer<Item>> resList;
 	mListSelectedItems = selectedItems();
 	for (QGraphicsItem *graphicsItem : mListSelectedItems) {
-		Item* item = dynamic_cast<Item*>(graphicsItem);
+		QSharedPointer<Item> item(dynamic_cast<Item*>(graphicsItem));
 		if (item != nullptr)
 			resList.push_back(item);
 	}
@@ -523,7 +523,7 @@ QList<TextPicture *> Scene::selectedTextPictureItems()
 void Scene::changePenStyle(const QString &text)
 {
 	mPenStyleItems = text;
-	for (Item *item : selectedSceneItems())
+	for (auto item : selectedSceneItems())
 		item->setPenStyle(text);
 	update();
 }
@@ -531,7 +531,7 @@ void Scene::changePenStyle(const QString &text)
 void Scene::changePenWidth(int width)
 {
 	mPenWidthItems = width;
-	for (Item *item : selectedSceneItems())
+	for (auto item : selectedSceneItems())
 		item->setPenWidth(width);
 	update();
 }
@@ -539,7 +539,7 @@ void Scene::changePenWidth(int width)
 void Scene::changePenColor(const QString &text)
 {
 	mPenColorItems = text;
-	for (Item *item : selectedSceneItems())
+	for (auto item : selectedSceneItems())
 		item->setPenColor(text);
 	update();
 }
@@ -547,7 +547,7 @@ void Scene::changePenColor(const QString &text)
 void Scene::changeBrushStyle(const QString &text)
 {
 	mBrushStyleItems = text;
-	for (Item *item : selectedSceneItems())
+	for (auto item : selectedSceneItems())
 		item->setBrushStyle(text);
 	update();
 }
@@ -555,7 +555,7 @@ void Scene::changeBrushStyle(const QString &text)
 void Scene::changeBrushColor(const QString &text)
 {
 	mBrushColorItems = text;
-	for (Item *item : selectedSceneItems())
+	for (auto item : selectedSceneItems())
 		item->setBrushColor(text);
 	update();
 }

--- a/qrgui/mainWindow/shapeEdit/scene.cpp
+++ b/qrgui/mainWindow/shapeEdit/scene.cpp
@@ -129,7 +129,7 @@ void Scene::setZValue(Item* item)
 void Scene::setZValueSelectedItems()
 {
 	mListSelectedItems = selectedItems();
-	for (QGraphicsItem *graphicsItem : mListSelectedItems) {
+	for (auto graphicsItem : mListSelectedItems) {
 		Item* item = dynamic_cast<Item*>(graphicsItem);
 		item->setZValue(mZValue);
 		mZValue++;
@@ -138,7 +138,7 @@ void Scene::setZValueSelectedItems()
 
 void Scene::setNullZValueItems()
 {
-	for (QGraphicsItem *graphicsItem : mListSelectedItems) {
+	for (auto graphicsItem : mListSelectedItems) {
 		Item* item = dynamic_cast<Item*>(graphicsItem);
 		item->setZValue(item->itemZValue());
 	}
@@ -480,7 +480,7 @@ void Scene::addImage(const QString &fileName)
 void Scene::deleteItem()
 {
 	QList<QGraphicsItem *> list = selectedItems();
-	for (QGraphicsItem *graphicsItem : list) {
+	for (auto graphicsItem : list) {
 		removeItem(graphicsItem);
 		delete graphicsItem;
 	}
@@ -498,7 +498,7 @@ QList<QSharedPointer<Item>> Scene::selectedSceneItems()
 {
 	QList<QSharedPointer<Item>> resList;
 	mListSelectedItems = selectedItems();
-	for (QGraphicsItem *graphicsItem : mListSelectedItems) {
+	for (auto graphicsItem : mListSelectedItems) {
 		QSharedPointer<Item> item(dynamic_cast<Item*>(graphicsItem));
 		if (item != nullptr)
 			resList.push_back(item);
@@ -563,7 +563,7 @@ void Scene::changePortsType(const QString &type)
 {
 	mPortType = type;
 
-	for (QGraphicsItem *item : selectedItems()) {
+	for (auto item : selectedItems()) {
 		PointPort *point = dynamic_cast<PointPort *>(item);
 		if (point) {
 			point->setType(type);
@@ -615,7 +615,7 @@ void Scene::changeFontPalette()
 
 void Scene::changePortsComboBox()
 {
-	for (QGraphicsItem *item : selectedItems()) {
+	for (auto item : selectedItems()) {
 		PointPort *point = dynamic_cast<PointPort *>(item);
 		if (point) {
 			emit existSelectedPortItems(point->getType());

--- a/qrgui/mainWindow/shapeEdit/scene.h
+++ b/qrgui/mainWindow/shapeEdit/scene.h
@@ -137,14 +137,12 @@ private:
 	CopyPasteType mCopyPaste;
 	QList<QSharedPointer<Item>> mListSelectedItemsForPaste;
 	QList<QGraphicsItem *> mListSelectedItems;
-	QList<TextPicture *> mListSelectedTextPictureItems;
-	TextPicture *mSelectedTextPicture;
-	QPair<bool, Item *> mNeedResize;
+	QList<QSharedPointer<TextPicture>> mListSelectedTextPictureItems;
 	QString mPortType;
 
 	void initListSelectedItemsForPaste();
 	QRectF selectedItemsBoundingRect() const;
-	QList<TextPicture *> selectedTextPictureItems();
+	QList<QSharedPointer<TextPicture>> selectedTextPictureItems();
 	QPointF setCXandCY(QGraphicsSceneMouseEvent *event);
 	void reshapeLine(QGraphicsSceneMouseEvent *event);
 	void reshapeLinePort(QGraphicsSceneMouseEvent *event);

--- a/qrgui/mainWindow/shapeEdit/scene.h
+++ b/qrgui/mainWindow/shapeEdit/scene.h
@@ -63,7 +63,7 @@ public:
 	void addStylus(bool checked);
 	void addNone(bool checked);
 
-	QList<Item *> selectedSceneItems();
+	QList<QSharedPointer<Item>> selectedSceneItems();
 
 signals:
 	void noSelectedItems();
@@ -135,7 +135,7 @@ private:
 	QString mFileName;
 	QPointF mC1;
 	CopyPasteType mCopyPaste;
-	QList<Item *> mListSelectedItemsForPaste;
+	QList<QSharedPointer<Item>> mListSelectedItemsForPaste;
 	QList<QGraphicsItem *> mListSelectedItems;
 	QList<TextPicture *> mListSelectedTextPictureItems;
 	TextPicture *mSelectedTextPicture;

--- a/qrgui/mainWindow/shapeEdit/shapeEdit.cpp
+++ b/qrgui/mainWindow/shapeEdit/shapeEdit.cpp
@@ -652,7 +652,7 @@ void ShapeEdit::addStylus(bool checked)
 
 void ShapeEdit::visibilityButtonClicked()
 {
-	QList<Item *> selectedItems = mScene->selectedSceneItems();
+	auto selectedItems = mScene->selectedSceneItems();
 	if (selectedItems.isEmpty()) {
 		return;
 	}

--- a/qrgui/mainWindow/shapeEdit/stylus.cpp
+++ b/qrgui/mainWindow/shapeEdit/stylus.cpp
@@ -25,33 +25,6 @@ Stylus::Stylus(qreal x1, qreal y1, Item* parent) : Item(parent), mStylusImpl()
 	mDomElementType = pictureType;
 }
 
-Stylus::Stylus(const Stylus &other)
-	:Item()
-{
-	mNeedScalingRect = other.mNeedScalingRect ;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = pictureType;
-	setX1(other.x1());
-	setX2(other.x2());
-	setY1(other.y1());
-	setY2(other.y2());
-	mTmpX1 = other.mTmpX1;
-	mTmpY1 = other.mTmpY1;
-	mListScalePoint = other.mListScalePoint;
-	for (AbstractItem *line : other.mAbstractListLine) {
-		Line *newLine = new Line(*dynamic_cast<Line *>(line));
-		mAbstractListLine.append(newLine);
-	}
-	setPos(other.x(), other.y());
-}
-
-Item* Stylus::clone()
-{
-	Stylus* item = new Stylus(*this);
-	return item;
-}
-
 void Stylus::addLine(qreal x2, qreal y2)
 {
 	setX2(x2);

--- a/qrgui/mainWindow/shapeEdit/stylus.h
+++ b/qrgui/mainWindow/shapeEdit/stylus.h
@@ -23,11 +23,10 @@
 
 class Stylus : public Item
 {
+	Q_DISABLE_COPY(Stylus)
 public:
 	QList<Line *> mListLine;
 	Stylus(qreal x1, qreal y1, Item* parent);
-	Stylus(const Stylus &other);
-	virtual Item* clone();
 	void addLine(qreal x2, qreal y2);
 	void addLineInList(Line *line);
 

--- a/qrgui/mainWindow/shapeEdit/text.cpp
+++ b/qrgui/mainWindow/shapeEdit/text.cpp
@@ -44,32 +44,6 @@ void Text::init(int x, int y, const QString &text)
 	mY1 = y;
 }
 
-Text::Text(const Text &other)
-	:Item()
-{
-	mIsDynamicText = other.mIsDynamicText;
-	mNeedScalingRect = other.mNeedScalingRect;
-	setPen(other.pen());
-	setBrush(other.brush());
-	mDomElementType = labelType;
-	mX1 = other.mX1;
-	mY1 = other.mY1;
-	mText.setPos(other.mText.x(), other.mText.y());
-	mText.setFlags(other.mText.flags());
-	mText.setTextInteractionFlags(Qt::TextEditorInteraction);
-	mText.setPlainText(other.mText.toPlainText());
-	mText.setParentItem(this);
-	mBoundingRect = other.mBoundingRect;
-	mListScalePoint = other.mListScalePoint;
-	setPos(other.x(), other.y());
-}
-
-Item* Text::clone()
-{
-	Text* item = new Text(*this);
-	return item;
-}
-
 void Text::drawItem(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
 {
 	Q_UNUSED(option);

--- a/qrgui/mainWindow/shapeEdit/text.h
+++ b/qrgui/mainWindow/shapeEdit/text.h
@@ -23,11 +23,10 @@
 
 class Text : public Item
 {
+	Q_DISABLE_COPY(Text)
 public:
 	Text(bool isDynamic = false);
 	Text(int x, int y, const QString &text = "text", bool isDynamic = false);
-	Text(const Text &other);
-	virtual Item* clone();
 	void init(int x, int y, const QString &text);
 	bool isDynamicText();
 	virtual void setIsDynamicText(bool isDynamic);

--- a/qrgui/mainWindow/shapeEdit/textPicture.cpp
+++ b/qrgui/mainWindow/shapeEdit/textPicture.cpp
@@ -33,20 +33,6 @@ TextPicture::TextPicture(int x, int y, const QString &text)
 	init(x, y, text);
 }
 
-TextPicture::TextPicture(const TextPicture &other)
-	: Text(other)
-{
-	mDomElementType = pictureType;
-	mText.setParentItem(other.parentItem());
-	mFont = other.mFont;
-}
-
-Item* TextPicture::clone()
-{
-	TextPicture* item = new TextPicture(*this);
-	return item;
-}
-
 void TextPicture::drawItem(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
 {
 	Q_UNUSED(option);

--- a/qrgui/mainWindow/shapeEdit/textPicture.h
+++ b/qrgui/mainWindow/shapeEdit/textPicture.h
@@ -18,11 +18,10 @@
 
 class TextPicture : public Text
 {
+	Q_DISABLE_COPY(TextPicture)
 public:
 	TextPicture();
 	TextPicture(int x, int y, const QString &text = "text");
-	TextPicture(const TextPicture &other);
-	virtual Item* clone();
 	void setTextName(const QString &name);
 	void setFontFamily(const QFont& font);
 	void setFontPixelSize(int size);

--- a/qrgui/mainWindow/shapeEdit/visibilityConditionsDialog.cpp
+++ b/qrgui/mainWindow/shapeEdit/visibilityConditionsDialog.cpp
@@ -18,7 +18,7 @@
 #include <QtWidgets/QPushButton>
 
 VisibilityConditionsDialog::VisibilityConditionsDialog(QMap<QString, PropertyInfo> const &properties
-		, QList<Item *> const &items, QWidget *parent)
+		, QList<QSharedPointer<Item>> const &items, QWidget *parent)
 	: QDialog(parent)
 	, ui(new Ui::VisibilityConditionsDialog)
 	, mProperties(properties), mItems(items)
@@ -64,7 +64,7 @@ void VisibilityConditionsDialog::changeOperators(Type type)
 
 void VisibilityConditionsDialog::okClicked()
 {
-	for (Item *item : mItems) {
+	for (auto item : mItems) {
 		item->setVisibilityCondition(ui->propertyComboBox->currentText()
 				, ui->operatorComboBox->currentText(), ui->valueWidget->value());
 	}
@@ -85,7 +85,7 @@ void VisibilityConditionsDialog::setWidgetValues()
 bool VisibilityConditionsDialog::areValuesEqual() const
 {
 	Item::VisibilityCondition value = mItems.first()->visibilityCondition();
-	for (Item *item : mItems) {
+	for (auto item : mItems) {
 		if (item->visibilityCondition() != value) {
 			return false;
 		}

--- a/qrgui/mainWindow/shapeEdit/visibilityConditionsDialog.h
+++ b/qrgui/mainWindow/shapeEdit/visibilityConditionsDialog.h
@@ -39,7 +39,7 @@ public:
 	};
 
 	explicit VisibilityConditionsDialog(QMap<QString, PropertyInfo> const &enumValues
-			, QList<Item *> const &items, QWidget *parent = nullptr);
+			, QList<QSharedPointer<Item>> const &items, QWidget *parent = nullptr);
 	~VisibilityConditionsDialog();
 
 private slots:
@@ -53,5 +53,5 @@ private:
 
 	Ui::VisibilityConditionsDialog *ui;
 	QMap<QString, PropertyInfo> mProperties;
-	QList<Item *> mItems;
+	QList<QSharedPointer<Item>> mItems;
 };

--- a/qrutils/graphicsUtils/abstractScene.cpp
+++ b/qrutils/graphicsUtils/abstractScene.cpp
@@ -190,6 +190,11 @@ bool AbstractScene::compareItems(AbstractItem* first, AbstractItem* second)
 	return first->zValue() < second->zValue();
 }
 
+bool AbstractScene::compareSharedPtrItems(QSharedPointer<AbstractItem> first, QSharedPointer<AbstractItem> second)
+{
+	return first->zValue() < second->zValue();
+}
+
 void AbstractScene::setEmptyPenBrushItems()
 {
 	mPenStyleItems = "Solid";

--- a/qrutils/graphicsUtils/abstractScene.cpp
+++ b/qrutils/graphicsUtils/abstractScene.cpp
@@ -190,7 +190,8 @@ bool AbstractScene::compareItems(AbstractItem* first, AbstractItem* second)
 	return first->zValue() < second->zValue();
 }
 
-bool AbstractScene::compareSharedPtrItems(QSharedPointer<AbstractItem> first, QSharedPointer<AbstractItem> second)
+bool AbstractScene::compareSharedPtrItems(const QSharedPointer<AbstractItem> &first
+										  , const QSharedPointer<AbstractItem> &second)
 {
 	return first->zValue() < second->zValue();
 }

--- a/qrutils/graphicsUtils/abstractScene.h
+++ b/qrutils/graphicsUtils/abstractScene.h
@@ -41,6 +41,8 @@ public:
 	virtual void forReleaseResize(QGraphicsSceneMouseEvent *event);
 
 	static bool compareItems(graphicsUtils::AbstractItem* first, graphicsUtils::AbstractItem* second);
+	static bool compareSharedPtrItems(QSharedPointer<graphicsUtils::AbstractItem> first
+							 , QSharedPointer<graphicsUtils::AbstractItem> second);
 	QString convertPenToString(const QPen &pen);
 	QString convertBrushToString(const QBrush &brush);
 	void setPenBrushItems(const QPen &pen, const QBrush &brush);

--- a/qrutils/graphicsUtils/abstractScene.h
+++ b/qrutils/graphicsUtils/abstractScene.h
@@ -41,8 +41,8 @@ public:
 	virtual void forReleaseResize(QGraphicsSceneMouseEvent *event);
 
 	static bool compareItems(graphicsUtils::AbstractItem* first, graphicsUtils::AbstractItem* second);
-	static bool compareSharedPtrItems(QSharedPointer<graphicsUtils::AbstractItem> first
-							 , QSharedPointer<graphicsUtils::AbstractItem> second);
+	static bool compareSharedPtrItems(const QSharedPointer<graphicsUtils::AbstractItem> &first
+							 , const QSharedPointer<graphicsUtils::AbstractItem> &second);
 	QString convertPenToString(const QPen &pen);
 	QString convertBrushToString(const QBrush &brush);
 	void setPenBrushItems(const QPen &pen, const QBrush &brush);


### PR DESCRIPTION
Using `Q_DISABLE_COPY`