### PR TITLE
Python timers fix [AUTOZIP]

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/model/modelTimer.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/modelTimer.cpp
@@ -24,7 +24,7 @@ ModelTimer::ModelTimer(const Timeline *timeline)
 	, mInterval(0)
 	, mRepeatable(false)
 {
-	connect(timeline, SIGNAL(tick()), this, SLOT(onTick()));
+	connect(timeline, &Timeline::tick, this, &ModelTimer::onTick);
 }
 
 ModelTimer::~ModelTimer()
@@ -81,13 +81,13 @@ void ModelTimer::setInterval(int ms)
 
 void ModelTimer::setRepeatable(bool repeatable)
 {
-	mRepeatable = repeatable;
+	setSingleShot(!repeatable);
 }
 
 void ModelTimer::onTimeout()
 {
 	AbstractTimer::onTimeout();
-	if (mRepeatable) {
+	if (!isSingleShot()) {
 		start();
 	}
 }

--- a/plugins/robots/common/twoDModel/src/engine/model/timeline.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/timeline.cpp
@@ -123,11 +123,7 @@ quint64 Timeline::timestamp() const
 
 utils::AbstractTimer *Timeline::produceTimer()
 {
-	auto connection = (QThread::currentThread() != this->thread()) ?
-				Qt::BlockingQueuedConnection : Qt::DirectConnection;
-	utils::AbstractTimer *t = nullptr;
-	QMetaObject::invokeMethod(this, [this, &t](){ t = produceTimerImpl();}, connection);
-	return t;
+	return produceTimerImpl();
 }
 
 void Timeline::setImmediateMode(bool immediateMode)

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikTextualInterpreter.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikTextualInterpreter.h
@@ -20,6 +20,7 @@
 #include "trikKitInterpreterCommon/trikbrick.h"
 #include "trikScriptRunner/trikScriptRunner.h"
 #include <trikNetwork/mailboxInterface.h>
+#include "twoDExecutionControl.h"
 
 #include "declSpec.h"
 
@@ -66,6 +67,7 @@ private:
 
 	TrikBrick mBrick;
 	trikNetwork::MailboxInterface *mMailbox {};
+	TwoDExecutionControl *mExecutionControl;
 	trikScriptRunner::TrikScriptRunner mScriptRunner;
 	qReal::ErrorReporterInterface *mErrorReporter {};
 };

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikTextualInterpreter.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikTextualInterpreter.h
@@ -67,7 +67,7 @@ private:
 
 	TrikBrick mBrick;
 	trikNetwork::MailboxInterface *mMailbox {};
-	TwoDExecutionControl *mExecutionControl;
+	TwoDExecutionControl *mExecutionControl {};
 	trikScriptRunner::TrikScriptRunner mScriptRunner;
 	qReal::ErrorReporterInterface *mErrorReporter {};
 };

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikbrick.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikbrick.h
@@ -65,6 +65,8 @@ public:
 
 	void reinitImitationCamera();
 
+	QDir getCurrentDir() const;
+
 public slots:
 	void configure(const QString &, const QString &) override {}
 	void playSound(const QString &) override {}
@@ -105,6 +107,7 @@ public slots:
 	QStringList readAll(const QString &path);
 	/// In trikRuntime returns QTimer, but we need timer with emulated 2D time. Hopefully this is enough
 	utils::AbstractTimer *timer(int milliseconds);
+
 	void processSensors(bool isRunning = true);
 
 signals:

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikbrick.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikbrick.h
@@ -101,12 +101,7 @@ public slots:
 	void stopEventDevice(const QString &) override {}
 
 	/// some ScriptExecution control replacements. @todo: factor out in the separate class
-	int random(int from, int to);
-	void wait(int milliseconds);
-	quint64 time() const;
 	QStringList readAll(const QString &path);
-	/// In trikRuntime returns QTimer, but we need timer with emulated 2D time. Hopefully this is enough
-	utils::AbstractTimer *timer(int milliseconds);
 
 	void processSensors(bool isRunning = true);
 
@@ -114,7 +109,6 @@ signals:
 	void error(const QString &msg);
 	void warning(const QString &msg);
 	void log(const QString &msg);
