### PR TITLE
Set motor power not only for engine but also for logical robot model

### DIFF
--- a/plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/twoD/parts/twoDMotor.cpp
+++ b/plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/twoD/parts/twoDMotor.cpp
@@ -26,6 +26,7 @@ TwoDMotor::TwoDMotor(kitBase::robotModel::DeviceInfo const &info
 
 void TwoDMotor::on(int speed)
 {
+	Ev3Motor::on(speed);
 	mEngine.setNewMotor(speed, 0, port(), true);
 }
 


### PR DESCRIPTION
The problem was: when checking power on EV3 motors from checker -- return value is always 0
That is because we don't set speed value for the logical model of the robot, only for engine