### PR TITLE
Wait for the plugin initialization

### DIFF
--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -66,6 +66,9 @@ Runner::Runner(const QString &report, const QString &trajectory,
 	connect(&*mErrorReporter, &qReal::ConsoleErrorReporter::criticalAdded, &*mReporter, &Reporter::addError);
 	connect(&*mErrorReporter, &qReal::ConsoleErrorReporter::logAdded, &*mReporter, &Reporter::addLog);
 
+	QEventLoop loop;
+	QTimer::singleShot(0, &loop, &QEventLoop::quit);
+	loop.exec();
 	mProjectManager->open(mSaveFile);
 }
 

--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -67,7 +67,7 @@ Runner::Runner(const QString &report, const QString &trajectory,
 	connect(&*mErrorReporter, &qReal::ConsoleErrorReporter::logAdded, &*mReporter, &Reporter::addLog);
 
 	/* 
-	Upon initialization of the EV3 kit plugin, a subscription to the sensorAdded event in the Box2DPhysicsEngine 
+	HACK: Upon initialization of the EV3 kit plugin, a subscription to the sensorAdded event in the Box2DPhysicsEngine 
 	is registered with a delay using QTimerSingleShot(10). While this does not pose an issue when 
 	utilizing TRIK Studio, it becomes problematic when using the 2D-model projectManager->open function, 
 	as the subscription is established too late. As a consequence, the sensors are not properly processed by Box2D.

--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -66,6 +66,12 @@ Runner::Runner(const QString &report, const QString &trajectory,
 	connect(&*mErrorReporter, &qReal::ConsoleErrorReporter::criticalAdded, &*mReporter, &Reporter::addError);
 	connect(&*mErrorReporter, &qReal::ConsoleErrorReporter::logAdded, &*mReporter, &Reporter::addLog);
 
+	/* 
+	Upon initialization of the EV3 kit plugin, a subscription to the sensorAdded event in the Box2DPhysicsEngine 
+	is registered with a delay using QTimerSingleShot(10). While this does not pose an issue when 
+	utilizing TRIK Studio, it becomes problematic when using the 2D-model projectManager->open function, 
+	as the subscription is established too late. As a consequence, the sensors are not properly processed by Box2D.
+	*/
 	QEventLoop loop;
 	QTimer::singleShot(0, &loop, &QEventLoop::quit);
 	loop.exec();

--- a/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
@@ -87,7 +87,7 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+228"/>
+        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+234"/>
         <source>Robot console</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
@@ -87,7 +87,7 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+225"/>
+        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+228"/>
         <source>Robot console</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
@@ -89,7 +89,7 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+225"/>
+        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+228"/>
         <source>Robot console</source>
         <translation>Консоль робота</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
@@ -89,7 +89,7 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+228"/>
+        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+234"/>
         <source>Robot console</source>
         <translation>Консоль робота</translation>
     </message>


### PR DESCRIPTION
Upon initialization of the `EV3` kit plugin, a subscription to the [sensorAdded](https://github.com/trikset/trik-studio/blob/1281f48c8d1e50c7c16b4f164bd7cffa55d4d001/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp#L128()) event in the `Box2DPhysicsEngine` is registered with a delay using [QTimerSingleShot(10)](https://github.com/trikset/trik-studio/blob/1281f48c8d1e50c7c16b4f164bd7cffa55d4d001/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp#L112). While this does not pose an issue when utilizing `TRIK Studio`, it becomes problematic when using the `2D-model` [projectManager->open function](https://github.com/trikset/trik-studio/blob/1281f48c8d1e50c7c16b4f164bd7cffa55d4d001/plugins/robots/checker/twoDModelRunner/runner.cpp#L69), as the subscription is established too late. As a consequence, the sensors are not properly processed by `Box2D`.