### PR TITLE
Add --dynamicbase linker flag for Win32

### DIFF
--- a/global.pri
+++ b/global.pri
@@ -105,6 +105,8 @@ equals(TEMPLATE, lib) {
 	}
 }
 
+win32: QMAKE_LFLAGS *= -Wl,--dynamicbase
+
 !nosanitizers:!clang:gcc:*-g++*:gcc4{
 	warning("Disabled sanitizers, failed to detect compiler version or too old compiler: $$QMAKE_CXX")
 	CONFIG += nosanitizers


### PR DESCRIPTION
Supposed to be an analog of the /DYNAMICBASE in MSVC, thus should help to work correctly with ASLR turned on