### PR TITLE
Walls and images alignment is disabled with Ctrl [AUTOZIP]

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/items/imageItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/items/imageItem.cpp
@@ -263,7 +263,7 @@ void ImageItem::resizeItem(QGraphicsSceneMouseEvent *event)
 {
 	mEstimatedPos += event->scenePos() - event->lastScenePos();
 	const auto showGrid = SettingsManager::value("2dShowGrid").toBool();
-	if (!showGrid || event->modifiers() != Qt::ShiftModifier) {
+	if (!showGrid || event->modifiers() == Qt::ControlModifier) {
 		if (dragState() != None) {
 			calcResizeItem(event);
 		} else {

--- a/plugins/robots/common/twoDModel/src/engine/items/wallItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/items/wallItem.h
@@ -53,8 +53,6 @@ public:
 	void resizeItem(QGraphicsSceneMouseEvent *event) override;
 	void reshapeRectWithShift() override;
 
-	QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
-
 	QDomElement serialize(QDomElement &element) const override;
 	void deserialize(const QDomElement &element) override;
 
@@ -78,18 +76,9 @@ protected:
 private:
 	void recalculateBorders();
 
-	void setBeginCoordinatesWithGrid(int indexGrid);
-	void setEndCoordinatesWithGrid(int indexGrid);
-	void countCellNumbCoordinates(int indexGrid);
-
 	graphicsUtils::LineImpl mLineImpl;
 
 	const QImage mImage;
-
-	int mCellNumbX1 = 0;
-	int mCellNumbY1 = 0;
-	int mCellNumbX2 = 0;
-	int mCellNumbY2 = 0;
 
 	QPainterPath mPath;
 	int mWallWidth {10};

--- a/qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp
+++ b/qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp
@@ -50,17 +50,6 @@ DynamicPropertiesDialog::DynamicPropertiesDialog(const qReal::Id &id
 	mUi->labels->setColumnCount(4);
 	mUi->labels->setHorizontalHeaderLabels({tr("Name"), tr("Type"), tr("Value"), ""});
 	mUi->labels->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-	connect(mUi->labels, &QTableWidget::cellChanged, this, [&](int row, int col){
-		if (col != 0) {
-			return;
-		}
-
-		QString text = mUi->labels->item(row, col)->text();
-		if (text.size() > 0 && text.at(0).isUpper()) {
-			text[0] = text[0].toLower();
-			mUi->labels->item(row, col)->setText(text);
-		}
-	});
 
 	if (hideLabels) {
 		mUi->labels->hide();
@@ -368,9 +357,8 @@ QString DynamicPropertiesDialog::tryToSave() const
 			return tr("Name is not filled in row %1").arg(i + 1);
 		}
 
-		// Return false if "Name" starts with digit
-		if (!mUi->labels->item(i, 0) || not mUi->labels->item(i, 0)->text().at(0).isLower()) {
-			return tr("Name should start with a lowercase letter(row %1)").arg(i + 1);
+		if (!mUi->labels->item(i, 0)->text().at(0).isLetter()) {
+			return tr("Name should start with a letter(row %1)").arg(i + 1);
 		}
 
 		const QString type = qobject_cast<QComboBox*>(mUi->labels->cellWidget(i, 1))->currentText();

--- a/qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui
+++ b/qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui
@@ -87,7 +87,7 @@
       </size>
      </property>
      <property name="text">
-      <string>Add Argumet</string>
+      <string>Add Argument</string>
      </property>
     </widget>
    </item>

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -353,7 +353,7 @@
 <context>
     <name>twoDModel::items::WallItem</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+64"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+59"/>
         <source>Wall (W)</source>
         <translation>Mur (W)</translation>
     </message>

--- a/qrtranslations/fr/qrgui_dialogs_fr.ts
+++ b/qrtranslations/fr/qrgui_dialogs_fr.ts
@@ -66,7 +66,7 @@
     </message>
     <message>
         <location line="+32"/>
-        <source>Add Argumet</source>
+        <source>Add Argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -590,7 +590,7 @@
         <translation type="unfinished">Valeur</translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+104"/>
         <location line="+15"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
@@ -606,8 +606,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Name should start with a lowercase letter(row %1)</source>
+        <location line="+4"/>
+        <source>Name should start with a letter(row %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -626,8 +626,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+278"/>
+        <location line="-269"/>
+        <location line="+277"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -629,7 +629,7 @@
 <context>
     <name>twoDModel::items::WallItem</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+64"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+59"/>
         <source>Wall (W)</source>
         <translation>Стена (W)</translation>
     </message>

--- a/qrtranslations/ru/qrgui_dialogs_ru.ts
+++ b/qrtranslations/ru/qrgui_dialogs_ru.ts
@@ -75,7 +75,7 @@
     <message>
         <location line="+32"/>
         <source>Add Argument</source>
-        <translation type="unfinished">обавить аргумент</translation>
+        <translation>Добавить аргумент</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -616,7 +616,7 @@
     <message>
         <location line="+4"/>
         <source>Name should start with a letter(row %1)</source>
-        <translation type="unfinished">Имя аргумента должно начинаться с буквы (строка %1)</translation>
+        <translation>Имя аргумента должно начинаться с буквы (строка %1)</translation>
     </message>
     <message>
         <location line="+11"/>

--- a/qrtranslations/ru/qrgui_dialogs_ru.ts
+++ b/qrtranslations/ru/qrgui_dialogs_ru.ts
@@ -74,8 +74,8 @@
     </message>
     <message>
         <location line="+32"/>
-        <source>Add Argumet</source>
-        <translation>Добавить аргумент</translation>
+        <source>Add Argument</source>
+        <translation type="unfinished">обавить аргумент</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -598,7 +598,7 @@
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+104"/>
         <location line="+15"/>
         <source>Error</source>
         <translation>Ошибка</translation>
@@ -614,9 +614,9 @@
         <translation>Имя параметра %1 не заполнено</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Name should start with a lowercase letter(row %1)</source>
-        <translation>Имя аргумента должно начинаться с маленькой буквы (строка %1)</translation>
+        <location line="+4"/>
+        <source>Name should start with a letter(row %1)</source>
+        <translation type="unfinished">Имя аргумента должно начинаться с буквы (строка %1)</translation>
     </message>
     <message>
         <location line="+11"/>
@@ -634,8 +634,8 @@
         <translation>Одинаковые имена</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+278"/>
+        <location line="-269"/>
+        <location line="+277"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>

--- a/qrutils/graphicsUtils/abstractScene.cpp
+++ b/qrutils/graphicsUtils/abstractScene.cpp
@@ -87,6 +87,7 @@ void AbstractScene::reshapeItem(QGraphicsSceneMouseEvent *event)
 	if (!mGraphicsItem) return;
 	auto oldPos = mGraphicsItem->pos();
 	reshapeItem(event, mGraphicsItem);
+	if (selectedItems().size() < 2) return;
 	auto delta = mGraphicsItem->pos() - oldPos;
 	if (mGraphicsItem->isSelected()) {
 		mGraphicsItem->setPos(oldPos);


### PR DESCRIPTION
Аргументы в подпрограммах теперь адекватно реагируют на большую букву в начале имени
Стены и картинки теперь можно не привязывать к сетке при перетаскивании с помощью зажатия Ctrl