-	void stopWaiting();
 
 private:
 	void printToShell(const QString &msg);

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
@@ -25,7 +25,7 @@
 class TwoDExecutionControl : public trikScriptRunner::TrikScriptControlInterface
 {
 public:
-	TwoDExecutionControl(trikControl::BrickInterface &brick,
+	TwoDExecutionControl(trik::TrikBrick &brick,
 			const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model);
 
 	~TwoDExecutionControl() override;

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "trikScriptRunner/trikScriptExecutionControl.h"
+#include "trikScriptRunner/trikScriptControlInterface.h"
 
 #include "trikControl/brickInterface.h"
 #include "trikbrick.h"
@@ -22,7 +22,7 @@
 #include <utils/abstractTimer.h>
 #include <trikKitInterpreterCommon/robotModel/twoD/trikTwoDRobotModel.h>
 
-class TwoDExecutionControl : public trikScriptRunner::TrikScriptExecutionControl
+class TwoDExecutionControl : public trikScriptRunner::TrikScriptControlInterface
 {
 public:
 	TwoDExecutionControl(
@@ -44,8 +44,18 @@ public:
 
 	void processSensors(bool isRunning = true);
 
+	bool isInEventDrivenMode() const override;
+	QVector<int32_t> getPhoto() override;
+	void system(const QString &command, bool synchronously) override;
+	void writeToFile(const QString &file, const QString &text) override;
+	void writeData(const QString &file, const QVector<uint8_t> &bytes) override;
+	QStringList readAll(const QString &file) const override;
+	void removeFile(const QString &file) override;
+
 public slots:
 	void reset() override;
+	void run() override;
+	void quit() override;
 
 private:
 	trik::TrikBrick mBrick;

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
@@ -64,7 +64,7 @@ public slots:
 
 private:
 	bool mInEventDrivenMode {false};
-	QSharedPointer<trik::TrikBrick> mBrick;
+	trik::TrikBrick &mBrick;
 	QList<QSharedPointer<utils::AbstractTimer>> mTimers;
 	QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> mTwoDRobotModel;
 };

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
@@ -1,0 +1,54 @@
+/* Copyright 2020 Andrei Khodko and CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include "trikScriptRunner/trikScriptExecutionControl.h"
+
+#include "trikControl/brickInterface.h"
+#include "trikbrick.h"
+
+#include <utils/abstractTimer.h>
+#include <trikKitInterpreterCommon/robotModel/twoD/trikTwoDRobotModel.h>
+
+class TwoDExecutionControl : public trikScriptRunner::TrikScriptExecutionControl
+{
+public:
+	TwoDExecutionControl(
+			trikControl::BrickInterface &brick
+			, const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model);
+
+	~TwoDExecutionControl() override;
+
+	int random(int from, int to) const override;
+
+	void wait(const int &milliseconds) override;
+
+	qint64 time() const override;
+
+	//QStringList readAll(const QString &file) const override;
+
+	/// In trikRuntime returns QTimer, but we need timer with emulated 2D time. Hopefully this is enough
+	utils::AbstractTimer *timer(int milliseconds) override;
+
+	void processSensors(bool isRunning = true);
+
+public slots:
+	void reset() override;
+
+private:
+	trik::TrikBrick mBrick;
+	QList<QSharedPointer<utils::AbstractTimer>> mTimers;
+	QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> mTwoDRobotModel;
+};

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
@@ -65,6 +65,6 @@ public slots:
 private:
 	bool mInEventDrivenMode {false};
 	trik::TrikBrick &mBrick;
-	QList<QSharedPointer<utils::AbstractTimer>> mTimers;
+	QList<utils::AbstractTimer*> mTimers; // Owns, but in safe manner: timers can be from different threads
 	QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> mTwoDRobotModel;
 };

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/twoDExecutionControl.h
@@ -25,9 +25,8 @@
 class TwoDExecutionControl : public trikScriptRunner::TrikScriptControlInterface
 {
 public:
-	TwoDExecutionControl(
-			trikControl::BrickInterface &brick
-			, const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model);
+	TwoDExecutionControl(trikControl::BrickInterface &brick,
+			const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model);
 
 	~TwoDExecutionControl() override;
 
@@ -45,11 +44,17 @@ public:
 	void processSensors(bool isRunning = true);
 
 	bool isInEventDrivenMode() const override;
+
 	QVector<int32_t> getPhoto() override;
+
 	void system(const QString &command, bool synchronously) override;
+
 	void writeToFile(const QString &file, const QString &text) override;
+
 	void writeData(const QString &file, const QVector<uint8_t> &bytes) override;
+
 	QStringList readAll(const QString &file) const override;
+
 	void removeFile(const QString &file) override;
 
 public slots:
@@ -58,7 +63,8 @@ public slots:
 	void quit() override;
 
 private:
-	trik::TrikBrick mBrick;
+	bool mInEventDrivenMode {false};
+	QSharedPointer<trik::TrikBrick> mBrick;
 	QList<QSharedPointer<utils::AbstractTimer>> mTimers;
 	QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> mTwoDRobotModel;
 };

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
@@ -66,8 +66,7 @@ trik::TrikTextualInterpreter::TrikTextualInterpreter(
 		, bool enablePython)
 	: mBrick(model)
 	, mMailbox(trikNetwork::MailboxFactory::create(8889))
-	, mExecutionControl(new TwoDExecutionControl(mBrick, model))
-	, mScriptRunner(mBrick, mMailbox, mExecutionControl)
+	, mScriptRunner(mBrick, mMailbox, new TwoDExecutionControl(mBrick, model))
 {
 	connect(&mBrick, &TrikBrick::error, this, &TrikTextualInterpreter::reportError);
 	connect(&mBrick, &TrikBrick::warning, this, &TrikTextualInterpreter::reportWarning);

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
@@ -31,8 +31,7 @@
 
 Q_DECLARE_METATYPE(utils::AbstractTimer*)
 
-const QString jsOverrides = "script.random = brick.random;script.wait = brick.wait;script.time = brick.time;"
-	"script.readAll = brick.readAll;script.timer = brick.timer;Date.now = brick.time;"
+const QString jsOverrides = "Date.now = script.time;"
 	"arrayPPinternal = function(arg) {"
 		"var res = '[';"
 		"for(var i = 0; i < arg.length; i++) {"
@@ -60,18 +59,15 @@ const QString jsOverrides = "script.random = brick.random;script.wait = brick.wa
 
 const QString pyOverrides ="\n__import__('sys').stdout = type('trik_studio_stdout', (object,),"
 				"{ 'write': brick.log, 'flush': lambda: None })\n"
-				"script.random = brick.random;"
-				"script.wait = brick.wait;"
-				"script.time = brick.time;"
-				"script.readAll = brick.readAll;"
-				"script.timer = brick.timer;"
 				"script.system = lambda command, synchronously=True: print('system is disabled')\n";
 
 trik::TrikTextualInterpreter::TrikTextualInterpreter(
 	const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model
 		, bool enablePython)
-	: mBrick(model), mMailbox(trikNetwork::MailboxFactory::create(8889))
-	, mScriptRunner(mBrick, mMailbox)
+	: mBrick(model)
+	, mMailbox(trikNetwork::MailboxFactory::create(8889))
+	, mExecutionControl(new TwoDExecutionControl(mBrick, model))
+	, mScriptRunner(mBrick, mMailbox, mExecutionControl)
 {
 	connect(&mBrick, &TrikBrick::error, this, &TrikTextualInterpreter::reportError);
 	connect(&mBrick, &TrikBrick::warning, this, &TrikTextualInterpreter::reportWarning);
@@ -151,8 +147,6 @@ void trik::TrikTextualInterpreter::abort()
 	Q_ASSERT(mScriptRunner.thread() == thread());
 	// just a wild test
 	QMetaObject::invokeMethod(&mScriptRunner, &trikScriptRunner::TrikScriptRunner::abort, Qt::QueuedConnection);
-	//mScriptRunner.abort();
-	mBrick.stopWaiting();
 	mRunning = false; // reset brick?
 	mBrick.processSensors(false);
 }

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp
@@ -26,7 +26,6 @@
 #include <kitBase/robotModel/robotParts/gyroscopeSensor.h>
 #include <kitBase/robotModel/robotParts/encoderSensor.h>
 #include <kitBase/robotModel/robotParts/random.h>
-#include <kitBase/robotModel/robotParts/random.h>
 #include <twoDModel/robotModel/parts/marker.h>
 #include <twoDModel/engine/model/timeline.h>
 #include <qrkernel/settingsManager.h>
@@ -61,7 +60,6 @@ TrikBrick::~TrikBrick()
 
 void TrikBrick::reset()
 {
-	emit stopWaiting();
 	mKeys.reset();///@todo: reset motos/device maps?
 	//mDisplay.reset(); /// - is actually needed? Crashes app at exit
 	for (const auto &m : mMotors) {
@@ -86,6 +84,11 @@ void TrikBrick::printToShell(const QString &msg)
 	}
 
 	sh->print(msg);
+}
+
+QDir TrikBrick::getCurrentDir() const
+{
+	return mCurrentDir;
 }
 
 void TrikBrick::init()

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
@@ -25,7 +25,7 @@
 TwoDExecutionControl::TwoDExecutionControl(
 		trik::TrikBrick &brick
 		, const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model)
-	: mBrick(&brick)
+	: mBrick(brick)
 	, mTwoDRobotModel(model)
 {
 	qRegisterMetaType<QVector<int32_t>>("QVector<int32_t>");
@@ -62,13 +62,6 @@ void TwoDExecutionControl::wait(const int &milliseconds)
 	connect(t, &utils::AbstractTimer::timeout, &loop, &QEventLoop::quit);
 	connect(&loop, &QObject::destroyed, t, &QObject::deleteLater);
 
-	// This one is from brick.reset(), that is called for toolbar Stop button
-	//connect(this, &TwoDExecutionControl::stopWaiting, &loop, &QEventLoop::quit);
-
-	// Old comment:
-	// timers that are produced by produceTimer() doesn't use stop singal
-	// be careful, one who use just utils::AbstractTimer can stuck
-	// New one: do we really need to connect to both signals?
 	connect(timeline, &twoDModel::model::Timeline::beforeStop, &loop, &QEventLoop::quit);
 	connect(timeline, &twoDModel::model::Timeline::stopped, &loop, &QEventLoop::quit);
 
@@ -113,7 +106,7 @@ bool TwoDExecutionControl::isInEventDrivenMode() const
 
 QVector<int32_t> TwoDExecutionControl::getPhoto()
 {
-	return trikControl::Utilities::rescalePhoto(mBrick->getStillImage());
+	return trikControl::Utilities::rescalePhoto(mBrick.getStillImage());
 }
 
 void TwoDExecutionControl::system(const QString &command, bool synchronously)
@@ -124,26 +117,26 @@ void TwoDExecutionControl::system(const QString &command, bool synchronously)
 
 void TwoDExecutionControl::writeToFile(const QString &file, const QString &text)
 {
-	QFile out(mBrick->getCurrentDir().absoluteFilePath(file));
+	QFile out(mBrick.getCurrentDir().absoluteFilePath(file));
 	out.open(QIODevice::WriteOnly | QIODevice::Append);
 	out.write(text.toUtf8());
 }
 
 void TwoDExecutionControl::writeData(const QString &file, const QVector<uint8_t> &bytes)
 {
-	QFile out(mBrick->getCurrentDir().absoluteFilePath(file));
+	QFile out(mBrick.getCurrentDir().absoluteFilePath(file));
 	out.open(QIODevice::WriteOnly | QIODevice::Append);
 	out.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
 }
 
 QStringList TwoDExecutionControl::readAll(const QString &file) const
 {
-	return mBrick->readAll(file);
+	return mBrick.readAll(file);
 }
 
 void TwoDExecutionControl::removeFile(const QString &file)
 {
-	QFile out(mBrick->getCurrentDir().absoluteFilePath(file));
+	QFile out(mBrick.getCurrentDir().absoluteFilePath(file));
 	out.remove();
 }
 

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
@@ -1,0 +1,107 @@
+/* Copyright 2020 Andrei Khodko and CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "trikKitInterpreterCommon/twoDExecutionControl.h"
+
+#include <QApplication>
+#include <QEventLoop>
+
+#include <kitBase/robotModel/robotParts/random.h>
+#include <kitBase/robotModel/robotModelUtils.h>
+#include <twoDModel/engine/model/timeline.h>
+
+TwoDExecutionControl::TwoDExecutionControl(
+		trikControl::BrickInterface &brick
+		, const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model)
+	: trikScriptRunner::TrikScriptExecutionControl(brick)
+	, mBrick(model)
+	, mTwoDRobotModel(model)
+{
+	//connect(this, &TwoDExecutionControl::readAll, &mBrick, &trik::TrikBrick::readAll);
+}
+
+TwoDExecutionControl::~TwoDExecutionControl()
+{
+}
+
+int TwoDExecutionControl::random(int from, int to) const
+{
+	using namespace kitBase::robotModel;
+	auto r = RobotModelUtils::findDevice<robotParts::Random>(*mTwoDRobotModel, "RandomPort");
+	// maybe store it later, like the others
+	if (!r) {
+		//emit error(tr("No cofigured random device"));
+		return -1;
+	}
+
+	return r->random(from, to);
+}
+
+void TwoDExecutionControl::wait(const int &milliseconds)
+{
+	auto timeline = dynamic_cast<twoDModel::model::Timeline *> (&mTwoDRobotModel->timeline());
+
+	if (!timeline->isStarted()) {
+		return;
+	}
+
+	QEventLoop loop;
+
+	auto t = timeline->produceTimer();
+	connect(t, &utils::AbstractTimer::timeout, &loop, &QEventLoop::quit);
+	connect(&loop, &QObject::destroyed, t, &QObject::deleteLater);
+
+	// This one is from brick.reset(), that is called for toolbar Stop button
+	//connect(this, &TwoDExecutionControl::stopWaiting, &loop, &QEventLoop::quit);
+
+	// Old comment:
+	// timers that are produced by produceTimer() doesn't use stop singal
+	// be careful, one who use just utils::AbstractTimer can stuck
+	// New one: do we really need to connect to both signals?
+	connect(timeline, &twoDModel::model::Timeline::beforeStop, &loop, &QEventLoop::quit);
+	connect(timeline, &twoDModel::model::Timeline::stopped, &loop, &QEventLoop::quit);
+
+	if (milliseconds == 0) {
+		QApplication::processEvents();
+	} else if (timeline->isStarted()) {
+		t->start(milliseconds);
+		loop.exec();
+	}
+}
+
+qint64 TwoDExecutionControl::time() const
+{
+	return mTwoDRobotModel->timeline().timestamp();
+}
+
+void TwoDExecutionControl::reset()
+{
+	emit stopWaiting();
+	qDebug() << "reset" << __PRETTY_FUNCTION__;
+	for (auto &&timer : mTimers) {
+		QMetaObject::invokeMethod(timer.data(), &utils::AbstractTimer::stop, Qt::QueuedConnection);
+		timer->deleteLater();
+	}
+
+	mTimers.clear();
+}
+
+utils::AbstractTimer *TwoDExecutionControl::timer(int milliseconds)
+{
+	auto result = QSharedPointer<utils::AbstractTimer>(mTwoDRobotModel->timeline().produceTimer());
+	mTimers.append(result);
+	result->setRepeatable(true);
+	result->start(milliseconds);
+	return result.get();
+}

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
@@ -82,7 +82,7 @@ void TwoDExecutionControl::reset()
 {
 	emit stopWaiting();
 	for (auto &&timer : mTimers) {
-		QMetaObject::invokeMethod(timer, &utils::AbstractTimer::stop, Qt::BlockingQueuedConnection);
+		QMetaObject::invokeMethod(timer, &utils::AbstractTimer::stop, Qt::QueuedConnection);
 		timer->deleteLater();
 	}
 	mTimers.clear();

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
@@ -24,7 +24,7 @@
 TwoDExecutionControl::TwoDExecutionControl(
 		trikControl::BrickInterface &brick
 		, const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model)
-	: trikScriptRunner::TrikScriptExecutionControl(brick)
+	: trikScriptRunner::TrikScriptControlInterface(brick)
 	, mBrick(model)
 	, mTwoDRobotModel(model)
 {
@@ -104,4 +104,45 @@ utils::AbstractTimer *TwoDExecutionControl::timer(int milliseconds)
 	result->setRepeatable(true);
 	result->start(milliseconds);
 	return result.get();
+}
+
+
+bool TwoDExecutionControl::isInEventDrivenMode() const
+{
+}
+
+QVector<int32_t> TwoDExecutionControl::getPhoto()
+{
+}
+
+QTimer *TwoDExecutionControl::timer(int milliseconds)
+{
+}
+
+void TwoDExecutionControl::system(const QString &command, bool synchronously)
+{
+}
+
+void TwoDExecutionControl::writeToFile(const QString &file, const QString &text)
+{
+}
+
+void TwoDExecutionControl::writeData(const QString &file, const QVector<uint8_t> &bytes)
+{
+}
+
+QStringList TwoDExecutionControl::readAll(const QString &file) const
+{
+}
+
+void TwoDExecutionControl::removeFile(const QString &file)
+{
+}
+
+void TwoDExecutionControl::run()
+{
+}
+
+void TwoDExecutionControl::quit()
+{
 }

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
@@ -82,20 +82,19 @@ void TwoDExecutionControl::reset()
 {
 	emit stopWaiting();
 	for (auto &&timer : mTimers) {
-		QMetaObject::invokeMethod(timer.data(), &utils::AbstractTimer::stop, Qt::QueuedConnection);
+		QMetaObject::invokeMethod(timer, &utils::AbstractTimer::stop, Qt::BlockingQueuedConnection);
 		timer->deleteLater();
 	}
-
 	mTimers.clear();
 }
 
 utils::AbstractTimer *TwoDExecutionControl::timer(int milliseconds)
 {
-	auto result = QSharedPointer<utils::AbstractTimer>(mTwoDRobotModel->timeline().produceTimer());
+	auto result = mTwoDRobotModel->timeline().produceTimer();
 	mTimers.append(result);
 	result->setRepeatable(true);
 	result->start(milliseconds);
-	return result.get();
+	return result;
 }
 
 

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
@@ -23,7 +23,7 @@
 #include <trikControl/utilities.h>
 
 TwoDExecutionControl::TwoDExecutionControl(
-		trikControl::BrickInterface &brick
+		trik::TrikBrick &brick
 		, const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model)
 	: mBrick(&brick)
 	, mTwoDRobotModel(model)

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp
@@ -41,7 +41,7 @@ int TwoDExecutionControl::random(int from, int to) const
 	auto r = RobotModelUtils::findDevice<robotParts::Random>(*mTwoDRobotModel, "RandomPort");
 	// maybe store it later, like the others
 	if (!r) {
-		//emit error(tr("No cofigured random device"));
+		mBrick.error(tr("No cofigured random device"));
 		return -1;
 	}
 

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/trikKitInterpreterCommon.pri
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/trikKitInterpreterCommon.pri
@@ -89,7 +89,8 @@ HEADERS += \
 	$$PWD/include/trikKitInterpreterCommon/trikEmulation/trikaccelerometeradapter.h \
 	$$PWD/include/trikKitInterpreterCommon/trikEmulation/trikGyroscopeAdapter.h \
 	$$PWD/include/trikKitInterpreterCommon/trikEmulation/trikProxyMarker.h \
-	$$PWD/include/trikKitInterpreterCommon/trikTextualInterpreter.h
+	$$PWD/include/trikKitInterpreterCommon/trikTextualInterpreter.h \
+	$$PWD/include/trikKitInterpreterCommon/twoDExecutionControl.h \
 
 SOURCES += \
 	$$PWD/src/robotModel/real/parts/display.cpp \
@@ -141,7 +142,8 @@ SOURCES += \
 	$$PWD/src/trikEmulation/trikaccelerometeradapter.cpp \
 	$$PWD/src/trikEmulation/trikGyroscopeAdapter.cpp \
 	$$PWD/src/trikEmulation/trikProxyMarker.cpp \
-	$$PWD/src/trikTextualInterpreter.cpp
+	$$PWD/src/trikTextualInterpreter.cpp \
+	$$PWD/src/twoDExecutionControl.cpp \
 
 FORMS += \
 	$$PWD/src/trikAdditionalPreferences.ui \

--- a/plugins/robots/utils/include/utils/abstractTimer.h
+++ b/plugins/robots/utils/include/utils/abstractTimer.h
@@ -16,11 +16,13 @@
 
 #include <QtCore/QObject>
 
+#include <QTimer>
+
 #include "utilsDeclSpec.h"
 
 namespace utils {
 
-class ROBOTS_UTILS_EXPORT AbstractTimer : public QObject
+class ROBOTS_UTILS_EXPORT AbstractTimer : public QTimer
 {
 	Q_OBJECT
 
@@ -34,15 +36,16 @@ public:
 
 	/// If \a repeatable then the timer will set itself up again when timeout reached.
 	/// By default timers are not repeatable.
+	/// TODO: Remove such methods, because it is QTimer herit now.
 	virtual void setRepeatable(bool repeatable) = 0;
 
 public slots:
 	virtual void start() = 0;
 	virtual void start(int ms) = 0;
-	virtual void stop() = 0;
+	Q_INVOKABLE virtual void stop() = 0;
 
 signals:
-	void timeout();
+	void timeout() ;
 
 protected slots:
 	virtual void onTimeout();

--- a/plugins/robots/utils/src/realTimer.cpp
+++ b/plugins/robots/utils/src/realTimer.cpp
@@ -19,7 +19,7 @@ using namespace utils;
 RealTimer::RealTimer()
 {
 	setRepeatable(false);
-	connect(&mTimer, SIGNAL(timeout()), this, SLOT(onTimeout()));
+	connect(&mTimer, &QTimer::timeout, this, &RealTimer::timeout);
 }
 
 bool RealTimer::isTicking() const

--- a/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+206"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+200"/>
         <source>Bogus input values</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,19 +98,19 @@
 <context>
     <name>trik::TrikBrick</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+84"/>
-        <location line="+70"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+82"/>
+        <location line="+75"/>
         <source>2d model shell part was not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-30"/>
-        <location line="+311"/>
+        <location line="+262"/>
         <source>Trying to read from file %1 failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-256"/>
+        <location line="-207"/>
         <source>No configured motor on port: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,11 +174,6 @@
         <source>Cannot get a photo from folders/project (possibly because of wrong path/empty project)</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location line="+13"/>
-        <source>No cofigured random device</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>trik::TrikKitInterpreterPlugin</name>
@@ -227,7 +222,7 @@
 <context>
     <name>trik::TrikTextualInterpreter</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="-98"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="-96"/>
         <location line="+15"/>
         <source>Unsupported script file type</source>
         <translation type="unfinished"></translation>

--- a/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+200"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+199"/>
         <source>Bogus input values</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
@@ -83,6 +83,14 @@
     </message>
 </context>
 <context>
+    <name>TwoDExecutionControl</name>
+    <message>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp" line="+44"/>
+        <source>No cofigured random device</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>trik::TrikAdditionalPreferences</name>
     <message>
         <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="+32"/>

--- a/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+200"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+199"/>
         <source>Bogus input values</source>
         <translation>Неподходящие значения аргументов</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+206"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+200"/>
         <source>Bogus input values</source>
         <translation>Неподходящие значения аргументов</translation>
     </message>
@@ -158,19 +158,19 @@
 <context>
     <name>trik::TrikBrick</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+84"/>
-        <location line="+70"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+82"/>
+        <location line="+75"/>
         <source>2d model shell part was not found</source>
         <translation>Консоль 2d модели не найдена</translation>
     </message>
     <message>
         <location line="-30"/>
-        <location line="+311"/>
+        <location line="+262"/>
         <source>Trying to read from file %1 failed</source>
         <translation>Не удалось открыть файл %1</translation>
     </message>
     <message>
-        <location line="-256"/>
+        <location line="-207"/>
         <source>No configured motor on port: %1</source>
         <translation>Не найден сконфигурированный  мотор на порту: %1</translation>
     </message>
@@ -235,9 +235,8 @@
         <translation>Получить снимок из папки/проекта не удалось (возможно из-за неправильного пути/отстуствия снимков в проекте)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>No cofigured random device</source>
-        <translation>Генератор случайных чисел не сконфигурирован</translation>
+        <translation type="vanished">Генератор случайных чисел не сконфигурирован</translation>
     </message>
 </context>
 <context>
@@ -284,7 +283,7 @@
 <context>
     <name>trik::TrikTextualInterpreter</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="-98"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="-96"/>
         <location line="+15"/>
         <source>Unsupported script file type</source>
         <translation>Неверный формат файла</translation>

--- a/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
@@ -139,6 +139,14 @@
     </message>
 </context>
 <context>
+    <name>TwoDExecutionControl</name>
+    <message>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp" line="+44"/>
+        <source>No cofigured random device</source>
+        <translation>Генератор случайных чисел не сконфигурирован</translation>
+    </message>
+</context>
+<context>
     <name>trik::TrikAdditionalPreferences</name>
     <message>
         <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="+32"/>


### PR DESCRIPTION
- [x]  Waits for runtime [patch](https://github.com/trikset/trikRuntime/pull/595).
- [x]  Needs to be fixed `QMetaObject::invokeMethod: Dead lock detected`

Use herit of trikScriptExecutionControl.