### PR TITLE
Add support for Network blocks in the visual language

### DIFF
--- a/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h
+++ b/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h
@@ -35,7 +35,6 @@ public:
 
 	/// Deinitializing a network communicator
 	virtual void release() = 0;
-
 };
 }
 }

--- a/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h
+++ b/plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h
@@ -1,0 +1,42 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include "device.h"
+#include "kitBase/kitBaseDeclSpec.h"
+
+namespace kitBase {
+namespace robotModel {
+namespace robotParts {
+
+/// Base class for robot network communication.
+class ROBOTS_KIT_BASE_EXPORT Communicator : public Device
+{
+	Q_OBJECT
+	Q_CLASSINFO("name", "communicator")
+	Q_CLASSINFO("friendlyName", tr("Communicator"))
+	Q_CLASSINFO("direction", "output")
+
+public:
+	/// Constructor, takes device type info and port on which this device is configured.
+	Communicator(const DeviceInfo &info, const PortInfo &port);
+
+	/// Deinitializing a network communicator
+	virtual void release() = 0;
+
+};
+}
+}
+}

--- a/plugins/robots/common/kitBase/kitBase.pri
+++ b/plugins/robots/common/kitBase/kitBase.pri
@@ -70,6 +70,7 @@ HEADERS += \
 	$$PWD/include/kitBase/robotModel/robotParts/colorSensorAmbient.h \
 	$$PWD/include/kitBase/robotModel/robotParts/colorSensorReflected.h \
 	$$PWD/include/kitBase/robotModel/robotParts/speaker.h \
+	$$PWD/include/kitBase/robotModel/robotParts/communicator.h \
 	$$PWD/include/kitBase/robotModel/robotParts/motor.h \
 	$$PWD/include/kitBase/robotModel/robotParts/display.h \
 	$$PWD/include/kitBase/robotModel/robotParts/button.h \
@@ -126,6 +127,7 @@ SOURCES += \
 	$$PWD/src/robotModel/portInfo.cpp \
 	$$PWD/src/robotModel/deviceInfo.cpp \
 	$$PWD/src/robotModel/robotParts/speaker.cpp \
+	$$PWD/src/robotModel/robotParts/communicator.cpp \
 	$$PWD/src/robotModel/robotParts/motor.cpp \
 	$$PWD/src/robotModel/robotParts/display.cpp \
 	$$PWD/src/robotModel/robotParts/button.cpp \

--- a/plugins/robots/common/kitBase/src/robotModel/commonRobotModel.cpp
+++ b/plugins/robots/common/kitBase/src/robotModel/commonRobotModel.cpp
@@ -21,6 +21,7 @@
 
 #include "kitBase/robotModel/robotParts/motor.h"
 #include "kitBase/robotModel/robotParts/random.h"
+#include "kitBase/robotModel/robotParts/communicator.h"
 
 const int updateInterval = 200;
 
@@ -72,9 +73,13 @@ void CommonRobotModel::connectToRobot()
 void CommonRobotModel::stopRobot()
 {
 	for (robotParts::Device * const device : mConfiguration.devices()) {
-		robotParts::Motor * const motor = dynamic_cast<robotParts::Motor *>(device);
+		auto* const motor = qobject_cast<robotParts::Motor *>(device);
 		if (motor) {
 			motor->off();
+		}
+		auto* const communicator = qobject_cast<robotParts::Communicator *>(device);
+		if (communicator) {
+			communicator->release();
 		}
 	}
 	/// @todo: add known deinitialization methods here (for example sensors termination after extending their inteface)

--- a/plugins/robots/common/kitBase/src/robotModel/robotParts/communicator.cpp
+++ b/plugins/robots/common/kitBase/src/robotModel/robotParts/communicator.cpp
@@ -1,0 +1,22 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "kitBase/robotModel/robotParts/communicator.h"
+
+using namespace kitBase::robotModel;
+using namespace robotParts;
+
+Communicator::Communicator(const DeviceInfo &info, const PortInfo &port)
+	: Device(info, port)
+{}

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikNetworkCommunicator.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikNetworkCommunicator.h
@@ -22,7 +22,7 @@ namespace parts {
 /// Class for TRIK robot network communication.
 class TrikNetworkCommunicator : public kitBase::robotModel::robotParts::Communicator
 {
-       Q_OBJECT
+	Q_OBJECT
 
 public:
 	TrikNetworkCommunicator(const kitBase::robotModel::DeviceInfo &info

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikNetworkCommunicator.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikNetworkCommunicator.h
@@ -43,7 +43,6 @@ public:
 
 	/// Clean the incoming message queue
 	virtual void clearQueue() = 0;
-
 };
 
 }

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikNetworkCommunicator.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikNetworkCommunicator.h
@@ -1,0 +1,51 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+#include <kitBase/robotModel/robotParts/communicator.h>
+
+namespace trik {
+namespace robotModel {
+namespace parts {
+
+/// Class for TRIK robot network communication.
+class TrikNetworkCommunicator : public kitBase::robotModel::robotParts::Communicator
+{
+       Q_OBJECT
+
+public:
+	TrikNetworkCommunicator(const kitBase::robotModel::DeviceInfo &info
+				, const kitBase::robotModel::PortInfo &port);
+
+
+	/// Send a message to a robot
+	virtual void send(const QString& message, int hullNumber) = 0;
+
+	/// Receive message from robot
+	virtual QString receive(bool wait) = 0;
+
+	/// Join the network with the specified hull number
+	virtual void joinNetwork(const QString &ip, int port, int hullNumber) = 0;
+
+	/// Send an interrupt to stop waiting for a message
+	virtual void stopWaiting() = 0;
+
+	/// Clean the incoming message queue
+	virtual void clearQueue() = 0;
+
+};
+
+}
+}
+}

--- a/plugins/robots/common/trikKit/include/trikKit/robotModel/trikRobotModelBase.h
+++ b/plugins/robots/common/trikKit/include/trikKit/robotModel/trikRobotModelBase.h
@@ -75,6 +75,7 @@ protected:
 
 	virtual kitBase::robotModel::PortInfo video2Port() const;
 	virtual kitBase::robotModel::PortInfo lidarPort() const;
+	virtual kitBase::robotModel::DeviceInfo networkInfo() const;
 };
 
 }

--- a/plugins/robots/common/trikKit/src/blocks/details/joinNetworkBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/joinNetworkBlock.cpp
@@ -1,0 +1,32 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+
+#include "joinNetworkBlock.h"
+
+using namespace trik;
+using namespace blocks::details;
+
+JoinNetworkBlock::JoinNetworkBlock(kitBase::robotModel::RobotModelInterface &robotModel):
+	kitBase::blocksBase::common::DeviceBlock<robotModel::parts::TrikNetworkCommunicator>(robotModel)
+{}
+
+void JoinNetworkBlock::doJob(robotModel::parts::TrikNetworkCommunicator &network)
+{
+	auto address = stringProperty("Address");
+	auto port = intProperty("IPPort");
+	auto hullNumber = intProperty("HullNumber");
+	network.joinNetwork(address, port, hullNumber);
+	emit done(mNextBlockId);
+}

