### PR TITLE
Fix crash when saving generated files for NXT

### DIFF
--- a/plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp
+++ b/plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp
@@ -34,7 +34,6 @@ NxtOsekCGeneratorPlugin::NxtOsekCGeneratorPlugin()
 	, mFlashRobotAction(new QAction(this))
 	, mUploadProgramAction(new QAction(this))
 	, mNxtToolsPresent(false)
-	, mMasterGenerator(nullptr)
 	, mCommunicator(utils::Singleton<communication::UsbRobotCommunicationThread>::instance())
 {
 	initActions();
@@ -179,21 +178,24 @@ void NxtOsekCGeneratorPlugin::onUploadingComplete(bool success)
 
 generatorBase::MasterGeneratorBase *NxtOsekCGeneratorPlugin::masterGenerator()
 {
-	mMasterGenerator = new NxtOsekCMasterGenerator(*mRepo
+	return new NxtOsekCMasterGenerator(*mRepo
 			, *mMainWindowInterface->errorReporter()
 			, *mParserErrorReporter
 			, *mRobotModelManager
 			, *mTextLanguage
 			, mMainWindowInterface->activeDiagram()
 			, generatorName());
-	return mMasterGenerator;
 }
 
 void NxtOsekCGeneratorPlugin::regenerateExtraFiles(const QFileInfo &newFileInfo)
 {
-	mMasterGenerator->initialize();
-	mMasterGenerator->setProjectDir(newFileInfo);
-	mMasterGenerator->generateOilAndMakeFiles();
+	// Static cast is possible and correct, but dynamic will be more flexible.
+	if (auto nxtGenerator = dynamic_cast<NxtOsekCMasterGenerator*>(masterGenerator())) {
+		QScopedPointer<NxtOsekCMasterGenerator> generator(nxtGenerator);
+		generator->initialize();
+		generator->setProjectDir(newFileInfo);
+		generator->generateOilAndMakeFiles();
+	}
 }
 
 void NxtOsekCGeneratorPlugin::flashRobot()

--- a/plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp
+++ b/plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp
@@ -190,7 +190,7 @@ generatorBase::MasterGeneratorBase *NxtOsekCGeneratorPlugin::masterGenerator()
 void NxtOsekCGeneratorPlugin::regenerateExtraFiles(const QFileInfo &newFileInfo)
 {
 	// Static cast is possible and correct, but dynamic will be more flexible.
-	if (auto nxtGenerator = dynamic_cast<NxtOsekCMasterGenerator*>(masterGenerator())) {
+	if (auto nxtGenerator = qobject_cast<NxtOsekCMasterGenerator*>(masterGenerator())) {
 		QScopedPointer<NxtOsekCMasterGenerator> generator(nxtGenerator);
 		generator->initialize();
 		generator->setProjectDir(newFileInfo);

--- a/plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.h
+++ b/plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.h
@@ -89,8 +89,6 @@ private:
 	bool mNxtToolsPresent { false };
 	/// Flasher object
 	QScopedPointer<NxtFlashTool> mFlashTool;
-
-	NxtOsekCMasterGenerator *mMasterGenerator;
 	const QSharedPointer<communication::UsbRobotCommunicationThread> mCommunicator;
 };
 

--- a/qrtranslations/fr/plugins/robots/nxtOsekCGenerator_fr.ts
+++ b/qrtranslations/fr/plugins/robots/nxtOsekCGenerator_fr.ts
@@ -165,13 +165,13 @@
         <translation>Génération (NXT OSEK C)</translation>
     </message>
     <message>
-        <location line="+52"/>
-        <location line="+129"/>
+        <location line="+51"/>
+        <location line="+132"/>
         <source>NXT tools package is not installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
+        <location line="-85"/>
         <source>Generate code</source>
         <translation>Générer le code</translation>
     </message>
@@ -196,7 +196,7 @@
         <translation>Téléverser le programme sur le dispositif NXT</translation>
     </message>
     <message>
-        <location line="+50"/>
+        <location line="+53"/>
         <source>flash.sh not found. Make sure it is present in QReal installation directory</source>
         <translation>flash.sh n&apos;est pas trouvé. Assurez-vous qu&apos;il soit présent dans le repertoire de  QReal</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/nxtOsekCGenerator_ru.ts
+++ b/qrtranslations/ru/plugins/robots/nxtOsekCGenerator_ru.ts
@@ -169,13 +169,13 @@
         <translation>Генерация (C)</translation>
     </message>
     <message>
-        <location line="+52"/>
-        <location line="+129"/>
+        <location line="+51"/>
+        <location line="+132"/>
         <source>NXT tools package is not installed</source>
         <translation>Пакет &quot;Инструменты NXT&quot; не установлен</translation>
     </message>
     <message>
-        <location line="-82"/>
+        <location line="-85"/>
         <source>Generate code</source>
         <translation>Генерировать код</translation>
     </message>
@@ -200,7 +200,7 @@
         <translation>Загрузить программу на устройство NXT</translation>
     </message>
     <message>
-        <location line="+50"/>
+        <location line="+53"/>
         <source>flash.sh not found. Make sure it is present in QReal installation directory</source>
         <translation>Не найден скрипт flash.sh. Убедитесь, что пакет nxt-tools установлен корректно</translation>
     </message>


### PR DESCRIPTION
When trying to save the source file generated for `NXT`, `TRIKStudio` crashes with `use heap after free`.
This solution is a workaround, as one needs to pass ownership of `NxtOsekCMasterGenerator` to the `NxtOsekCGeneratorPlugin` object, but this requires to rewrite RobotsGeneratorPluginBase (that leads to changes in behaviour in others kits)
