### PR TITLE
Smooth rendering for .svg sensor images

### DIFF
--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/image.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/image.h
@@ -62,7 +62,7 @@ public:
 	void setPath(const QString &path);
 
 	/// Draws image with \a painter inside the \a rect considering \a zoom.
-	void draw(QPainter &painter, const QRect &rect, qreal zoom = 1.0);
+	void draw(QPainter &painter, const QRect &rect, qreal zoom = 1.0) const;
 
 	/// Returns imageId for this image.
 	QString imageId() const;

--- a/plugins/robots/common/twoDModel/src/engine/model/image.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/image.cpp
@@ -180,7 +180,7 @@ void Image::setPath(const QString &path)
 	}
 }
 
-void Image::draw(QPainter &painter, const QRect &rect, qreal zoom)
+void Image::draw(QPainter &painter, const QRect &rect, qreal zoom) const
 {
 	if (mExternal && !mPath.isEmpty()) {
 		utils::ImagesCache::instance().drawImageWithoutCachingSize(mPath, painter, rect, zoom);

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/sensorItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/sensorItem.cpp
@@ -43,7 +43,7 @@ SensorItem::SensorItem(model::SensorsConfiguration &configuration
 	, mImageRect(imageRect.isEmpty() ? this->imageRect() : imageRect)
 	, mBoundingRect(mImageRect.adjusted(-selectionDrift, -selectionDrift
 			, selectionDrift, selectionDrift))
-	, mImage(QImage(pathToImage.isEmpty() ? this->pathToImage() : pathToImage))
+	, mImage(pathToImage.isEmpty() ? this->pathToImage() : pathToImage, false)
 	, mPortItem(new PortItem(port))
 {
 	setFlags(ItemIsSelectable | ItemIsMovable | ItemSendsGeometryChanges);
@@ -67,7 +67,7 @@ void SensorItem::drawItem(QPainter *painter, const QStyleOptionGraphicsItem *sty
 	painter->setRenderHints(painter->renderHints()
 			| QPainter::SmoothPixmapTransform
 			| QPainter::HighQualityAntialiasing);
-	painter->drawImage(mImageRect, mImage);
+	mImage.draw(*painter, imageRect().toRect());
 	painter->restore();
 }
 

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/sensorItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/sensorItem.h
@@ -26,6 +26,7 @@
 
 #include "src/engine/items/solidItem.h"
 #include "twoDModel/engine/model/sensorsConfiguration.h"
+#include "twoDModel/engine/model/image.h"
 
 namespace twoDModel {
 namespace view {
@@ -93,7 +94,9 @@ protected:
 
 	const QRectF mImageRect;
 	const QRectF mBoundingRect;
-	const QImage mImage;
+	// Use utilitary class that can handle PNG & SVG properly.
+	// QImage renders SVG ugly, thus robot moves smothier now
+	const twoDModel::model::Image mImage;
 	PortItem *mPortItem;  // Has ownership.
 };
 


### PR DESCRIPTION
Change .svg image rendering. At least video camera sensor for TRIK looks nicer.