### PR TITLE
Fix crash with balls/skittles memory access [AUTOZIP]

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp
@@ -59,7 +59,7 @@ Box2DPhysicsEngine::Box2DPhysicsEngine (const WorldModel &worldModel
 	connect(&worldModel, &model::WorldModel::ballAdded,
 			this, [this](const QSharedPointer<QGraphicsItem> &i) {itemAdded(i.data());});
 	connect(&worldModel, &model::WorldModel::itemRemoved,
-			this, [this](const QSharedPointer<QGraphicsItem> &i) {itemAdded(i.data());});
+			this, [this](const QSharedPointer<QGraphicsItem> &i) {itemRemoved(i.data());});
 }
 
 Box2DPhysicsEngine::~Box2DPhysicsEngine(){


### PR DESCRIPTION
Fix WorldModel::clear behavior

Это и есть креш после загрузки мира.