### PR TITLE
Add gyro interface for TS the same as on the controller

### DIFF
--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/robotModel.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/robotModel.h
@@ -143,7 +143,9 @@ public:
 	/// Returns accelerometer sensor data.
 	Q_INVOKABLE QVector<int> accelerometerReading() const;
 
-	/// Returns gyroscope sensor data.
+	/// Returns gyroscope sensor data:
+	/// data[0] -- angular velocity over Z axis (millidegrees per second)
+	/// data[1] -- tilt around Z axis (millidegrees)
 	Q_INVOKABLE QVector<int> gyroscopeReading() const;
 
 	Q_INVOKABLE QVector<int> gyroscopeCalibrate();
@@ -214,7 +216,7 @@ private:
 	QPointF mPos;
 	qreal mAngle;
 	qreal mGyroAngle;
-	qreal mDeltaRadiansOfAngle;
+	qreal mDeltaDegreesOfAngle;
 	int mBeepTime;
 	bool mIsOnTheGround;
 	QColor mMarker;

--- a/plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/robotModel.cpp
@@ -47,7 +47,7 @@ RobotModel::RobotModel(robotModel::TwoDRobotModel &robotModel
 	, mPos(QPointF(0, 0))
 	, mAngle(0)
 	, mGyroAngle(0)
-	, mDeltaRadiansOfAngle(0)
+	, mDeltaDegreesOfAngle(0)
 	, mBeepTime(0)
 	, mIsOnTheGround(true)
 	, mMarker(Qt::transparent)
@@ -73,7 +73,7 @@ void RobotModel::reinit()
 	}
 
 	mBeepTime = 0;
-	mDeltaRadiansOfAngle = 0;
+	mDeltaDegreesOfAngle = 0;
 	mAcceleration = QPointF(0, 0);
 }
 
@@ -208,7 +208,8 @@ void RobotModel::countSpeedAndAcceleration()
 		mAngleStampPrevious = mAngle;
 		mIsFirstAngleStamp = false;
 	} else {
-		mDeltaRadiansOfAngle = qDegreesToRadians(mAngle - mAngleStampPrevious);
+		// Convert to millidegress per second
+		mDeltaDegreesOfAngle = (mAngle - mAngleStampPrevious) * 1000 / Timeline::timeInterval;
 		mAngleStampPrevious = mAngle;
 	}
 
@@ -304,7 +305,7 @@ QVector<int> RobotModel::accelerometerReading() const
 
 QVector<int> RobotModel::gyroscopeReading() const
 {
-	return {static_cast<int>(mDeltaRadiansOfAngle * gyroscopeConstant)
+	return {static_cast<int>(mDeltaDegreesOfAngle * 1000)
 		, static_cast<int>((mAngle - mGyroAngle) * 1000)};
 }
 

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDGyroscopeSensor.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDGyroscopeSensor.cpp
@@ -14,6 +14,7 @@
 
 #include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDGyroscopeSensor.h"
 #include "twoDModel/engine/twoDModelEngineInterface.h"
+#include "trikKernel/timeVal.h"
 
 constexpr auto FULL_ANGLE = 360000;
 
@@ -28,10 +29,11 @@ GyroscopeSensor::GyroscopeSensor(const kitBase::robotModel::DeviceInfo &info
 
 QVector<int> GyroscopeSensor::convert(const QVector<int> &data) const
 {
-	int t = mEngine.modelTimeline().timestamp();
-	int tmp = (data[1] + FULL_ANGLE/2) % FULL_ANGLE;
+	const auto &timestamp = mEngine.modelTimeline().timestamp();
+	int t = trikKernel::TimeVal(static_cast<int>(timestamp / 1000), (timestamp % 1000) * 1000).packedUInt32();
+	int tmp = (data[1] + FULL_ANGLE / 2) % FULL_ANGLE;
 	if (tmp < 0) {
 		tmp += FULL_ANGLE;
 	}
-	return {0, 0, data[0], t, 0, 0, tmp - FULL_ANGLE/2};
+	return {0, 0, data[0], t, 0, 0, tmp - FULL_ANGLE / 2};
 }


### PR DESCRIPTION
The unified interface of `read`:
0-2 -- angular velocities (millideg per second)
3 -- timestamp in packed format (to get the difference between timestamps function `timeInterval(t1, t2)` should be used)
4-6 -- tilt (millideg)

Example of code:

```
brick.gyroscope().calibrate(1000)
script.wait(1100)

g_read = brick.gyroscope().read
v_prev = g_read()

brick.motor(M3).setPower(-10)
brick.motor(M4).setPower(10)

tilt = 0
while (tilt < 90) {
  script.wait(100)
  v = g_read()
  dt = timeInterval(v[3], v_prev[3]) / 1000000
  tilt += v[2] * dt / 1000
  v_prev = v
}

brick.motor(M3).setPower(0)
brick.motor(M4).setPower(0)
```