### PR TITLE
Fix macOS subprograms crash

### DIFF
--- a/qrgui/mainWindow/palette/paletteTreeWidget.cpp
+++ b/qrgui/mainWindow/palette/paletteTreeWidget.cpp
@@ -41,6 +41,8 @@ void PaletteTreeWidget::addGroups(QList<QPair<QString, QList<PaletteElement>>> &
 		, const QString &diagramFriendlyName
 		, bool sort)
 {
+	qDeleteAll(mPaletteItems);
+	qDeleteAll(mPaletteElements);
 	mPaletteItems.clear();
 	mPaletteElements.clear();
 	mElementsSet.clear();

--- a/qrtranslations/fr/qrgui_mainWindow_fr.ts
+++ b/qrtranslations/fr/qrgui_mainWindow_fr.ts
@@ -1121,7 +1121,7 @@ WARNING: The settings will be restored after application restart</source>
         <translation type="obsolete">Ajouter un élément</translation>
     </message>
     <message>
-        <location filename="../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="+143"/>
+        <location filename="../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="+145"/>
         <source>Add Entity</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/qrgui_mainWindow_ru.ts
+++ b/qrtranslations/ru/qrgui_mainWindow_ru.ts
@@ -1250,7 +1250,7 @@ WARNING: The settings will be restored after application restart</source>
         <translation type="obsolete">Добавить элемент</translation>
     </message>
     <message>
-        <location filename="../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="+143"/>
+        <location filename="../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="+145"/>
         <source>Add Entity</source>
         <translation>Добавить сущность</translation>
     </message>


### PR DESCRIPTION
Fixes #1708 

Add resource clean up to PaletteTreeWidget in addGroups()
Fixes macOS Catalina crash.