--- a/plugins/robots/common/trikKit/src/blocks/details/joinNetworkBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/joinNetworkBlock.h
@@ -1,0 +1,36 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include <kitBase/blocksBase/common/deviceBlock.h>
+#include "trikKit/robotModel/parts/trikNetworkCommunicator.h"
+
+namespace trik {
+namespace blocks {
+namespace details {
+
+class JoinNetworkBlock: public kitBase::blocksBase::common::DeviceBlock<robotModel::parts::TrikNetworkCommunicator>
+{
+	Q_OBJECT
+public:
+	JoinNetworkBlock(kitBase::robotModel::RobotModelInterface &robotModel);
+
+private:
+	void doJob(robotModel::parts::TrikNetworkCommunicator &network) override;
+};
+
+}
+}
+}

--- a/plugins/robots/common/trikKit/src/blocks/details/sendMessageBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/sendMessageBlock.cpp
@@ -1,0 +1,30 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "sendMessageBlock.h"
+
+using namespace trik;
+using namespace blocks::details;
+
+SendMessageBlock::SendMessageBlock(kitBase::robotModel::RobotModelInterface &robotModel):
+	kitBase::blocksBase::common::DeviceBlock<robotModel::parts::TrikNetworkCommunicator>(robotModel)
+{}
+
+void SendMessageBlock::doJob(robotModel::parts::TrikNetworkCommunicator &network)
+{
+	auto message = stringProperty("Message");
+	auto hullNumber = intProperty("HullNumber");
+	network.send(message, hullNumber);
+	emit done(mNextBlockId);
+}

--- a/plugins/robots/common/trikKit/src/blocks/details/sendMessageBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/sendMessageBlock.h
@@ -1,0 +1,36 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include <kitBase/blocksBase/common/deviceBlock.h>
+#include "trikKit/robotModel/parts/trikNetworkCommunicator.h"
+
+namespace trik {
+namespace blocks {
+namespace details {
+
+class SendMessageBlock: public kitBase::blocksBase::common::DeviceBlock<robotModel::parts::TrikNetworkCommunicator>
+{
+	Q_OBJECT
+public:
+	SendMessageBlock(kitBase::robotModel::RobotModelInterface &robotModel);
+
+private:
+	void doJob(robotModel::parts::TrikNetworkCommunicator &network) override;
+};
+
+}
+}
+}

