### PR TITLE
Fix disappearing run/stop button

### DIFF
--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/view/twoDModelWidget.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/view/twoDModelWidget.h
@@ -259,8 +259,6 @@ private:
 
 	bool mSensorsReadOnly {};
 	bool mRobotPositionReadOnly {};
-
-	bool mCompactMode {};
 };
 
 }

--- a/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
@@ -780,9 +780,7 @@ void TwoDModelWidget::setInteractivityFlags(ReadOnlyFlags flags)
 
 void TwoDModelWidget::setCompactMode(bool enabled)
 {
-	mCompactMode = enabled;
-	setRunStopButtonsVisibility();
-	mActions->setSaveLoadActionsShortcutsEnabled(!mCompactMode);
+	mActions->setSaveLoadActionsShortcutsEnabled(!enabled);
 }
 
 QString TwoDModelWidget::editorId() const
@@ -854,8 +852,8 @@ void TwoDModelWidget::setDetailsVisibility(bool visible)
 
 void TwoDModelWidget::setRunStopButtonsVisibility()
 {
-	mUi->runButton->setVisible(!mCompactMode && !mModel.timeline().isStarted());
-	mUi->stopButton->setVisible(!mCompactMode && mModel.timeline().isStarted());
+	mUi->runButton->setVisible(!mModel.timeline().isStarted());
+	mUi->stopButton->setVisible(mModel.timeline().isStarted());
 }
 
 QGraphicsView::DragMode TwoDModelWidget::cursorTypeToDragType(CursorType type) const

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -739,7 +739,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+339"/>
+        <location line="+337"/>
         <source>Hide details</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -1090,7 +1090,7 @@
         <translation type="vanished">Попытка загрузить слишком большое изображение может заморозить выполнение на некоторое время. Продолжить?</translation>
     </message>
     <message>
-        <location line="+339"/>
+        <location line="+337"/>
         <source>Hide details</source>
         <translation>Скрыть детали</translation>
     </message>


### PR DESCRIPTION
Fixed
> В режиме плавающих окон, если сначала в отдельное окно открыть 2д-сцену, а потом закрыть ее (чтобы она вернулась обратно) - пропадает кнопка запуска