### PR TITLE
Fix macOS installer name

### DIFF
--- a/buildScripts/github/build_installer.sh
+++ b/buildScripts/github/build_installer.sh
@@ -35,6 +35,6 @@ $EXECUTOR bash -c "installer/build-trik-studio.sh $QTBIN $QTIFWBIN ."
 
 if $NEED_DEPLOY ; then
     $EXECUTOR bash -c "\
-          mv installer/trik-studio*installer* installer/$TSNAME \
-          && rsync -v --rsh='ssh -o StrictHostKeyChecking=no' installer/$TSNAME $username@$host:~/dl/ts/fresh/installer/$TSNAME"
+          INSTALLER_NAME=$(find installer -name "trik-studio*installer*" | head -n 1) \
+          && rsync -v --rsh='ssh -o StrictHostKeyChecking=no' $INSTALLER_NAME $username@$host:~/dl/ts/fresh/installer/$TSNAME"
 fi

--- a/buildScripts/github/build_installer.sh
+++ b/buildScripts/github/build_installer.sh
@@ -9,8 +9,7 @@ case $RUNNER_OS in
     ;;
   Linux)
     QTIFWBIN=$(find "$HOME"/Qt/Tools -name "bin" | head -n 1)
-    ID=$(grep '^ID=' /etc/os-release | cut -d'=' -f2)
-    TSNAME="trik-studio-installer-linux-$BRANCH_NAME-$ID.run"
+    TSNAME="trik-studio-installer-linux-$BRANCH_NAME.run"
     ;;
   *) exit 1 ;;
 esac
@@ -26,7 +25,7 @@ if [[ $RUNNER_OS == Linux ]] ; then
       echo Start build checker archive
       $EXECUTOR bash -c "bin/build-checker-installer.sh"
       if $NEED_DEPLOY ; then
-          $EXECUTOR bash -c "rsync -v --rsh='ssh -o StrictHostKeyChecking=no' bin/trik_checker.tar.xz $username@$host:~/dl/ts/fresh/checker/checker-linux-$CONFIG-$BRANCH_NAME-$ID.tar.xz"
+          $EXECUTOR bash -c "rsync -v --rsh='ssh -o StrictHostKeyChecking=no' bin/trik_checker.tar.xz $username@$host:~/dl/ts/fresh/checker/checker-linux-$CONFIG-$BRANCH_NAME.tar.xz"
       fi
 fi
 


### PR DESCRIPTION
During the `push` action, the name of the `macOS` installer was implicitly changed, which led to the failure of scripts to verify its integrity