### PR TITLE
Fix problem with trik sensors code generation

### DIFF
--- a/plugins/robots/generators/trik/trikGeneratorBase/src/trikGeneratorFactory.cpp
+++ b/plugins/robots/generators/trik/trikGeneratorBase/src/trikGeneratorFactory.cpp
@@ -75,6 +75,11 @@ TrikGeneratorFactory::~TrikGeneratorFactory()
 {
 }
 
+void TrikGeneratorFactory::initDeviceVariables()
+{
+	mDeviceVariables.reset(new trik::parts::TrikDeviceVariables());
+}
+
 AbstractSimpleGenerator *TrikGeneratorFactory::simpleGenerator(const qReal::Id &id
 		, GeneratorCustomizer &customizer)
 {

--- a/plugins/robots/generators/trik/trikGeneratorBase/src/trikGeneratorFactory.h
+++ b/plugins/robots/generators/trik/trikGeneratorBase/src/trikGeneratorFactory.h
@@ -34,6 +34,7 @@ public:
 			, generatorBase::GeneratorCustomizer &customizer) override;
 
 	QStringList pathsToTemplates() const override;
+	void initDeviceVariables() override;
 
 private:
 	const QStringList mPathsToTemplates;


### PR DESCRIPTION
Fixed
> не генерируются сенсорные переменные gamepadPad1Pressed, gamepadButton1 и т.д.