### PR TITLE
Allow custom speed up for background mode [AUTOZIP]

### DIFF
--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -111,7 +111,7 @@ bool Runner::interpret(const QString &saveFile, bool background, int customSpeed
 
 		auto &t = twoDModelWindow->model().timeline();
 		t.setImmediateMode(background);
-		if (!background && customSpeedFactor >= model::Timeline::normalSpeedFactor) {
+		if (customSpeedFactor >= model::Timeline::normalSpeedFactor) {
 			t.setSpeedFactor(customSpeedFactor);
 		}
 	}


### PR DESCRIPTION
`-s <num>` now can be used together with `-b` to set custom speed up factor for background mode.
Part of #984 