### PR TITLE
Add support for NXT code generation in the 2D model

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -140,7 +140,7 @@ jobs:
     - name: Run minimal Python interpeter tests in direct script mode
       run: |
         PATH="" $SHELL -c 'for i in "$GITHUB_WORKSPACE"/tests/*.qrs; do "$TWOD_EXEC_NAME" --generate-path "$i".py \
-         --close -s 5 --script-path "$i".py -m script "$i"; done'
+          --generate-mode python --close -s 5 --script-path "$i".py -m script "$i"; done'
       timeout-minutes: 15
       
     - name: Run minimal Javascript interpeter tests as fields in .qrs (For backward compatibility)
@@ -153,4 +153,17 @@ jobs:
       run: |
         PATH="" $SHELL -c 'for i in "$GITHUB_WORKSPACE"/tests/*.qrs; do "$PATCHER_NAME" -s "$i".py "$i" \
          && "$TWOD_EXEC_NAME" --close -s 5 -m script "$i"; done'
+      timeout-minutes: 5
+
+    - name: Run nxt generation tests
+      run: |
+        curl --output nxt_tests.7z "https://dl.trikset.com/edu/.solutions20200701/nxt_generation.7z"
+        7z x nxt_tests.7z || 7za x nxt_tests.7z
+        set -x
+        for i in "$GITHUB_WORKSPACE"/nxt/*.qrs;
+        do
+          "$TWOD_EXEC_NAME" --generate-mode nxt --generate-path "$i".c --only-generate "$i"
+          ls "$GITHUB_WORKSPACE"/nxt/
+          cat "$i".c
+        done
       timeout-minutes: 5

--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -107,6 +107,12 @@ bool Runner::generate(const QString &generatePath, const QString &generateMode)
 				emit action.action()->triggered();
 			}
 		}
+		if (generateMode == "nxt") {
+			qDebug() << action.action()->objectName();
+			if (action.action()->objectName() == "generateCode") {
+				emit action.action()->triggered();
+			}
+		}
 	}
 
 	auto codes = mTextManager->code(mMainWindow->activeDiagram());

--- a/plugins/robots/checker/twoDModelRunner/runner.cpp
+++ b/plugins/robots/checker/twoDModelRunner/runner.cpp
@@ -108,7 +108,6 @@ bool Runner::generate(const QString &generatePath, const QString &generateMode)
 			}
 		}
 		if (generateMode == "nxt") {
-			qDebug() << action.action()->objectName();
 			if (action.action()->objectName() == "generateCode") {
 				emit action.action()->triggered();
 			}

--- a/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
@@ -92,7 +92,7 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+240"/>
+        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+239"/>
         <source>Robot console</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModelRunner_fr.ts
@@ -51,7 +51,12 @@ In background mode the session will be terminated just after the execution ended
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+3"/>
+        <source>Do not run the interpretation in any mode, this is a parameter that is only used to generate a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-6"/>
         <source>Select &quot;python&quot; or &quot;javascript&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -87,7 +92,7 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+234"/>
+        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+240"/>
         <source>Robot console</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
@@ -58,8 +58,12 @@ In background mode the session will be terminated just after the execution ended
     </message>
     <message>
         <location line="+3"/>
+        <source>Do not run the interpretation in any mode, this is a parameter that is only used to generate a file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Do not run the interpretation in any mode, this is a parameter used only to generate a file.</source>
-        <translation>Не запускайте интерпретацию ни в каком режиме, этот параметр используется только для генерации файла.</translation>
+        <translation type="vanished">Не запускайте интерпретацию ни в каком режиме, этот параметр используется только для генерации файла.</translation>
     </message>
     <message>
         <location line="-6"/>

--- a/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
@@ -98,7 +98,7 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+240"/>
+        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+239"/>
         <source>Robot console</source>
         <translation>Консоль робота</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModelRunner_ru.ts
@@ -57,7 +57,12 @@ In background mode the session will be terminated just after the execution ended
         <translation>Путь к Python или Javascript файлу, который будет использоваться для интерпретации.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+3"/>
+        <source>Do not run the interpretation in any mode, this is a parameter used only to generate a file.</source>
+        <translation>Не запускайте интерпретацию ни в каком режиме, этот параметр используется только для генерации файла.</translation>
+    </message>
+    <message>
+        <location line="-6"/>
         <source>Select &quot;python&quot; or &quot;javascript&quot;.</source>
         <translation>Выберите &quot;python&quot; или &quot;javascript&quot;.</translation>
     </message>
@@ -89,7 +94,7 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+234"/>
+        <location filename="../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+240"/>
         <source>Robot console</source>
         <translation>Консоль робота</translation>
     </message>


### PR DESCRIPTION
1. Use `JavaScript` as the default mode for executing files.
2. Add an option to generate the source code without further execution.
3. Add support for `NXT` code generation.

Closes #1877