### PR TITLE
Force Win32 executables and DLLs to build with highentropy-va and nxcompat

### DIFF
--- a/global.pri
+++ b/global.pri
@@ -105,6 +105,8 @@ equals(TEMPLATE, lib) {
 	}
 }
 
+win32: QMAKE_LFLAGS *= -Wl,--dynamicbase
+
 !nosanitizers:!clang:gcc:*-g++*:gcc4{
 	warning("Disabled sanitizers, failed to detect compiler version or too old compiler: $$QMAKE_CXX")
 	CONFIG += nosanitizers

--- a/global.pri
+++ b/global.pri
@@ -105,7 +105,7 @@ equals(TEMPLATE, lib) {
 	}
 }
 
-win32: QMAKE_LFLAGS *= -Wl,--dynamicbase
+win32: QMAKE_LFLAGS *= -Wl,--dynamicbase,--high-entropy-va,--nxcompat
 
 !nosanitizers:!clang:gcc:*-g++*:gcc4{
 	warning("Disabled sanitizers, failed to detect compiler version or too old compiler: $$QMAKE_CXX")


### PR DESCRIPTION
Force Win32 executables and DLLs to build with highentropy-va and nxcompat