### PR TITLE
Dont use deprecated function

### DIFF
--- a/qrutils/interpreter/thread.cpp
+++ b/qrutils/interpreter/thread.cpp
@@ -83,8 +83,8 @@ void Thread::initTimer()
 	connect(mProcessEventsTimer, SIGNAL(timeout())
 			, mProcessEventsMapper, SLOT(map()));
 
-	connect(mProcessEventsMapper, SIGNAL(mapped(QObject*))
-			, this, SLOT(interpretAfterEventsProcessing(QObject*)));
+	connect(mProcessEventsMapper, &QSignalMapper::mappedObject
+			, this, &Thread::interpretAfterEventsProcessing);
 }
 
 void Thread::interpret()


### PR DESCRIPTION
Possibly fixes crash with incorrectly handled state of the QSignalMapper in destruction https://doc.qt.io/Qt-5/qsignalmapper-obsolete.html