### PR TITLE
Try to determine behavior when search libpython

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      
+ - package-ecosystem: "pip"
+    directory: "/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-linux-gnu.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-linux-gnu.sh
@@ -23,11 +23,12 @@ rsync -a "$BIN_DIR"/{system.js,TRIK.py,2D-model,checkapp}            			"$PWD/..
 [ -r venv/bin/activate ] || "python3.${TRIK_PYTHON3_VERSION_MINOR}" -m venv venv
 . venv/bin/activate
 python3 -m pip install -U pip
-python3 -m pip install pyinstaller numpy
+python3 -m pip install -r requirements.txt
 
 #PyInstaller provides all required modules
 #So we need to handle this garbage of files later (below) with proper rsync
-pyinstaller --clean --noconfirm --log-level DEBUG --debug noarchive --onedir --name trik \
+#Determine python behavior when searching pythonlib
+PYTHONHASHSEED=1 pyinstaller --clean --noconfirm --log-level DEBUG --debug noarchive --onedir --name trik \
 	--hidden-import=math \
 	--hidden-import=random \
 	--hidden-import=sys \

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-mac.sh
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/prebuild-mac.sh
@@ -25,11 +25,12 @@ copy_qt_lib QtSerialPort
 [ -r venv/bin/activate ] || python3."${TRIK_PYTHON3_VERSION_MINOR}" -m venv venv
 . venv/bin/activate
 python3 -m pip install -U pip
-python3 -m pip install pyinstaller numpy
+python3 -m pip install -r requirements.txt
 
 #PyInstaller provides all required modules
 #So we need to handle this garbage of files later (below) with proper rsync
-pyinstaller --clean --noconfirm --log-level DEBUG --debug noarchive --onedir --name trik \
+#Determine python behavior when searching pythonlib
+PYTHONHASHSEED=1 pyinstaller --clean --noconfirm --log-level DEBUG --debug noarchive --onedir --name trik \
 	--hidden-import=math \
 	--hidden-import=random \
 	--hidden-import=sys \

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/requirements.txt
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/requirements.txt
@@ -1,0 +1,2 @@
+pyinstaller==6.9.0
+numpy==2.1.0

--- a/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/requirements.txt
+++ b/installer/packages/trik-studio/ru.qreal.root.trik.core/meta/requirements.txt
@@ -1,2 +1,2 @@
 pyinstaller==6.9.0
-numpy==2.1.0
+numpy==2.0.1


### PR DESCRIPTION
1.  `PyInstaller` is [looking for](https://github.com/trikset/trik-studio/actions/runs/10388290904/job/28765300051#step:11:1677) the `libpython3.10.so` shared library instead of `libpython3.10.so.1.0`, which has [caused issue](https://github.com/trikset/trik-studio/actions/runs/10388290904/job/28765300051#step:11:3241) when creating the symbolic link `libpython3.10.so` -> `libpython3.10.so.1.0`.