### PR TITLE
Call script.wait instead of brick in jsOverrides

### DIFF
--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
@@ -52,7 +52,7 @@ const QString jsOverrides = "Date.now = script.time;"
 		"} else {res += arguments[i].toString();}"
 		"};"
 		"brick.log(res+'\\n');"
-		"brick.wait(0);"
+		"script.wait(0);"
 		"return res;"
 	"};"
 	"script.system = function() {print('system is disabled in the interpreter');};";


### PR DESCRIPTION
Because the script now has its own 2D model heir, which we use instead of custom brick methods.