### PR TITLE
Add shortcut CTRL + I for load world model with robot

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp
@@ -30,6 +30,7 @@ ActionsBox::ActionsBox(QObject *parent)
 	, mDeleteAllAction(new QAction(QIcon(":/icons/2d_clear.png"), tr("Clear items"), this))
 	, mClearFloorAction(new QAction(QIcon(":/icons/2d_clear_floor.svg"), tr("Clear floor"), this))
 {
+	mLoadWorldModelAction->setShortcut(Qt::CTRL + Qt::Key_I);
 	mScrollHandModeAction->setCheckable(true);
 	mMultiSelectionModeAction->setCheckable(true);
 	mSceneModeActions.addAction(mScrollHandModeAction.data());


### PR DESCRIPTION
Upload a model of the world with a robot using the shortcut `CTRL + I`
Addresses https://github.com/trikset/trik-studio/issues/1826