### PR TITLE
Clazy support

### DIFF
--- a/.github/workflows/common_build.yml
+++ b/.github/workflows/common_build.yml
@@ -40,7 +40,7 @@ jobs:
     uses: ./.github/workflows/setup_environment.yml
     with:
       os: ubuntu-latest
-      lint: true
+      lint_vera: true
       build: false
       build_installer: false
 
@@ -93,6 +93,7 @@ jobs:
       build_installer: false
       qmake_extra: "CONFIG+=tests CONFIG+=noPch CONFIG+=ccache CONFIG+=no-sanitizers CONFIG+=use_system_qscintilla2 CONFIG+=use_system_quazip"
       trik_python3_version_minor: 10
+      lint_clazy: true
 
   build-ubuntu-debug-tests:
     needs: lint

--- a/.github/workflows/setup_environment.yml
+++ b/.github/workflows/setup_environment.yml
@@ -179,6 +179,7 @@ jobs:
         checks: 'level0,level1,no-connect-by-name,no-non-pod-global-static'
         database: '.'
         install-stable: true
+        ignore-dirs: '^(buildScripts|thirdparty|installer)$'
       if: ${{ inputs.lint_clazy }}
 
     - name: Build Installer

--- a/.github/workflows/setup_environment.yml
+++ b/.github/workflows/setup_environment.yml
@@ -174,10 +174,11 @@ jobs:
       if: ${{ inputs.build == true }}
 
     - name: Clazy-standalone
-      uses: MinyazevR/clazy-standalone-action@v0.2.1
+      uses: MinyazevR/clazy-standalone-action@v0.3.2
       with:
         checks: 'level0,level1,level2'
-        database: '.'
+        database: './compile_commands.json'
+        fail-on-warning: true
         install-stable: true
         only-diff: true
         ignore-dirs: '^(buildScripts|thirdparty|installer)$'

--- a/.github/workflows/setup_environment.yml
+++ b/.github/workflows/setup_environment.yml
@@ -10,7 +10,11 @@ on:
         required: false
         type: string
         default: "time"
-      lint:
+      lint_vera:
+        required: false
+        type: boolean
+        default: false
+      lint_clazy:
         required: false
         type: boolean
         default: false
@@ -124,11 +128,11 @@ jobs:
         INSTALL_INSTALLER_ENVIRONMENT: ${{ inputs.linux_installer_environment }}
       if: ${{ inputs.build }}
       
-    - name: Lint
+    - name: Lint Vera
       run: |
           sudo apt-get update && sudo apt-get install -y --no-install-recommends qttools5-dev-tools qtbase5-dev vera++ 
           ${{ inputs.executor }} buildScripts/github/vera_translation.sh
-      if: ${{ inputs.lint }}
+      if: ${{ inputs.lint_vera }}
 
     - name: Restore cache
       uses: actions/cache@v4
@@ -152,6 +156,7 @@ jobs:
         CONFIG: ${{ inputs.config }}
         EXECUTOR: ${{ inputs.executor }}
         QMAKE_EXTRA: ${{ inputs.qmake_extra }}
+        NEED_COMPILE_DATABASE: ${{ inputs.lint_clazy }}
       if: ${{ inputs.build }}
 
     - name: Save build cache
@@ -167,6 +172,14 @@ jobs:
         TRIK_PYTHON3_VERSION_MINOR: ${{ inputs.trik_python3_version_minor }}
         TESTS: ${{ inputs.tests }}
       if: ${{ inputs.build == true }}
+
+    - name: Clazy-standalone
+      uses: MinyazevR/clazy-standalone-action@v0.2.1
+      with:
+        checks: 'level0,level1,no-connect-by-name,no-non-pod-global-static'
+        database: '.'
+        install-stable: true
+      if: ${{ inputs.lint_clazy }}
 
     - name: Build Installer
       run: |

--- a/.github/workflows/setup_environment.yml
+++ b/.github/workflows/setup_environment.yml
@@ -103,7 +103,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-depth: 2
 
     - name: Remove thirdparty submodules (use from libs from distro)
       run: |
@@ -176,9 +176,10 @@ jobs:
     - name: Clazy-standalone
       uses: MinyazevR/clazy-standalone-action@v0.2.1
       with:
-        checks: 'level0,level1,no-connect-by-name,no-non-pod-global-static'
+        checks: 'level0,level1,level2'
         database: '.'
         install-stable: true
+        only-diff: true
         ignore-dirs: '^(buildScripts|thirdparty|installer)$'
       if: ${{ inputs.lint_clazy }}
 

--- a/buildScripts/github/build_internal.sh
+++ b/buildScripts/github/build_internal.sh
@@ -15,6 +15,10 @@ rm -f .qmake.cache
 qmake -Wall PYTHON_VERSION=3.$TRIK_PYTHON3_VERSION_MINOR PYTHON_PATH=/usr CONFIG+=$CONFIG $QMAKE_EXTRA $PROJECT.pro
 make -j $(nproc) qmake_all 2>&1 | tee -a build.log
 ccache -s
-make -j $(nproc) all 2>&1 | tee -a build.log
+if [ "$NEED_COMPILE_DATABASE" = "true" ]; then
+  bear -- make -j $(nproc) all 2>&1 | tee -a build.log
+else
+  make -j $(nproc) all 2>&1 | tee -a build.log
+fi
 ccache -s
 ls bin

--- a/buildScripts/github/install.sh
+++ b/buildScripts/github/install.sh
@@ -53,7 +53,7 @@ case "$(uname)" in
     elif [ "$ID" = "ubuntu" ]; then
       sudo apt-get update && sudo apt-get install -y --no-install-recommends ccache curl libusb-1.0-0-dev \
       make qtscript5-dev qttools5-dev-tools qtmultimedia5-dev libqt5serialport5-dev libqt5svg5-dev \
-      libudev-dev "$TRIK_PYTHON"-dev qtbase5-private-dev qtwayland5 libqscintilla2-qt5-dev libquazip5-dev
+      libudev-dev "$TRIK_PYTHON"-dev qtbase5-private-dev qtwayland5 libqscintilla2-qt5-dev libquazip5-dev bear
     elif [[ "$ID" = "rocky" || "$ID" = '"rocky"' ]]; then
       GCC_VERSION=${GCC_VERSION:-13}
       sudo yum update -y &&  sudo yum install -y --setopt=install_weak_deps=False epel-release


### PR DESCRIPTION
Closes #39
Testing the integration of the `Clazy` static analyzer into your project.
The code base is too large, and there will be many errors and warnings, so the following plan was adopted:
1. Only the source files that were modified during the `PR` and the files they depend on (headers) are run.
2. It is suggested to start with enabling absolutely all checks (`level0,level1,level2`) and interpreting any warning as an error. If necessary, after writing another pull request, it will be possible to disable some checks globally or mark it in a specific `cpp` file.
3. If you are satisfied with the current changes, roll back to one commit, which is a demonstration of the work, and `CI` should fail