### PR TITLE
Add explicit validation when using uninitialized variables

### DIFF
--- a/qrtext/src/lua/luaInterpreter.cpp
+++ b/qrtext/src/lua/luaInterpreter.cpp
@@ -123,7 +123,13 @@ QVariant LuaInterpreter::interpret(const QSharedPointer<core::ast::Node> &root
 		return QVariant();
 
 	} else if (root->is<ast::Identifier>()) {
-		return mIdentifierValues.value(as<ast::Identifier>(root)->name());
+		auto name = as<ast::Identifier>(root)->name();
+		auto value = mIdentifierValues.value(as<ast::Identifier>(root)->name());
+		if (value.isNull()) {
+			mErrors.append(core::Error(root->start(), QObject::tr("Seems like accessing an uninitialized variable %1").arg(name)
+					, core::ErrorType::runtimeError, core::Severity::error));
+		}
+		return value;
 	} else if (root->is<ast::FunctionCall>()) {
 		auto function = as<ast::FunctionCall>(root)->function();
 		auto name = as<ast::Identifier>(function)->name();

--- a/qrtext/src/lua/luaInterpreter.cpp
+++ b/qrtext/src/lua/luaInterpreter.cpp
@@ -125,8 +125,9 @@ QVariant LuaInterpreter::interpret(const QSharedPointer<core::ast::Node> &root
 	} else if (root->is<ast::Identifier>()) {
 		auto name = as<ast::Identifier>(root)->name();
 		auto value = mIdentifierValues.value(as<ast::Identifier>(root)->name());
-		if (value.isNull()) {
-			mErrors.append(core::Error(root->start(), QObject::tr("Seems like accessing an uninitialized variable %1").arg(name)
+		if (!value.isValid()) {
+			mErrors.append(core::Error(root->start(),
+					QObject::tr("Seems like accessing an uninitialized variable %1").arg(name)
 					, core::ErrorType::runtimeError, core::Severity::error));
 		}
 		return value;

--- a/qrtranslations/fr/qrtext_fr.ts
+++ b/qrtranslations/fr/qrtext_fr.ts
@@ -93,12 +93,17 @@
     </message>
     <message>
         <location line="+12"/>
-        <location line="+32"/>
+        <location line="+38"/>
         <source>This construction is not supported by interpreter</source>
         <translation>Cette construction n&apos;est pas supportée par l&apos;interpréteur</translation>
     </message>
     <message>
-        <location line="+105"/>
+        <location line="-28"/>
+        <source>Seems like accessing an uninitialized variable %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+133"/>
         <location line="+10"/>
         <location line="+13"/>
         <source>Division by zero</source>

--- a/qrtranslations/fr/qrtext_fr.ts
+++ b/qrtranslations/fr/qrtext_fr.ts
@@ -93,7 +93,7 @@
     </message>
     <message>
         <location line="+12"/>
-        <location line="+38"/>
+        <location line="+39"/>
         <source>This construction is not supported by interpreter</source>
         <translation>Cette construction n&apos;est pas supportée par l&apos;interpréteur</translation>
     </message>

--- a/qrtranslations/ru/qrtext_ru.ts
+++ b/qrtranslations/ru/qrtext_ru.ts
@@ -63,7 +63,7 @@
         <translation>Несоответствие типов.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="+416"/>
+        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="+417"/>
         <source>Explicit table indexes of non-integer type are not supported</source>
         <translation>Явное указание индексов нечисловых типов в таблицах не поддержано</translation>
     </message>
@@ -72,14 +72,14 @@
         <translation type="vanished">Эта переменная только для чтения</translation>
     </message>
     <message>
-        <location line="-309"/>
+        <location line="-310"/>
         <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="+378"/>
         <source>Variable %1 is read-only</source>
         <translation>Переменная %1 только для чтения</translation>
     </message>
     <message>
         <location line="+12"/>
-        <location line="+38"/>
+        <location line="+39"/>
         <source>This construction is not supported by interpreter</source>
         <translation>Конструкция не поддерживается интерпретатором</translation>
     </message>

--- a/qrtranslations/ru/qrtext_ru.ts
+++ b/qrtranslations/ru/qrtext_ru.ts
@@ -63,7 +63,7 @@
         <translation>Несоответствие типов.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="+410"/>
+        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="+416"/>
         <source>Explicit table indexes of non-integer type are not supported</source>
         <translation>Явное указание индексов нечисловых типов в таблицах не поддержано</translation>
     </message>
@@ -72,19 +72,24 @@
         <translation type="vanished">Эта переменная только для чтения</translation>
     </message>
     <message>
-        <location line="-303"/>
+        <location line="-309"/>
         <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="+378"/>
         <source>Variable %1 is read-only</source>
         <translation>Переменная %1 только для чтения</translation>
     </message>
     <message>
         <location line="+12"/>
-        <location line="+32"/>
+        <location line="+38"/>
         <source>This construction is not supported by interpreter</source>
         <translation>Конструкция не поддерживается интерпретатором</translation>
     </message>
     <message>
-        <location line="+202"/>
+        <location line="-28"/>
+        <source>Seems like accessing an uninitialized variable %1</source>
+        <translation>Обращение к неинициализированной переменной %1</translation>
+    </message>
+    <message>
+        <location line="+230"/>
         <source>Currently interpreter allows only tables denoted by identifier and by integer expression index, as in &apos;a[1 + 2][3]&apos;</source>
         <translation>Сейчас интерпретатор поддерживает именованные таблицы с целочисленным выражением в качестве индекса, например, &apos;a[1 + 2][3]&apos;</translation>
     </message>


### PR DESCRIPTION
The `mIdentifierValues` container contains the names of variables that change in two cases:
1. These are pre-reserved variables (for example, for reading sensor readings or the `PI` number)
2. During the `AST` traverse, the `Assignment` operator was discovered.

At the time of using the variable (`ast::Identifier`), it is suggested to explicitly check the received `QVariant` for the presence of a value.