### PR TITLE
Fix a crash when uploading an xml field

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
@@ -74,9 +74,15 @@ bool ConstraintsChecker::parseConstraints(const QDomElement &constraintsXml)
 	mEvents.clear();
 	mActiveEvents.clear();
 	mVariables.clear();
-
-	mCurrentXml = constraintsXml;
 	mParsedSuccessfully = mParser->parse(constraintsXml);
+
+	if (mParsedSuccessfully) {
+		auto importNode = mCurrentConstraintDocument.importNode(constraintsXml, true);
+		if (!importNode.isNull()) {
+			mCurrentXml = importNode.toElement();
+			mCurrentConstraintDocument.appendChild(mCurrentXml);
+		}
+	}
 
 	for (const QString &error : mParser->errors()) {
 		reportParserError(error);

--- a/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.h
+++ b/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.h
@@ -136,6 +136,7 @@ private:
 
 	QList<details::Event *> mActiveEvents; //No ownership
 
+	QDomDocument mCurrentConstraintDocument;
 	QDomElement mCurrentXml;
 	bool mEnabled { true };
 };

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -288,7 +288,7 @@
 <context>
     <name>twoDModel::constraints::ConstraintsChecker</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+112"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+118"/>
         <source>Error while parsing constraints: %1</source>
         <translation>Une erreur lors de l&apos;analyse des contraints est survenue : %1</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -560,7 +560,7 @@
 <context>
     <name>twoDModel::constraints::ConstraintsChecker</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+112"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+118"/>
         <source>Error while parsing constraints: %1</source>
         <translation>Ошибка чтения ограничений: %1</translation>
     </message>


### PR DESCRIPTION
When trying to serialize xml field `constraints`, a crash occurs because a field of the `QDomElement` `mCurrentXml` class is used, which is bound to the main `QDomElement`, which is a local variable in lambda. This problem occurs only for `constraints`, since the rest of the xml entities are not bound to the underlying `QDomDocument` during deserialization.