### PR TITLE
Hot fix for connect signal for property editor

### DIFF
--- a/qrgui/editor/propertyEditorView.cpp
+++ b/qrgui/editor/propertyEditorView.cpp
@@ -212,8 +212,10 @@ void PropertyEditorView::setRootIndex(const QModelIndex &index)
 
 	connect(mButtonManager.get(), &PushButtonPropertyManager::buttonClicked
 			, this, &PropertyEditorView::buttonClicked, Qt::UniqueConnection);
-	connect(mVariantManager.get(), &QtVariantPropertyManager::valueChanged
-			, this, &PropertyEditorView::buttonClicked, Qt::UniqueConnection);
+	// For some reason c++11-style connections do not work here!
+	// TODO: fix with new SIGNAL/SLOT signature
+	connect(mVariantManager.get(), SIGNAL(valueChanged(QtProperty*, QVariant))
+				, this, SLOT(editorValueChanged(QtProperty *, QVariant)), Qt::UniqueConnection);
 	mPropertyEditor->setPropertiesWithoutValueMarked(true);
 	mPropertyEditor->setRootIsDecorated(false);
 }

--- a/qrtranslations/fr/qrgui_editor_fr.ts
+++ b/qrtranslations/fr/qrgui_editor_fr.ts
@@ -247,7 +247,7 @@
 <context>
     <name>qReal::gui::editor::PropertyEditorView</name>
     <message>
-        <location filename="../../qrgui/editor/propertyEditorView.cpp" line="+303"/>
+        <location filename="../../qrgui/editor/propertyEditorView.cpp" line="+305"/>
         <source>Specify directory:</source>
         <translation type="unfinished">Choisissez le répertoire :</translation>
     </message>

--- a/qrtranslations/ru/qrgui_editor_ru.ts
+++ b/qrtranslations/ru/qrgui_editor_ru.ts
@@ -251,7 +251,7 @@
 <context>
     <name>qReal::gui::editor::PropertyEditorView</name>
     <message>
-        <location filename="../../qrgui/editor/propertyEditorView.cpp" line="+303"/>
+        <location filename="../../qrgui/editor/propertyEditorView.cpp" line="+305"/>
         <source>Specify directory:</source>
         <translation>Выберите каталог:</translation>
     </message>


### PR DESCRIPTION
Fixed:
> Не получается изменять поля блока в окошке справа. Точнее, вводятся значения и тд, но у блока они не меняются.