### PR TITLE
Fix bug that elapsed time in constraints is not reset to zero

### DIFF
--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/model.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/model.h
@@ -121,6 +121,7 @@ private:
 	qReal::ErrorReporterInterface *mErrorReporter;  // Doesn`t take ownership.
 	physics::PhysicsEngineBase *mRealisticPhysicsEngine;  // Takes ownership.
 	physics::PhysicsEngineBase *mSimplePhysicsEngine;  // Takes ownership.
+	quint64 mStartTimestamp {0};
 };
 
 }

--- a/plugins/robots/common/twoDModel/src/engine/model/model.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/model.cpp
@@ -52,10 +52,11 @@ void Model::init(qReal::ErrorReporterInterface &errorReporter
 {
 	mErrorReporter = &errorReporter;
 	mWorldModel.init(errorReporter);
+	connect(&timeline(), &Timeline::started, this, [&]() { mStartTimestamp = timeline().timestamp(); });
 	mChecker.reset(new constraints::ConstraintsChecker(errorReporter, *this));
 	connect(mChecker.data(), &constraints::ConstraintsChecker::success, this, [&]() {
 		errorReporter.addInformation(tr("The task was accomplished in %1 sec!")
-									.arg(QString::number(timeline().timestamp() / 1000.0)));
+									.arg(QString::number((timeline().timestamp() - mStartTimestamp) / 1000.0)));
 		// Stopping cannot be performed immediately because we still have constraints to check in event loop
 		// and they need scene to be alive (in checker stopping interpretation means deleting all).
 		QTimer::singleShot(0, &interpreterControl,

--- a/plugins/robots/common/twoDModel/src/engine/model/timeline.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/timeline.cpp
@@ -44,8 +44,6 @@ void Timeline::start()
 	if (!mIsStarted) {
 		mIsStarted = true;
 		emit started();
-		emit tick(); /// hack so that constraints init-on would start immediatly
-		/// ideally they should be triggered on started()
 		gotoNextFrame();
 	}
 }

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -361,7 +361,7 @@
 <context>
     <name>twoDModel::model::Model</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="+57"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="+58"/>
         <source>The task was accomplished in %1 sec!</source>
         <translation>La tâche a été accomplie en %1 secondes!</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -637,7 +637,7 @@
 <context>
     <name>twoDModel::model::Model</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="+57"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="+58"/>
         <source>The task was accomplished in %1 sec!</source>
         <translation>Задание выполнено за %1 сек!</translation>
     </message>


### PR DESCRIPTION
* Strange extra tick is 4 years old and connections to this signal look safe and doesn't require it to be emitted in `start`
* This extra tick affects on timelineBox counter: timelineBox is incremented one more extra time in comparison to the internal Timeline counter  