--- a/plugins/robots/common/trikKit/src/blocks/details/trikPrintTextBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/trikPrintTextBlock.cpp
@@ -30,20 +30,11 @@ void TrikPrintTextBlock::doJob(kitBase::robotModel::robotParts::Display &display
 	const int x = eval<int>("XCoordinateText");
 	const int y = eval<int>("YCoordinateText");
 	const int fontSize = eval<int>("FontSize");
-
-	QString result = stringProperty("PrintText");
-	if (boolProperty("Evaluate")) {
-	     bool ok;
-	     eval<QString>("PrintText").toDouble(&ok);
-	     if (ok) {
-		     result = QString::number(QString::number(eval<qreal>("PrintText"), 'f', 6).toDouble());
-	     }
-	     else {
-		     result =  eval<QString>("PrintText");
-	     }
-	}
-
+	const QString result = boolProperty("Evaluate")
+			? QString::number(QString::number(eval<qreal>("PrintText"), 'f', 6).toDouble())
+			: stringProperty("PrintText");
 	const bool redraw = boolProperty("Redraw");
+
 	if (!errorsOccured()) {
 		trikDisplay->printText(x, y, result, fontSize);
 		if (redraw) {

--- a/plugins/robots/common/trikKit/src/blocks/details/trikPrintTextBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/trikPrintTextBlock.cpp
@@ -30,11 +30,20 @@ void TrikPrintTextBlock::doJob(kitBase::robotModel::robotParts::Display &display
 	const int x = eval<int>("XCoordinateText");
 	const int y = eval<int>("YCoordinateText");
 	const int fontSize = eval<int>("FontSize");
-	const QString result = boolProperty("Evaluate")
-			? QString::number(QString::number(eval<qreal>("PrintText"), 'f', 6).toDouble())
-			: stringProperty("PrintText");
-	const bool redraw = boolProperty("Redraw");
 
+	QString result = stringProperty("PrintText");
+	if (boolProperty("Evaluate")) {
+	     bool ok;
+	     eval<QString>("PrintText").toDouble(&ok);
+	     if (ok) {
+		     result = QString::number(QString::number(eval<qreal>("PrintText"), 'f', 6).toDouble());
+	     }
+	     else {
+		     result =  eval<QString>("PrintText");
+	     }
+	}
+
+	const bool redraw = boolProperty("Redraw");
 	if (!errorsOccured()) {
 		trikDisplay->printText(x, y, result, fontSize);
 		if (redraw) {

--- a/plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp
@@ -1,0 +1,77 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "waitForMessageBlock.h"
+#include "trikKit/robotModel/parts/trikNetworkCommunicator.h"
+#include <utils/abstractTimer.h>
+#include <qrutils/stringUtils.h>
+#include <kitBase/robotModel/robotModelInterface.h>
+#include <kitBase/robotModel/robotModelUtils.h>
+
+using namespace trik;
+using namespace blocks::details;
+using namespace kitBase::robotModel;
+
+WaitForMessageBlock::WaitForMessageBlock(kitBase::robotModel::RobotModelInterface &robotModel):
+	WaitBlock(robotModel)
+{
+	mActiveWaitingTimer->setSingleShot(true);
+	mActiveWaitingTimer->setInterval(100);
+
+}
+
+void WaitForMessageBlock::handle()
+{
+	evalCode(stringProperty("Variable") + " = " + mMessage);
+	stop();
+	emit done(mNextBlockId);
+	return;
+}
+
+void WaitForMessageBlock::run()
+{
+	mNetwork = RobotModelUtils::findDevice<robotModel::parts::TrikNetworkCommunicator>(mRobotModel, "CommunicatorPort");
+
+	if (!mNetwork) {
+		error(tr("Device not found for port name CommunicatorPort"));
+		return;
+	}
+
+	auto wait = boolProperty("Synchronized");
+
+	if (!wait) {
+		mMessage = utils::StringUtils::wrap(utils::StringUtils::dequote(mNetwork->receive(wait)));
+		handle();
+		return;
+	}
+
+	mActiveWaitingTimer->start();
+}
+
+void WaitForMessageBlock::timerTimeout()
+{
+	auto message = mNetwork->receive(false);
+	if (message != QString()) {
+		mMessage = utils::StringUtils::wrap(utils::StringUtils::dequote(message));
+		handle();
+		return;
+	}
+
+	mActiveWaitingTimer->start();
+}
+
+DeviceInfo WaitForMessageBlock::device() const
+{
+	return DeviceInfo::create<robotModel::parts::TrikNetworkCommunicator>();
+}

--- a/plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp
@@ -28,7 +28,6 @@ WaitForMessageBlock::WaitForMessageBlock(kitBase::robotModel::RobotModelInterfac
 {
 	mActiveWaitingTimer->setSingleShot(true);
 	mActiveWaitingTimer->setInterval(100);
-
 }
 
 void WaitForMessageBlock::handle()

--- a/plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.h
@@ -1,0 +1,46 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include "trikKit/robotModel/parts/trikNetworkCommunicator.h"
+#include <kitBase/blocksBase/common/waitBlock.h>
+
+namespace trik {
+namespace blocks {
+namespace details {
+
+class WaitForMessageBlock: public kitBase::blocksBase::common::WaitBlock
+{
+	Q_OBJECT
+public:
+	explicit WaitForMessageBlock(kitBase::robotModel::RobotModelInterface &robotModel);
+
+private slots:
+	void timerTimeout() override;
+private:
+	void run() override;
+
+	void handle();
+
+	kitBase::robotModel::DeviceInfo device() const override;
+
+	robotModel::parts::TrikNetworkCommunicator *mNetwork {};
+	QString mMessage;
+
+};
+
+}
+}
+}

--- a/plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.h
+++ b/plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.h
@@ -37,8 +37,7 @@ private:
 	kitBase::robotModel::DeviceInfo device() const override;
 
 	robotModel::parts::TrikNetworkCommunicator *mNetwork {};
-	QString mMessage;
-
+	QString mMessage {};
 };
 
 }

--- a/plugins/robots/common/trikKit/src/blocks/trikBlocksFactoryBase.cpp
+++ b/plugins/robots/common/trikKit/src/blocks/trikBlocksFactoryBase.cpp
@@ -58,6 +58,9 @@
 #include "details/waitGamepadWheelBlock.h"
 #include "details/waitPadPressBlock.h"
 #include "details/trikWaitForGyroscopeBlock.h"
+#include "details/joinNetworkBlock.h"
+#include "details/sendMessageBlock.h"
+#include "details/waitForMessageBlock.h"
 
 #include "details/writeToFileBlock.h"
 #include "details/removeFileBlock.h"
@@ -98,11 +101,11 @@ qReal::interpretation::Block *TrikBlocksFactoryBase::produceBlock(const qReal::I
 	} else if (elementMetatypeIs(element, "TrikInitVideoStreaming")) {
 		return new InitVideoStreamingBlock(mRobotModelManager->model());
 	} else if (elementMetatypeIs(element, "TrikSendMessage")) {
-		return new qReal::interpretation::blocks::EmptyBlock();
+		return new SendMessageBlock(mRobotModelManager->model());
 	} else if (elementMetatypeIs(element, "TrikWaitForMessage")) {
-		return new qReal::interpretation::blocks::EmptyBlock();
+		return new WaitForMessageBlock(mRobotModelManager->model());
 	} else if (elementMetatypeIs(element, "TrikJoinNetwork")) {
-		return new qReal::interpretation::blocks::EmptyBlock();
+		return new JoinNetworkBlock(mRobotModelManager->model());
 	} else if (elementMetatypeIs(element, "TrikLed")) {
 		return new LedBlock(mRobotModelManager->model());
 

--- a/plugins/robots/common/trikKit/src/robotModel/parts/trikNetworkCommunicator.cpp
+++ b/plugins/robots/common/trikKit/src/robotModel/parts/trikNetworkCommunicator.cpp
@@ -1,0 +1,22 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "trikKit/robotModel/parts/trikNetworkCommunicator.h"
+
+using namespace trik::robotModel::parts;
+using namespace kitBase::robotModel;
+
+TrikNetworkCommunicator::TrikNetworkCommunicator(const DeviceInfo &info, const PortInfo &port)
+	: kitBase::robotModel::robotParts::Communicator(info, port)
+{}

--- a/plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp
+++ b/plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp
@@ -21,6 +21,7 @@
 #include <kitBase/robotModel/robotParts/accelerometerSensor.h>
 #include <kitBase/robotModel/robotParts/encoderSensor.h>
 #include <kitBase/robotModel/robotParts/lidarSensor.h>
+#include <kitBase/robotModel/robotParts/communicator.h>
 
 #include "trikKit/robotModel/parts/trikLightSensor.h"
 #include "trikKit/robotModel/parts/trikTouchSensor.h"
@@ -124,6 +125,8 @@ TrikRobotModelBase::TrikRobotModelBase(const QString &kitId, const QString &robo
 
 	addAllowedConnection(PortInfo("GamepadConnectionIndicatorPort", input, {}, "gamepadConnected")
 			, { gamepadConnectionIndicatorInfo() });
+
+	addAllowedConnection(PortInfo("CommunicatorPort", output), { networkInfo() });
 }
 
 QList<PortInfo> TrikRobotModelBase::configurablePorts() const
@@ -278,6 +281,12 @@ DeviceInfo TrikRobotModelBase::gamepadConnectionIndicatorInfo() const
 DeviceInfo TrikRobotModelBase::videoCameraInfo() const {
 	return DeviceInfo::create<parts::TrikVideoCamera>();
 }
+
+DeviceInfo TrikRobotModelBase::networkInfo() const
+{
+       return DeviceInfo::create<robotParts::Communicator>();
+}
+
 
 QHash<QString, int> TrikRobotModelBase::buttonCodes() const
 {

--- a/plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp
+++ b/plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp
@@ -284,7 +284,7 @@ DeviceInfo TrikRobotModelBase::videoCameraInfo() const {
 
 DeviceInfo TrikRobotModelBase::networkInfo() const
 {
-       return DeviceInfo::create<robotParts::Communicator>();
+	return DeviceInfo::create<robotParts::Communicator>();
 }
 
 

--- a/plugins/robots/common/trikKit/trikKit.pri
+++ b/plugins/robots/common/trikKit/trikKit.pri
@@ -35,6 +35,7 @@ HEADERS += \
 	$$PWD/include/trikKit/robotModel/parts/trikGamepadPadPressSensor.h \
 	$$PWD/include/trikKit/robotModel/parts/trikGamepadWheel.h \
 	$$PWD/include/trikKit/robotModel/parts/trikSpeaker.h \
+	$$PWD/include/trikKit/robotModel/parts/trikNetworkCommunicator.h \
 	$$PWD/include/trikKit/robotModel/parts/trikPowerMotor.h \
 	$$PWD/include/trikKit/robotModel/parts/trikServoMotor.h \
 	$$PWD/include/trikKit/robotModel/parts/trikInfraredSensor.h \
@@ -53,6 +54,9 @@ HEADERS += \
 	$$PWD/include/trikKit/blocks/trikV62BlocksFactory.h \
 	$$PWD/src/blocks/details/setBackgroundBlock.h \
 	$$PWD/src/blocks/details/smileBlock.h \
+	$$PWD/src/blocks/details/sendMessageBlock.h \
+	$$PWD/src/blocks/details/joinNetworkBlock.h \
+	$$PWD/src/blocks/details/waitForMessageBlock.h \
 	$$PWD/src/blocks/details/trikEnginesForwardBlock.h \
 	$$PWD/src/blocks/details/trikEnginesBackwardBlock.h \
 	$$PWD/src/blocks/details/waitForMotionBlock.h \
@@ -102,6 +106,7 @@ SOURCES += \
 	$$PWD/src/robotModel/parts/trikServoMotor.cpp \
 	$$PWD/src/robotModel/parts/trikSonarSensor.cpp \
 	$$PWD/src/robotModel/parts/trikSpeaker.cpp \
+	$$PWD/src/robotModel/parts/trikNetworkCommunicator.cpp \
 	$$PWD/src/robotModel/parts/trikShell.cpp \
 	$$PWD/src/robotModel/parts/trikMotorsAggregator.cpp \
 	$$PWD/src/robotModel/parts/trikTouchSensor.cpp \
@@ -111,6 +116,9 @@ SOURCES += \
 	$$PWD/src/blocks/trikV62BlocksFactory.cpp \
 	$$PWD/src/blocks/details/setBackgroundBlock.cpp \
 	$$PWD/src/blocks/details/smileBlock.cpp \
+	$$PWD/src/blocks/details/sendMessageBlock.cpp \
+	$$PWD/src/blocks/details/joinNetworkBlock.cpp \
+	$$PWD/src/blocks/details/waitForMessageBlock.cpp \
 	$$PWD/src/blocks/details/trikEnginesForwardBlock.cpp \
 	$$PWD/src/blocks/details/trikEnginesBackwardBlock.cpp \
 	$$PWD/src/blocks/details/waitForMotionBlock.cpp \

--- a/plugins/robots/editor/trik/generated/elements.h
+++ b/plugins/robots/editor/trik/generated/elements.h
@@ -753,7 +753,7 @@
 			label_1->setPlainTextMode(false);
 			label_1->setPrefix(QObject::tr("Address:"));
 			addLabel(label_1);
-			QSharedPointer<qReal::LabelProperties> label_2(new qReal::LabelProperties(2, 0.9, 1.8, "Port", false, 0));
+			QSharedPointer<qReal::LabelProperties> label_2(new qReal::LabelProperties(2, 0.9, 1.8, "IPPort", false, 0));
 			label_2->setBackground(Qt::white);
 			label_2->setScalingX(false);
 			label_2->setScalingY(false);
@@ -793,7 +793,7 @@
 		{
 			addProperty("Address", "string", QObject::tr("192.168.77.1"), QObject::tr("Address"), QObject::tr(""), false);
 			addProperty("HullNumber", "int", QString::fromUtf8("-1"), QObject::tr("Hull Number"), QObject::tr(""), false);
-			addProperty("Port", "int", QString::fromUtf8("-1"), QObject::tr("Port"), QObject::tr(""), false);
+			addProperty("IPPort", "int", QString::fromUtf8("-1"), QObject::tr("Port"), QObject::tr(""), false);
 		}
 	};
 

--- a/plugins/robots/editor/trik/trikMetamodel.xml
+++ b/plugins/robots/editor/trik/trikMetamodel.xml
@@ -1282,7 +1282,7 @@
 					</picture>
 					<labels>
 					        <label x="45" y="60" textBinded="Address" hard="false" prefix="Address:"/>
-						<label x="45" y="90" textBinded="Port" hard="false" prefix="Port:"/>
+						<label x="45" y="90" textBinded="IPPort" hard="false" prefix="Port:"/>
 						<label x="45" y="120" textBinded="HullNumber" hard="false" prefix="Hull number:"/>
 					</labels>
 					<nonResizeable/>
@@ -1292,7 +1292,7 @@
 					        <property displayedName="Address" type="string" name="Address">
 						        <default>192.168.77.1</default>
 						</property>
-						<property displayedName="Port" type="int" name="Port">
+						<property displayedName="Port" type="int" name="IPPort">
 						        <default>-1</default>
 						</property>
 						<property displayedName="Hull Number" type="int" name="HullNumber">

--- a/plugins/robots/interpreters/interpreterCore/src/coreBlocks/details/printTextBlock.cpp
+++ b/plugins/robots/interpreters/interpreterCore/src/coreBlocks/details/printTextBlock.cpp
@@ -28,19 +28,9 @@ void PrintTextBlock::doJob(kitBase::robotModel::robotParts::Display &display)
 {
 	const int x = eval<int>("XCoordinateText");
 	const int y = eval<int>("YCoordinateText");
-
-	QString result = stringProperty("PrintText");
-	if (boolProperty("Evaluate")) {
-	     bool ok;
-	     eval<QString>("PrintText").toDouble(&ok);
-	     if (ok) {
-		     result = QString::number(QString::number(eval<qreal>("PrintText"), 'f', 6).toDouble());
-	     }
-	     else {
-		     result =  eval<QString>("PrintText");
-	     }
-	}
-
+	const QString result = boolProperty("Evaluate")
+			? QString::number(QString::number(eval<qreal>("PrintText"), 'f', 6).toDouble())
+			: stringProperty("PrintText");
 	const bool redraw = boolProperty("Redraw");
 
 	if (!errorsOccured()) {

--- a/plugins/robots/interpreters/interpreterCore/src/coreBlocks/details/printTextBlock.cpp
+++ b/plugins/robots/interpreters/interpreterCore/src/coreBlocks/details/printTextBlock.cpp
@@ -28,9 +28,19 @@ void PrintTextBlock::doJob(kitBase::robotModel::robotParts::Display &display)
 {
 	const int x = eval<int>("XCoordinateText");
 	const int y = eval<int>("YCoordinateText");
-	const QString result = boolProperty("Evaluate")
-			? QString::number(QString::number(eval<qreal>("PrintText"), 'f', 6).toDouble())
-			: stringProperty("PrintText");
+
+	QString result = stringProperty("PrintText");
+	if (boolProperty("Evaluate")) {
+	     bool ok;
+	     eval<QString>("PrintText").toDouble(&ok);
+	     if (ok) {
+		     result = QString::number(QString::number(eval<qreal>("PrintText"), 'f', 6).toDouble());
+	     }
+	     else {
+		     result =  eval<QString>("PrintText");
+	     }
+	}
+
 	const bool redraw = boolProperty("Redraw");
 
 	if (!errorsOccured()) {

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h
@@ -55,7 +55,6 @@ public:
 	void release() override;
 private:
 	trikNetwork::MailboxInterface *mMailbox {}; // ownership --- TrikKitInterpreterPluginBase
-
 };
 
 }

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h
@@ -32,7 +32,8 @@ class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT TwoDNetworkCommunicator
 
 public:
 	TwoDNetworkCommunicator(const kitBase::robotModel::DeviceInfo &info
-			, const kitBase::robotModel::PortInfo &port);
+			, const kitBase::robotModel::PortInfo &port
+			, trikNetwork::MailboxInterface *mailbox);
 	~TwoDNetworkCommunicator();
 
 	/// Send a message to a robot
@@ -53,7 +54,7 @@ public:
 	/// Deinitializing a TRIK network communicator
 	void release() override;
 private:
-	QSharedPointer<trikNetwork::MailboxInterface> mMailbox;
+	trikNetwork::MailboxInterface *mMailbox {}; // ownership --- TrikKitInterpreterPluginBase
 
 };
 

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h
@@ -25,7 +25,8 @@ namespace twoD {
 namespace parts {
 
 /// Class for implementing 2D-model network communication between robots
-class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT TwoDNetworkCommunicator : public robotModel::parts::TrikNetworkCommunicator
+class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT TwoDNetworkCommunicator
+		: public robotModel::parts::TrikNetworkCommunicator
 {
 	Q_OBJECT
 

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h
@@ -1,0 +1,62 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include <trikKit/robotModel/parts/trikNetworkCommunicator.h>
+#include <trikNetwork/mailboxFactory.h>
+#include <trikControl/brickInterface.h>
+#include "trikKitInterpreterCommon/declSpec.h"
+
+namespace trik {
+namespace robotModel {
+namespace twoD {
+namespace parts {
+
+/// Class for implementing 2D-model network communication between robots
+class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT TwoDNetworkCommunicator : public robotModel::parts::TrikNetworkCommunicator
+{
+	Q_OBJECT
+
+public:
+	TwoDNetworkCommunicator(const kitBase::robotModel::DeviceInfo &info
+			, const kitBase::robotModel::PortInfo &port);
+	~TwoDNetworkCommunicator();
+
+	/// Send a message to a robot
+	void send(const QString& message, int hullNumber) override;
+
+	/// Receive message from robot
+	QString receive(bool wait) override;
+
+	/// Send an interrupt to stop waiting for a message
+	void stopWaiting() override;
+
+	/// Clean the incoming message queue
+	void clearQueue() override;
+
+	/// Join the network with the specified hull number
+	void joinNetwork(const QString &ip, int port, int hullNumber) override;
+
+	/// Deinitializing a TRIK network communicator
+	void release() override;
+private:
+	QSharedPointer<trikNetwork::MailboxInterface> mMailbox;
+
+};
+
+}
+}
+}
+}

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/trikTwoDRobotModel.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/trikTwoDRobotModel.h
@@ -28,8 +28,8 @@ namespace robotModel {
 namespace twoD {
 
 /// @todo Refactor common code out of here.
-///       It needs ceoncerns separation: robot model is device factory and container for device-port configuration.
-///       So, for diffrent TRIK cases devices are the same, but mappings between ports and devices are
+///       It needs concerns separation: robot model is device factory and container for device-port configuration.
+///       So, for different TRIK cases devices are the same, but mappings between ports and devices are
 ///       different. And across models devices are different (2d and real) but port mappings are the same.
 ///       Clearly we need to separate this into two hierarchies.
 class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT TrikTwoDRobotModel : public twoDModel::robotModel::TwoDRobotModel

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/trikTwoDRobotModel.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/robotModel/twoD/trikTwoDRobotModel.h
@@ -17,6 +17,7 @@
 #include <twoDModel/robotModel/twoDRobotModel.h>
 
 #include "trikKitInterpreterCommon/declSpec.h"
+#include "trikNetwork/mailboxInterface.h"
 
 namespace qReal {
 class ErrorReporterInterface;
@@ -27,8 +28,8 @@ namespace robotModel {
 namespace twoD {
 
 /// @todo Refactor common code out of here.
-///       It needs concerns separation: robot model is device factory and container for device-port configuration.
-///       So, for different TRIK cases devices are the same, but mappings between ports and devices are
+///       It needs ceoncerns separation: robot model is device factory and container for device-port configuration.
+///       So, for diffrent TRIK cases devices are the same, but mappings between ports and devices are
 ///       different. And across models devices are different (2d and real) but port mappings are the same.
 ///       Clearly we need to separate this into two hierarchies.
 class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT TrikTwoDRobotModel : public twoDModel::robotModel::TwoDRobotModel
@@ -68,6 +69,9 @@ public:
 	/// Sets the error reporter for writing bubbling messages by shell emulator.
 	void setErrorReporter(qReal::ErrorReporterInterface &errorReporter);
 
+	/// Sets the trik mailbox for twoDNetworkCommunicator execution.
+	void setMailbox(trikNetwork::MailboxInterface &mailbox);
+
 private:
 	kitBase::robotModel::robotParts::Device *createDevice(
 			const kitBase::robotModel::PortInfo &port
@@ -81,6 +85,7 @@ private:
 	twoDModel::engine::TwoDModelDisplayWidget *mDisplayWidget;
 	qReal::ErrorReporterInterface *mErrorReporter {};
 	QPolygonF mCollidingPolygon;
+	trikNetwork::MailboxInterface *mMailbox {}; //ownership TrikKitInterpreterPluginBase
 };
 
 }

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikKitInterpreterPluginBase.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikKitInterpreterPluginBase.h
@@ -26,7 +26,7 @@
 
 #include "robotModel/twoD/trikTwoDRobotModel.h"
 #include "trikAdditionalPreferences.h"
-
+#include <trikNetwork/mailboxInterface.h>
 #include <trikKitInterpreterCommon/trikTextualInterpreter.h>
 
 /// @todo: refactor
@@ -55,7 +55,6 @@ public:
 
 	QSharedPointer<kitBase::blocksBase::BlocksFactoryInterface> blocksFactoryFor(
 			const kitBase::robotModel::RobotModelInterface *model) override;
-
 	QList<kitBase::AdditionalPreferences *> settingsWidgets() override;
 
 	QWidget *quickPreferencesFor(const kitBase::robotModel::RobotModelInterface &model) override;
@@ -105,6 +104,7 @@ private:
 	QSharedPointer<robotModel::twoD::TrikTwoDRobotModel> mTwoDRobotModel;
 
 	QScopedPointer<TrikTextualInterpreter> mTextualInterpreter;
+	QScopedPointer<trikNetwork::MailboxInterface> mMailbox;
 
 	QAction mStart;
 	QAction mStop;

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikTextualInterpreter.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikTextualInterpreter.h
@@ -33,6 +33,7 @@ class ROBOTS_TRIK_KIT_INTERPRETER_COMMON_EXPORT TrikTextualInterpreter
 
 public:
 	TrikTextualInterpreter(const QSharedPointer<robotModel::twoD::TrikTwoDRobotModel> &model
+			       , trikNetwork::MailboxInterface *mailbox
 						   , bool enablePython = false);
 	~TrikTextualInterpreter() override;
 
@@ -46,7 +47,6 @@ public:
 	bool isRunning() const;
 	void setRunning(bool running);
 	void setCurrentDir(const QString &dir, const QString &languageExtension);
-	void setMailboxHullNumber();
 	QStringList supportedRobotModelNames() const;
 	QStringList knownMethodNames() const;
 
@@ -67,7 +67,7 @@ private:
 	bool mRunning { false };
 
 	TrikBrick mBrick;
-	QSharedPointer<trikNetwork::MailboxInterface> mMailbox;
+	trikNetwork::MailboxInterface *mMailbox {}; // ownership --- TrikKitInterpreterPluginBase
 	TwoDExecutionControl *mExecutionControl {};
 	trikScriptRunner::TrikScriptRunner mScriptRunner;
 	qReal::ErrorReporterInterface *mErrorReporter {};

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikTextualInterpreter.h
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/include/trikKitInterpreterCommon/trikTextualInterpreter.h
@@ -67,7 +67,7 @@ private:
 	bool mRunning { false };
 
 	TrikBrick mBrick;
-	trikNetwork::MailboxInterface *mMailbox {};
+	QSharedPointer<trikNetwork::MailboxInterface> mMailbox;
 	TwoDExecutionControl *mExecutionControl {};
 	trikScriptRunner::TrikScriptRunner mScriptRunner;
 	qReal::ErrorReporterInterface *mErrorReporter {};

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDNetworkCommunicator.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDNetworkCommunicator.cpp
@@ -14,17 +14,16 @@
 
 #include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h"
 #include <qrkernel/settingsManager.h>
-#include <trikNetwork/mailboxFactory.h>
 #include <trikNetwork/mailboxInterface.h>
 
 using namespace trik::robotModel::twoD::parts;
 using namespace kitBase::robotModel;
 
 TwoDNetworkCommunicator::TwoDNetworkCommunicator(const DeviceInfo &info
-		, const PortInfo &port)
+		, const PortInfo &port
+		,trikNetwork::MailboxInterface *mailbox)
 	: robotModel::parts::TrikNetworkCommunicator(info, port)
-	, mMailbox(qReal::SettingsManager::value("TRIK2DMailbox", "").toBool()
-		   ? trikNetwork::MailboxFactory::create(8889): nullptr)
+	, mMailbox(mailbox)
 {}
 
 

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDNetworkCommunicator.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/parts/twoDNetworkCommunicator.cpp
@@ -1,0 +1,79 @@
+/* Copyright 2024 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h"
+#include <qrkernel/settingsManager.h>
+#include <trikNetwork/mailboxFactory.h>
+#include <trikNetwork/mailboxInterface.h>
+
+using namespace trik::robotModel::twoD::parts;
+using namespace kitBase::robotModel;
+
+TwoDNetworkCommunicator::TwoDNetworkCommunicator(const DeviceInfo &info
+		, const PortInfo &port)
+	: robotModel::parts::TrikNetworkCommunicator(info, port)
+	, mMailbox(qReal::SettingsManager::value("TRIK2DMailbox", "").toBool()
+		   ? trikNetwork::MailboxFactory::create(8889): nullptr)
+{}
+
+
+TwoDNetworkCommunicator::~TwoDNetworkCommunicator(){
+}
+
+void TwoDNetworkCommunicator::send(const QString& message, int hullNumber)
+{
+	if (mMailbox) {
+		mMailbox->send(hullNumber, message);
+	}
+}
+
+QString TwoDNetworkCommunicator::receive(bool wait)
+{
+	if (mMailbox) {
+		return mMailbox->receive(wait);
+	}
+
+	return QString();
+}
+
+void TwoDNetworkCommunicator::stopWaiting()
+{
+	if (mMailbox) {
+		mMailbox->stopWaiting();
+	}
+}
+
+void TwoDNetworkCommunicator::clearQueue()
+{
+	if (mMailbox) {
+		mMailbox->clearQueue();
+	}
+}
+
+void TwoDNetworkCommunicator::release()
+{
+	if (mMailbox) {
+		mMailbox->stopWaiting();
+		mMailbox->clearQueue();
+	}
+}
+
+void TwoDNetworkCommunicator::joinNetwork(const QString &ip, int port, int hullNumber)
+{
+	if (mMailbox) {
+		mMailbox->joinNetwork(ip, port, hullNumber);
+	}
+}
+
+

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/trikTwoDRobotModel.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/trikTwoDRobotModel.cpp
@@ -46,7 +46,6 @@
 #include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDLightSensor.h"
 #include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDGyroscopeSensor.h"
 #include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h"
-
 using namespace trik::robotModel;
 using namespace trik::robotModel::twoD;
 using namespace kitBase::robotModel;
@@ -81,7 +80,7 @@ QPair<qreal, int> TrikTwoDRobotModel::rangeSensorAngleAndDistance
 robotParts::Device *TrikTwoDRobotModel::createDevice(const PortInfo &port, const DeviceInfo &deviceInfo)
 {
 	if (deviceInfo.isA<robotParts::Communicator>()) {
-		return new parts::TwoDNetworkCommunicator(deviceInfo, port);
+		return new parts::TwoDNetworkCommunicator(deviceInfo, port, mMailbox);
 	}
 
 
@@ -276,4 +275,9 @@ QHash<QString, int> TrikTwoDRobotModel::buttonCodes() const
 void TrikTwoDRobotModel::setErrorReporter(qReal::ErrorReporterInterface &errorReporter)
 {
 	mErrorReporter = &errorReporter;
+}
+
+void TrikTwoDRobotModel::setMailbox(trikNetwork::MailboxInterface &mailbox)
+{
+	mMailbox = &mailbox;
 }

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/trikTwoDRobotModel.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/robotModel/twoD/trikTwoDRobotModel.cpp
@@ -45,6 +45,7 @@
 #include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDColorSensor.h"
 #include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDLightSensor.h"
 #include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDGyroscopeSensor.h"
+#include "trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h"
 
 using namespace trik::robotModel;
 using namespace trik::robotModel::twoD;
@@ -79,6 +80,11 @@ QPair<qreal, int> TrikTwoDRobotModel::rangeSensorAngleAndDistance
 
 robotParts::Device *TrikTwoDRobotModel::createDevice(const PortInfo &port, const DeviceInfo &deviceInfo)
 {
+	if (deviceInfo.isA<robotParts::Communicator>()) {
+		return new parts::TwoDNetworkCommunicator(deviceInfo, port);
+	}
+
+
 	if (deviceInfo.isA<robotParts::Display>()) {
 		return new parts::Display(deviceInfo, port, *engine());
 	}
@@ -139,6 +145,13 @@ void TrikTwoDRobotModel::onInterpretationStarted()
 		shell->reset();
 	} else {
 		QLOG_WARN() << "TRIK shell is not configured before intepretation start!";
+	}
+
+	auto * const mailbox = RobotModelUtils::findDevice<parts::TwoDNetworkCommunicator>(*this, "CommunicatorPort");
+	if (mailbox) {
+		mailbox->release();
+	} else {
+		QLOG_WARN() << "TRIK network is not configured before intepretation start!";
 	}
 }
 

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp
@@ -55,9 +55,6 @@ TrikAdditionalPreferences::TrikAdditionalPreferences(const QStringList &realRobo
 
 	connect(mUi->packImagesPushButton, &QPushButton::clicked
 			, this, &TrikAdditionalPreferences::packImagesToProjectClicked);
-
-	connect(mUi->mailboxCheckBox, &QCheckBox::toggled, mUi->mailboxHullNumberLabel, &QLabel::setVisible);
-	connect(mUi->mailboxCheckBox, &QCheckBox::toggled, mUi->mailboxHullNumber, &QLineEdit::setVisible);
 }
 
 TrikAdditionalPreferences::~TrikAdditionalPreferences()
@@ -73,7 +70,6 @@ void TrikAdditionalPreferences::save()
 	SettingsManager::setValue("TrikSimulatedCameraImagesFromProject", mUi->imagesFromProjectCheckBox->isChecked());
 	SettingsManager::setValue("TrikWebCameraRealName", mUi->cameraNameLineEdit->text());
 	SettingsManager::setValue("TRIK2DMailbox", mUi->mailboxCheckBox->isChecked());
-	SettingsManager::setValue("TRIK2DHullNumber", mUi->mailboxHullNumber->text());
 	mUi->robotImagePicker->save();
 
 	if (mailboxSavedState != mUi->mailboxCheckBox->isChecked()) {

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>357</width>
-    <height>427</height>
+    <height>445</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -144,20 +144,6 @@
        <widget class="QCheckBox" name="mailboxCheckBox">
         <property name="text">
          <string>Enable Mailbox</string>
-        </property>
-       </widget>
-      </item>
-	  <item row="0" column="1">
-       <widget class="QLabel" name="mailboxHullNumberLabel">
-        <property name="text">
-         <string>Hull number:</string>
-        </property>
-       </widget>
-      </item>
-	  <item row="0" column="2">
-       <widget class="QLineEdit" name="mailboxHullNumber">
-        <property name="text">
-         <string>999</string>
         </property>
        </widget>
       </item>

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreter.pri
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreter.pri
@@ -56,6 +56,7 @@ HEADERS += \
 	$$PWD/robotModel/twoD/parts/twoDObjectSensor.h \
 	$$PWD/robotModel/twoD/parts/twoDColorSensor.h \
 	$$PWD/robotModel/twoD/parts/twoDShell.h \
+	$$PWD/robotModel/twoD/parts/twoDNetworkCommunicator.h \
 	$$PWD/robotModel/real/trikV62RealRobotModel.h \
 	$$PWD/robotModel/twoD/trikV62TwoDRobotModel.h \
 	$$PWD/trikV62AdditionalPreferences.h \
@@ -93,6 +94,7 @@ SOURCES += \
 	$$PWD/robotModel/twoD/parts/twoDColorSensor.cpp \
 	$$PWD/robotModel/twoD/parts/twoDLed.cpp \
 	$$PWD/robotModel/twoD/parts/twoDShell.cpp \
+	$$PWD/robotModel/twoD/parts/twoDNetworkCommunicator.cpp \
 	$$PWD/trikV62AdditionalPreferences.cpp \
 	$$PWD/trikV62DisplayWidget.cpp \
 	$$PWD/trikV62KitInterpreterPlugin.cpp \

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp
@@ -25,9 +25,9 @@
 #include <qrkernel/settingsManager.h>
 #include <qrkernel/settingsListener.h>
 #include <qrkernel/platformInfo.h>
-
 #include <qrgui/textEditor/qscintillaTextEdit.h>
 #include <qrgui/textEditor/languageInfo.h>
+#include "trikNetwork/mailboxFactory.h"
 
 using namespace trik;
 using namespace qReal;
@@ -51,8 +51,15 @@ void TrikKitInterpreterPluginBase::initKitInterpreterPluginBase
 		, const QSharedPointer<blocks::TrikBlocksFactoryBase> &blocksFactory
 		)
 {
+	auto isMailboxEnabled = qReal::SettingsManager::value("TRIK2DMailbox", "").toBool();
+	if (isMailboxEnabled) {
+		mMailbox.reset(trikNetwork::MailboxFactory::create(8889));
+	}
 	mRealRobotModel.reset(realRobotModel);
 	mTwoDRobotModel.reset(twoDRobotModel);
+	if (mMailbox) {
+		mTwoDRobotModel->setMailbox(*mMailbox);
+	}
 	mBlocksFactory = blocksFactory;
 
 	const auto modelEngine = new twoDModel::engine::TwoDModelEngineFacade(*mTwoDRobotModel);
@@ -84,9 +91,7 @@ void TrikKitInterpreterPluginBase::initKitInterpreterPluginBase
 		}
 	}
 #endif
-	mTextualInterpreter.reset(new TrikTextualInterpreter(mTwoDRobotModel, enablePython));
-	connect(mAdditionalPreferences, &TrikAdditionalPreferences::settingsChanged
-			, mTextualInterpreter.data(), &TrikTextualInterpreter::setMailboxHullNumber);
+	mTextualInterpreter.reset(new TrikTextualInterpreter(mTwoDRobotModel, mMailbox.data(), enablePython));
 }
 
 void TrikKitInterpreterPluginBase::startCodeInterpretation(const QString &code, const QString &extension)

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp
@@ -36,10 +36,10 @@ const QString jsOverrides = "Date.now = script.time;";
 
 trik::TrikTextualInterpreter::TrikTextualInterpreter(
 	const QSharedPointer<trik::robotModel::twoD::TrikTwoDRobotModel> &model
+		, trikNetwork::MailboxInterface *mailbox
 		, bool enablePython)
 	: mBrick(model)
-	, mMailbox(qReal::SettingsManager::value("TRIK2DMailbox", "").toBool()
-			   ? trikNetwork::MailboxFactory::create(8889): nullptr)
+	, mMailbox(mailbox)
 	, mScriptRunner(mBrick, mMailbox, new TwoDExecutionControl(mBrick, model))
 {
 	connect(&mBrick, &TrikBrick::error, this, &TrikTextualInterpreter::reportError);
@@ -71,13 +71,6 @@ trik::TrikTextualInterpreter::TrikTextualInterpreter(
 trik::TrikTextualInterpreter::~TrikTextualInterpreter()
 {
 	abort();
-}
-
-void trik::TrikTextualInterpreter::setMailboxHullNumber()
-{
-	if (mMailbox) {
-		mMailbox->setHullNumber(qReal::SettingsManager::value("TRIK2DHullNumber", "999").toInt());
-	}
 }
 
 void trik::TrikTextualInterpreter::interpretCommand(const QString &script)

--- a/plugins/robots/interpreters/trikKitInterpreterCommon/trikKitInterpreterCommon.pri
+++ b/plugins/robots/interpreters/trikKitInterpreterCommon/trikKitInterpreterCommon.pri
@@ -73,6 +73,7 @@ HEADERS += \
 	$$PWD/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDObjectSensor.h \
 	$$PWD/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDColorSensor.h \
 	$$PWD/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDShell.h \
+	$$PWD/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDNetworkCommunicator.h \
 	$$PWD/include/trikKitInterpreterCommon/robotModel/twoD/parts/twoDGyroscopeSensor.h \
 	$$PWD/include/trikKitInterpreterCommon/robotModel/twoD/trikTwoDRobotModel.h \
 	$$PWD/include/trikKitInterpreterCommon/trikAdditionalPreferences.h \
@@ -128,6 +129,7 @@ SOURCES += \
 	$$PWD/src/robotModel/twoD/parts/twoDColorSensor.cpp \
 	$$PWD/src/robotModel/twoD/parts/twoDLed.cpp \
 	$$PWD/src/robotModel/twoD/parts/twoDShell.cpp \
+	$$PWD/src/robotModel/twoD/parts/twoDNetworkCommunicator.cpp \
 	$$PWD/src/robotModel/twoD/parts/twoDGyroscopeSensor.cpp \
 	$$PWD/src/robotModel/twoD/trikTwoDRobotModel.cpp \
 	$$PWD/src/trikAdditionalPreferences.cpp \

--- a/qrtranslations/fr/plugins/robots/kitBase_fr.ts
+++ b/qrtranslations/fr/plugins/robots/kitBase_fr.ts
@@ -159,6 +159,14 @@
     </message>
 </context>
 <context>
+    <name>kitBase::robotModel::robotParts::Communicator</name>
+    <message>
+        <location filename="../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h" line="+29"/>
+        <source>Communicator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>kitBase::robotModel::robotParts::Display</name>
     <message>
         <location filename="../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/display.h" line="+29"/>

--- a/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
@@ -52,17 +52,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Hull number:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>999</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-88"/>
+        <location line="-74"/>
         <source>Camera:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -129,7 +119,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+25"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -248,7 +238,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+57"/>
         <source>TRIK_PYTHONPATH must be set correctly to run Python script.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKitInterpreterCommon_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+171"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+164"/>
         <source>Bogus input values</source>
         <translation type="unfinished"></translation>
     </message>
@@ -238,7 +238,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
+        <location line="+61"/>
         <source>TRIK_PYTHONPATH must be set correctly to run Python script.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/trikKit_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKit_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>trik::blocks::details::WaitForMessageBlock</name>
     <message>
-        <location filename="../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="+47"/>
+        <location filename="../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="+46"/>
         <source>Device not found for port name CommunicatorPort</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/trikKit_fr.ts
+++ b/qrtranslations/fr/plugins/robots/trikKit_fr.ts
@@ -2,6 +2,14 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="fr_FR">
 <context>
+    <name>trik::blocks::details::WaitForMessageBlock</name>
+    <message>
+        <location filename="../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="+47"/>
+        <source>Device not found for port name CommunicatorPort</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>trik::blocks::details::WaitGamepadButtonBlock</name>
     <message>
         <location filename="../../../../plugins/robots/common/trikKit/src/blocks/details/waitGamepadButtonBlock.cpp" line="+41"/>
@@ -12,8 +20,8 @@
 <context>
     <name>trik::robotModel::TrikRobotModelBase</name>
     <message>
-        <location filename="../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="+92"/>
-        <location line="+204"/>
+        <location filename="../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="+93"/>
+        <location line="+212"/>
         <source>Video 2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/kitBase_ru.ts
+++ b/qrtranslations/ru/plugins/robots/kitBase_ru.ts
@@ -159,6 +159,14 @@
     </message>
 </context>
 <context>
+    <name>kitBase::robotModel::robotParts::Communicator</name>
+    <message>
+        <location filename="../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h" line="+29"/>
+        <source>Communicator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>kitBase::robotModel::robotParts::Display</name>
     <message>
         <location filename="../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/display.h" line="+29"/>

--- a/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
@@ -76,17 +76,11 @@
         <translation>Активировать Mailbox</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Hull number:</source>
-        <translation>Бортномер:</translation>
+        <translation type="vanished">Бортномер:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>999</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-52"/>
+        <location line="-38"/>
         <source>Images:</source>
         <translation>Изображения:</translation>
     </message>
@@ -185,7 +179,7 @@
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+25"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
@@ -313,7 +307,7 @@
         <translation>Оставновить</translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+57"/>
         <source>TRIK_PYTHONPATH must be set correctly to run Python script.</source>
         <translation>Для запуска программы на Python доложна быть корректно выставлена переменная окружения TRIK_PYTHONPATH</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKitInterpreterCommon_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+171"/>
+        <location filename="../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+164"/>
         <source>Bogus input values</source>
         <translation>Неподходящие значения аргументов</translation>
     </message>
@@ -307,7 +307,7 @@
         <translation>Оставновить</translation>
     </message>
     <message>
-        <location line="+57"/>
+        <location line="+61"/>
         <source>TRIK_PYTHONPATH must be set correctly to run Python script.</source>
         <translation>Для запуска программы на Python доложна быть корректно выставлена переменная окружения TRIK_PYTHONPATH</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/trikKit_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKit_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>trik::blocks::details::WaitForMessageBlock</name>
     <message>
-        <location filename="../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="+47"/>
+        <location filename="../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="+46"/>
         <source>Device not found for port name CommunicatorPort</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/trikKit_ru.ts
+++ b/qrtranslations/ru/plugins/robots/trikKit_ru.ts
@@ -2,6 +2,14 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
 <context>
+    <name>trik::blocks::details::WaitForMessageBlock</name>
+    <message>
+        <location filename="../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="+47"/>
+        <source>Device not found for port name CommunicatorPort</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>trik::blocks::details::WaitGamepadButtonBlock</name>
     <message>
         <location filename="../../../../plugins/robots/common/trikKit/src/blocks/details/waitGamepadButtonBlock.cpp" line="+41"/>
@@ -12,8 +20,8 @@
 <context>
     <name>trik::robotModel::TrikRobotModelBase</name>
     <message>
-        <location filename="../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="+92"/>
-        <location line="+204"/>
+        <location filename="../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="+93"/>
+        <location line="+212"/>
         <source>Video 2</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
1. A temporary solution for a bug in `TrikPrintTextBlock` with the inability to display strings on the display
2. The `mailbox` entity has been taken to a higher level for use in visual language
3. Support for `TrikJoinNetwork`, `TrikWaitForMessage`, `TrikSendMessage` blocks in visual language
4. Cut out unnecessary functionality due to the use of the TrikJoinNetwork block