### PR TITLE
Make the rotation angle calculation function continuous

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp
@@ -78,8 +78,17 @@ qreal Box2DPhysicsEngine::rotation(model::RobotModel &robot) const
 		return 0;
 	}
 
-	auto angle = b2Rot_GetAngle(b2Body_GetRotation(mBox2DRobots[&robot]->getBodyId()));
-	return angleToScene(angle - mPrevAngle);
+	auto currentAngle = b2Rot_GetAngle(b2Body_GetRotation(mBox2DRobots[&robot]->getBodyId()));
+	qreal deltaAngle = currentAngle - mPrevAngle;
+
+	const qreal epsilon = 1e-6;
+
+	if (deltaAngle > mathUtils::pi + epsilon) {
+	    deltaAngle -= 2 * mathUtils::pi;
+	} else if (deltaAngle < -mathUtils::pi - epsilon) {
+	    deltaAngle += 2 * mathUtils::pi;
+	}
+	return angleToScene(deltaAngle);
 }
 
 void Box2DPhysicsEngine::onPressedReleasedSelectedItems(bool active)

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DRobot.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DRobot.cpp
@@ -154,7 +154,7 @@ void Box2DRobot::setRotation(float angle)
 		b2Body_GetJoints(wheelBodyId, joints.data(), 1);
 		auto position = b2Joint_GetLocalFrameB(joints[0]);
 		auto point = b2Body_GetWorldPoint(b2Joint_GetBodyB(joints[0]), position.p);
-		b2Body_SetTransform(wheelBodyId, point , rotation);
+		b2Body_SetTransform(wheelBodyId, point, rotation);
 	}
 
 	reinitSensors();


### PR DESCRIPTION
The old `box2D` `GetAngle` allowed you to work with angles from a wide range, while `b2Rot_GetAngle` returns values from the [-pi, pi] range, which makes the function intermittent when it exits the range, meaning that the angle difference between two frames can be as large as `2pi`.