### PR TITLE
Validate polygon before creating box2D object

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.cpp
@@ -62,6 +62,9 @@ Box2DItem::Box2DItem(twoDModel::model::physics::Box2DPhysicsEngine *engine
 		}
 
 		b2Hull hull = b2ComputeHull(mPolygon, collidingPolygon.size());
+		if (!b2ValidateHull(&hull)) {
+			return;
+		}
 		polygonShape = b2MakePolygon(&hull, 0.0f);
 		fixtureDef.density = engine->computeDensity(collidingPolygon, item->mass());
 	}


### PR DESCRIPTION
Although [PR](https://github.com/trikset/trik-studio/pull/1962) is correct, it has side effects that were not found in the tests. When using a `2D model` in the `UI`, many objects have a fixed size, and some support resize. For example, when a `wall` is resized, the `2D object` is recreated. However, when the user initially drags the wall object (before it is extended in the resize), a very small wall fragment is already created (`TwoDModelScene::mousePressEvent`), which has negative consequences when calculating the polygon. It is proposed to filter out such polygons.