### PR TITLE
Increase the timer for waiting for sensors

### DIFF
--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -73,7 +73,7 @@ Runner::Runner(const QString &report, const QString &trajectory,
 	as the subscription is established too late. As a consequence, the sensors are not properly processed by Box2D.
 	*/
 	QEventLoop loop;
-	QTimer::singleShot(0, &loop, &QEventLoop::quit);
+	QTimer::singleShot(10, &loop, &QEventLoop::quit);
 	loop.exec();
 	mProjectManager->open(mSaveFile);
 }


### PR DESCRIPTION
Due to the fact that after the tests were added, action was [failed](https://github.com/trikset/trik-studio/actions/runs/12624954188/job/35176605391#step:15:433) on `macOS`, it is proposed to make the time for `QSingleShot` comparable to the time for `QSingleShot` in the `sensorAdded` subscription.