### PR TITLE
Fix typo in Linux installer

### DIFF
--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-linux-gnu.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-linux-gnu.sh
@@ -14,6 +14,6 @@ cp -pr $BIN_DIR/librobots-trik-kit-interpreter-common.so*                       
 rsync -a "$BIN_DIR"/libtrikPythonQt{,_QtAll}-Qt*-Python*.so*                                        "$PWD"/../data/lib/
 ldd $BIN_DIR/libtrikPythonQt_QtAll-Qt5*-Python3*.so.1.0  | grep python3 | cut -d ' ' -f 3 | head -n 1 | xargs cp -prvt $PWD/../data/lib/
 
-cp rsync -a "$BIN_DIR"/libtrik*.so*                                                         "$PWD"/../data/lib/
+rsync -a "$BIN_DIR"/libtrik*.so*                                                         "$PWD"/../data/lib/
 
 cp     $BIN_DIR/system.{py,js} $BIN_DIR/2D-model                       		 $PWD/../data/bin/


### PR DESCRIPTION
Fix typo in the installer scripts that doesn't allow to build installer properly