### PR TITLE
Feature for checker language: support indexing of list

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp
@@ -323,6 +323,13 @@ QVariant ValuesFactory::propertyOf(const QVariantList &list, const QString &prop
 		return list.isEmpty();
 	}
 
+	// Accessing list element by index
+	bool isInt;
+	auto index = property.toInt(&isInt);
+	if (isInt && index >= 0 && index < list.size()) {
+		return list.at(index);
+	}
+
 	ok && (*ok = false);
 	return QVariant();
 }


### PR DESCRIPTION
Support list indexing for checker lists: now `robot1.display.labels.10.text` will return 10-th element of labels list 