### PR TITLE
Add CubeItem

### DIFF
--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/model/worldModel.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/model/worldModel.h
@@ -41,6 +41,7 @@ class ColorFieldItem;
 class ImageItem;
 class RegionItem;
 class CommentItem;
+class CubeItem;
 }
 
 namespace model {
@@ -86,6 +87,9 @@ public:
 	/// Returns a set of balls in the world model. Result is mapping of ball ids to balls themselves.
 	const QMap<QString, QSharedPointer<items::BallItem>> &balls() const;
 
+	/// Returns a set of cubes in the world model. Result is mapping of cube ids to cubes themselves.
+	const QMap<QString, QSharedPointer<items::CubeItem>> &cubes() const;
+
 	/// Returns a set of color field items in the world model. Result is mapping of field ids to fields themselves.
 	const QMap<QString, QSharedPointer<items::ColorFieldItem>> &colorFields() const;
 
@@ -118,6 +122,12 @@ public:
 
 	/// Removes \a ball from the world model.
 	void removeBall(QSharedPointer<items::BallItem> ball);
+
+	/// Appends \a cube into world model.
+	void addCube(const QSharedPointer<items::CubeItem> &cube);
+
+	/// Removes \a cube from the world model.
+	void removeCube(QSharedPointer<items::CubeItem> cube);
 
 	/// Appends \a comment into world model.
 	void addComment(const QSharedPointer<items::CommentItem> &comment);
@@ -179,6 +189,9 @@ public:
 	/// Creates ball item described by \a element in the world model.
 	void createBall(const QDomElement &element);
 
+	/// Creates cube item described by \a element in the world model.
+	void createCube(const QDomElement &element);
+
 	/// Creates line colored item described by \a element in the world model.
 	void createLine(const QDomElement &element);
 
@@ -216,8 +229,11 @@ signals:
 	/// Emitted each time when model is appended with some new skittle.
 	void skittleAdded(const QSharedPointer<items::SkittleItem> &item);
 
-	/// Emitted each time when model is appended with some new skittle.
+	/// Emitted each time when model is appended with some new ball.
 	void ballAdded(const QSharedPointer<items::BallItem> &item);
+
+	/// Emitted each time when model is appended with some new cube.
+	void cubeAdded(const QSharedPointer<items::CubeItem> &item);
 
 	/// Emitted each time when model is appended with some new color field item.
 	void commentAdded(const QSharedPointer<items::CommentItem> &item);
@@ -258,6 +274,7 @@ private:
 	QMap<QString, QSharedPointer<items::WallItem>> mWalls;
 	QMap<QString, QSharedPointer<items::SkittleItem>> mSkittles;
 	QMap<QString, QSharedPointer<items::BallItem>> mBalls;
+	QMap<QString, QSharedPointer<items::CubeItem>> mCubes;
 	QMap<QString, QSharedPointer<items::ColorFieldItem>> mColorFields;
 	QMap<QString, QSharedPointer<items::ImageItem>> mImageItems;
 	QMap<QString, QSharedPointer<items::RegionItem>> mRegions;

--- a/plugins/robots/common/twoDModel/include/twoDModel/engine/view/twoDModelWidget.h
+++ b/plugins/robots/common/twoDModel/include/twoDModel/engine/view/twoDModelWidget.h
@@ -182,6 +182,7 @@ private:
 		, drawWall
 		, drawSkittle
 		, drawBall
+		, drawCube
 		, drawLine
 		, drawStylus
 		, drawEllipse

--- a/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
@@ -24,6 +24,7 @@
 #include "src/engine/items/wallItem.h"
 #include "src/engine/items/skittleItem.h"
 #include "src/engine/items/ballItem.h"
+#include "src/engine/items/cubeItem.h"
 #include "src/engine/items/colorFieldItem.h"
 #include "src/engine/items/regions/regionItem.h"
 
@@ -168,7 +169,8 @@ void ConstraintsChecker::bindToWorldModelObjects()
 			, this, [this](const QSharedPointer<items::SkittleItem> &item) { bindObject(item->id(), item.data()); });
 	connect(&mModel.worldModel(), &model::WorldModel::ballAdded
 			, this, [this](const QSharedPointer<items::BallItem> &item) { bindObject(item->id(), item.data()); });
-
+	connect(&mModel.worldModel(), &model::WorldModel::cubeAdded
+			, this, [this](const QSharedPointer<items::CubeItem> &item) { bindObject(item->id(), item.data()); });
 	connect(&mModel.worldModel(), &model::WorldModel::itemRemoved
 			, this, [this](const QSharedPointer<QGraphicsItem> &item) {
 		for (const QString &key : mObjects.keys(dynamic_cast<QObject*>(item.data()))) {

--- a/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp
@@ -286,7 +286,7 @@ void ConstraintsChecker::programStarted()
 		}
 
 		const QString robotId = robotIds[0];
-		for (kitBase::robotModel::robotParts::Device * const device : robot->info().configuration().devices()) {
+		for (auto &&device : robot->info().configuration().devices()) {
 			bindDeviceObject(robotId, robot, device->port());
 		}
 	}

--- a/plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp
@@ -65,7 +65,6 @@ void CubeItem::drawItem(QPainter *painter, const QStyleOptionGraphicsItem *optio
 	Q_UNUSED(widget)
 	mSvgRenderer->render(painter,
 		graphicsUtils::RectangleImpl::calcRect(x1(), y1(), x2(), y2()));
-
 }
 
 void CubeItem::setPenBrushForExtraction(QPainter *painter, const QStyleOptionGraphicsItem *option)

--- a/plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp
@@ -48,7 +48,7 @@ CubeItem::~CubeItem()
 
 QAction *CubeItem::cubeTool()
 {
-	QAction * const result = new QAction(QIcon(":/icons/2d_cube.svg"), tr("Cube (X)"), nullptr);
+	const auto &result = new QAction(QIcon(":/icons/2d_cube.svg"), tr("Cube (X)"), nullptr);
 	result->setShortcuts({QKeySequence(Qt::Key_X), QKeySequence(Qt::Key_4)});
 	result->setCheckable(true);
 	return result;
@@ -92,31 +92,31 @@ void CubeItem::savePos()
 
 QDomElement CubeItem::serialize(QDomElement &element) const
 {
-	QDomElement ballNode = AbstractItem::serialize(element);
-	auto *coordSystem = coordinateSystem();
-	ballNode.setTagName("cube");
-	ballNode.setAttribute("x",
+	QDomElement cubeNode = AbstractItem::serialize(element);
+	const auto &coordSystem = coordinateSystem();
+	cubeNode.setTagName("cube");
+	cubeNode.setAttribute("x",
 			      QString::number(coordSystem->toUnit(x1() + scenePos().x())));
-	ballNode.setAttribute("y",
+	cubeNode.setAttribute("y",
 			      QString::number(coordSystem->toUnit(y1() + scenePos().y())));
-	ballNode.setAttribute("markerX",
+	cubeNode.setAttribute("markerX",
 			      QString::number(coordSystem->toUnit(x1() + mStartPosition.x())));
-	ballNode.setAttribute("markerY",
+	cubeNode.setAttribute("markerY",
 			      QString::number(coordSystem->toUnit(y1() + mStartPosition.y())));
-	ballNode.setAttribute("rotation", QString::number(rotation()));
-	ballNode.setAttribute("startRotation", QString::number(mStartRotation));
-	return ballNode;
+	cubeNode.setAttribute("rotation", QString::number(rotation()));
+	cubeNode.setAttribute("startRotation", QString::number(mStartRotation));
+	return cubeNode;
 }
 
 void CubeItem::deserialize(const QDomElement &element)
 {
 	AbstractItem::deserialize(element);
-	auto *coordSystem = coordinateSystem();
-	qreal x = coordSystem->toPx(element.attribute("x", "0").toDouble());
-	qreal y = coordSystem->toPx(element.attribute("y", "0").toDouble());
-	qreal markerX = coordSystem->toPx(element.attribute("markerX", "0").toDouble());
-	qreal markerY = coordSystem->toPx(element.attribute("markerY", "0").toDouble());
-	qreal rotation = element.attribute("rotation", "0").toDouble();
+	const auto &coordSystem = coordinateSystem();
+	const auto x = coordSystem->toPx(element.attribute("x", "0").toDouble());
+	const auto y = coordSystem->toPx(element.attribute("y", "0").toDouble());
+	const auto markerX = coordSystem->toPx(element.attribute("markerX", "0").toDouble());
+	const auto markerY = coordSystem->toPx(element.attribute("markerY", "0").toDouble());
+	const auto rotation = element.attribute("rotation", "0").toDouble();
 	mStartRotation = element.attribute("startRotation", "0").toDouble();
 
 	setPos(QPointF(x, y));

--- a/plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp
@@ -1,0 +1,184 @@
+/* Copyright 2025 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "cubeItem.h"
+
+#include <QtGui/QIcon>
+#include <QtWidgets/QAction>
+#include <QtSvg/QSvgRenderer>
+
+using namespace twoDModel::items;
+
+CubeItem::CubeItem(const QPointF &position)
+	: mSvgRenderer(new QSvgRenderer)
+{
+	mSvgRenderer->load(QString(":/icons/2d_ball.svg"));
+	setPos(position);
+	setZValue(ZValue::Moveable);
+	setTransformOriginPoint(boundingRect().center());
+}
+
+BallItem::~BallItem()
+{
+	delete mSvgRenderer;
+}
+
+QAction *BallItem::ballTool()
+{
+	QAction * const result = new QAction(QIcon(":/icons/2d_ball.svg"), tr("Ball (B)"), nullptr);
+	result->setShortcuts({QKeySequence(Qt::Key_B), QKeySequence(Qt::Key_4)});
+	result->setCheckable(true);
+	return result;
+}
+
+QRectF BallItem::boundingRect() const
+{
+	return QRectF({-static_cast<qreal>(ballSize.width() / 2.0), -static_cast<qreal>(ballSize.height() / 2.0)}
+				  , ballSize);
+}
+
+void BallItem::drawItem(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+{
+	Q_UNUSED(option)
+	Q_UNUSED(widget)
+	mSvgRenderer->render(painter, boundingRect());
+}
+
+void BallItem::setPenBrushForExtraction(QPainter *painter, const QStyleOptionGraphicsItem *option)
+{
+	Q_UNUSED(option)
+	painter->setPen(getStrokePen());
+	if (isSelected()) {
+		QColor extraColor = getStrokePen().color();
+		extraColor.setAlphaF(0.5);
+		painter->setBrush(extraColor);
+	}
+}
+
+void BallItem::drawExtractionForItem(QPainter *painter)
+{
+	painter->drawEllipse(boundingRect());
+}
+
+void BallItem::savePos()
+{
+	saveStartPosition();
+	AbstractItem::savePos();
+}
+
+QDomElement BallItem::serialize(QDomElement &element) const
+{
+	QDomElement ballNode = AbstractItem::serialize(element);
+	ballNode.setTagName("ball");
+	ballNode.setAttribute("x", QString::number(x1() + scenePos().x()));
+	ballNode.setAttribute("y", QString::number(y1() + scenePos().y()));
+	ballNode.setAttribute("markerX", QString::number(x1() + mStartPosition.x()));
+	ballNode.setAttribute("markerY", QString::number(y1() + mStartPosition.y()));
+	ballNode.setAttribute("rotation", QString::number(rotation()));
+	ballNode.setAttribute("startRotation", QString::number(mStartRotation));
+	return ballNode;
+}
+
+void BallItem::deserialize(const QDomElement &element)
+{
+	AbstractItem::deserialize(element);
+
+	qreal x = element.attribute("x", "0").toDouble();
+	qreal y = element.attribute("y", "0").toDouble();
+	qreal markerX = element.attribute("markerX", "0").toDouble();
+	qreal markerY = element.attribute("markerY", "0").toDouble();
+	qreal rotation = element.attribute("rotation", "0").toDouble();
+	mStartRotation = element.attribute("startRotation", "0").toDouble();
+
+	setPos(QPointF(x, y));
+	setTransformOriginPoint(boundingRect().center());
+	mStartPosition = {markerX, markerY};
+	setRotation(rotation);
+	emit x1Changed(x1());
+}
+
+QPainterPath BallItem::shape() const
+{
+	QPainterPath result;
+	result.addEllipse(boundingRect());
+	return result;
+}
+
+void BallItem::saveStartPosition()
+{
+	if (this->editable()) {
+		mStartPosition = pos();
+		mStartRotation = rotation();
+		emit x1Changed(x1());
+	}
+}
+
+void BallItem::returnToStartPosition()
+{
+	setPos(mStartPosition);
+	setRotation(mStartRotation);
+	emit x1Changed(x1());
+}
+
+QPolygonF BallItem::collidingPolygon() const
+{
+	return QPolygonF(boundingRect().adjusted(1, 1, -1, -1).translated(scenePos()));
+}
+
+qreal BallItem::angularDamping() const
+{
+	return 0.09f;
+}
+
+qreal BallItem::linearDamping() const
+{
+	return 0.09f;
+}
+
+QPainterPath BallItem::path() const
+{
+	QPainterPath path;
+	QPolygonF collidingPlgn = collidingPolygon();
+	QMatrix m;
+	m.rotate(rotation());
+
+	QPointF firstP = collidingPlgn.at(0);
+	collidingPlgn.translate(-firstP.x(), -firstP.y());
+
+	path.addEllipse(collidingPlgn.boundingRect());
+	path = m.map(path);
+	path.translate(firstP.x(), firstP.y());
+
+	return path;
+}
+
+bool BallItem::isCircle() const
+{
+	return true;
+}
+
+qreal BallItem::mass() const
+{
+	return 0.015f;
+}
+
+qreal BallItem::friction() const
+{
+	return 1.0f;
+}
+
+SolidItem::BodyType BallItem::bodyType() const
+{
+	return SolidItem::DYNAMIC;
+}

--- a/plugins/robots/common/twoDModel/src/engine/items/cubeItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/items/cubeItem.h
@@ -1,0 +1,73 @@
+/* Copyright 20w5 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include <qrutils/graphicsUtils/rotateItem.h>
+
+#include "src/engine/items/solidItem.h"
+
+class QSvgRenderer;
+
+namespace twoDModel {
+namespace items {
+
+class CubeItem : public graphicsUtils::RotateItem, public SolidItem
+{
+	Q_OBJECT
+	Q_DISABLE_COPY(CubeItem)
+
+public:
+	explicit CubeItem(const QPointF &position);
+	~CubeItem();
+
+	/// Creates and returns ball item for 2D model palette.
+	/// Transfers ownership.
+	static QAction *cubeTool();
+
+	QRectF boundingRect() const override;
+	void drawItem(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+	void drawExtractionForItem(QPainter *painter) override;
+	void setPenBrushForExtraction(QPainter *painter, const QStyleOptionGraphicsItem *option) override;
+
+	void drawFieldForResizeItem(QPainter* painter) override { Q_UNUSED(painter) }
+	void resizeItem(QGraphicsSceneMouseEvent *event) override { Q_UNUSED(event) }
+	void savePos() override;
+
+	QDomElement serialize(QDomElement &element) const override;
+	void deserialize(const QDomElement &element) override;
+
+	void saveStartPosition();
+	void returnToStartPosition();
+
+	bool isCircle() const override;
+	qreal mass() const override;
+	BodyType bodyType() const override;
+	qreal friction() const override;
+	QPolygonF collidingPolygon() const override;
+	qreal angularDamping() const override;
+	qreal linearDamping() const override;
+	QPainterPath shape () const override;
+
+	QPainterPath path() const;
+
+private:
+	QPointF mStartPosition;
+	qreal mStartRotation {0.0};
+
+	QSvgRenderer *mSvgRenderer;
+};
+
+}
+}

--- a/plugins/robots/common/twoDModel/src/engine/items/cubeItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/items/cubeItem.h
@@ -33,7 +33,7 @@ public:
 			  QPointF position);
 	~CubeItem();
 
-	/// Creates and returns ball item for 2D model palette.
+	/// Creates and returns cube item for 2D model palette.
 	/// Transfers ownership.
 	static QAction *cubeTool();
 

--- a/plugins/robots/common/twoDModel/src/engine/items/cubeItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/items/cubeItem.h
@@ -56,6 +56,7 @@ public:
 	qreal mass() const override;
 	BodyType bodyType() const override;
 	qreal friction() const override;
+	qreal restitution() const override;
 	QPolygonF collidingPolygon() const override;
 	qreal angularDamping() const override;
 	qreal linearDamping() const override;
@@ -64,10 +65,17 @@ public:
 	QPainterPath path() const;
 
 private:
+	void setEdgeSize(const qreal size);
 	QPointF mStartPosition;
 	qreal mStartRotation {0.0};
 
 	QSvgRenderer *mSvgRenderer;
+	qreal mEdgeSizePx;
+	qreal mMass;
+	qreal mFriction;
+	qreal mRestitution;
+	qreal mAngularDamping;
+	qreal mLinearDamping;
 };
 
 }

--- a/plugins/robots/common/twoDModel/src/engine/items/cubeItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/items/cubeItem.h
@@ -1,4 +1,4 @@
-/* Copyright 20w5 CyberTech Labs Ltd.
+/* Copyright 2025 CyberTech Labs Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,8 @@ class CubeItem : public graphicsUtils::RotateItem, public SolidItem
 	Q_DISABLE_COPY(CubeItem)
 
 public:
-	explicit CubeItem(const QPointF &position);
+	explicit CubeItem(graphicsUtils::AbstractCoordinateSystem *metricSystem,
+			  QPointF position);
 	~CubeItem();
 
 	/// Creates and returns ball item for 2D model palette.

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/box2DPhysicsEngine.cpp
@@ -25,6 +25,7 @@
 #include "src/engine/items/wallItem.h"
 #include "src/engine/items/skittleItem.h"
 #include "src/engine/items/ballItem.h"
+#include "src/engine/items/cubeItem.h"
 #include "src/engine/items/startPosition.h"
 #include "qrutils/mathUtils/math.h"
 #include "parts/box2DWheel.h"
@@ -50,6 +51,8 @@ Box2DPhysicsEngine::Box2DPhysicsEngine (const WorldModel &worldModel
 	connect(&worldModel, &model::WorldModel::skittleAdded,
 			this, [this](const QSharedPointer<QGraphicsItem> &i) {itemAdded(i.data());});
 	connect(&worldModel, &model::WorldModel::ballAdded,
+			this, [this](const QSharedPointer<QGraphicsItem> &i) {itemAdded(i.data());});
+	connect(&worldModel, &model::WorldModel::cubeAdded,
 			this, [this](const QSharedPointer<QGraphicsItem> &i) {itemAdded(i.data());});
 	connect(&worldModel, &model::WorldModel::itemRemoved,
 			this, [this](const QSharedPointer<QGraphicsItem> &i) {itemRemoved(i.data());});

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.cpp
@@ -87,7 +87,7 @@ Box2DItem::~Box2DItem()
 	}
 }
 
-void Box2DItem::moveToPosition(const b2Vec2 &pos)
+void Box2DItem::moveToPosition(b2Vec2 pos)
 {
 	b2Body_SetTransform(mBodyId, pos, b2Body_GetRotation(mBodyId));
 	mPreviousPosition = b2Body_GetPosition(mBodyId);

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.cpp
@@ -28,6 +28,9 @@ Box2DItem::Box2DItem(twoDModel::model::physics::Box2DPhysicsEngine *engine
 	b2BodyDef bodyDef = b2DefaultBodyDef();
 	bodyDef.position = pos;
 	bodyDef.rotation = b2MakeRot(angle);
+	bodyDef.angularDamping = item->angularDamping();
+	bodyDef.linearDamping = item->linearDamping();
+
 	if (item->bodyType() == SolidItem::DYNAMIC) {
 		bodyDef.type = b2_dynamicBody;
 	} else if (item->bodyType() == SolidItem::KINEMATIC) {
@@ -38,8 +41,6 @@ Box2DItem::Box2DItem(twoDModel::model::physics::Box2DPhysicsEngine *engine
 
 	auto worldId = this->mEngine.box2DWorldId();
 	mBodyId = b2CreateBody(worldId, &bodyDef);
-	b2Body_SetAngularDamping(mBodyId, item->angularDamping());
-	b2Body_SetLinearDamping(mBodyId, item->linearDamping());
 	b2ShapeDef fixtureDef = b2DefaultShapeDef();
 	fixtureDef.material.restitution = 0.8f;
 	QPolygonF collidingPolygon = item->collidingPolygon();

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.cpp
@@ -21,7 +21,7 @@ using namespace twoDModel::items;
 using namespace parts;
 
 Box2DItem::Box2DItem(twoDModel::model::physics::Box2DPhysicsEngine *engine
-		, const SolidItem *item, const b2Vec2 &pos, float angle)
+		, const SolidItem *item, b2Vec2 pos, float angle)
 	: mIsCircle(false)
 	, mEngine(*engine)
 {

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.h
@@ -33,7 +33,7 @@ class Box2DItem
 {
 public:
 	Box2DItem(twoDModel::model::physics::Box2DPhysicsEngine *mEngine
-			, const items::SolidItem *mItem, const b2Vec2 &pos, float angle);
+			, const items::SolidItem *mItem, b2Vec2 pos, float angle);
 
 	~Box2DItem();
 

--- a/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.h
+++ b/plugins/robots/common/twoDModel/src/engine/model/physics/parts/box2DItem.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include <box2d/box2d.h>
-
+#include <QObject>
 class QPolygonF;
 
 namespace twoDModel{
@@ -31,14 +31,15 @@ namespace parts {
 
 class Box2DItem
 {
+	Q_DISABLE_COPY(Box2DItem)
 public:
 	Box2DItem(twoDModel::model::physics::Box2DPhysicsEngine *mEngine
 			, const items::SolidItem *mItem, b2Vec2 pos, float angle);
 
 	~Box2DItem();
 
-	/// Transform item to a new position, IMPORTANT: \a pos is a center point of box2d object.
-	void moveToPosition(const b2Vec2 &pos);
+	/// Transform item tb2Vec2 pos IMPORTANT: \a pos is a center point of box2d object.
+	void moveToPosition(b2Vec2 pos);
 	void setRotation(float angle);
 
 	const b2Vec2 &getPosition();

--- a/plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp
@@ -26,6 +26,7 @@
 #include "src/engine/items/wallItem.h"
 #include "src/engine/items/skittleItem.h"
 #include "src/engine/items/ballItem.h"
+#include "src/engine/items/cubeItem.h"
 #include "src/engine/items/colorFieldItem.h"
 #include "src/engine/items/curveItem.h"
 #include "src/engine/items/rectangleItem.h"
@@ -182,6 +183,11 @@ const QMap<QString, QSharedPointer<items::BallItem>> &WorldModel::balls() const
 	return mBalls;
 }
 
+const QMap<QString, QSharedPointer<items::CubeItem>> &WorldModel::cubes() const
+{
+	return mCubes;
+}
+
 void WorldModel::addWall(const QSharedPointer<items::WallItem> &wall)
 {
 	const QString id = wall->id();
@@ -235,6 +241,24 @@ void WorldModel::removeBall(QSharedPointer<items::BallItem> ball)
 {
 	mBalls.remove(ball->id());
 	Q_EMIT itemRemoved(ball);
+}
+
+void WorldModel::addCube(const QSharedPointer<items::CubeItem> &cube)
+{
+	const QString id = cube->id();
+	if (mCubes.contains(id)) {
+		mErrorReporter->addError(tr("Trying to add an item with a duplicate id: %1").arg(id));
+		return; // probably better than having no way to delete those duplicate items on the scene
+	}
+
+	mCubes[id] = cube;
+	Q_EMIT cubeAdded(cube);
+}
+
+void WorldModel::removeCube(QSharedPointer<items::CubeItem> cube)
+{
+	mCubes.remove(cube->id());
+	Q_EMIT itemRemoved(cube);
 }
 
 void WorldModel::addComment(const QSharedPointer<items::CommentItem> &comment)
@@ -350,6 +374,10 @@ void WorldModel::clear()
 		removeBall(mBalls.last());
 	}
 
+	while (!mCubes.isEmpty()) {
+		removeCube(mCubes.last());
+	}
+
 	while (!mColorFields.isEmpty()) {
 		removeColorField(mColorFields.last());
 	}
@@ -434,6 +462,10 @@ QPainterPath WorldModel::buildSolidItemsPath() const
 		path.addPath(ball->path());
 	}
 
+	for (auto &&cube: mCubes) {
+		path.addPath(cube->path());
+	}
+
 	return path;
 }
 
@@ -488,6 +520,12 @@ QDomElement WorldModel::serializeWorld(QDomElement &parent) const
 	result.appendChild(balls);
 	for (auto &&ball : mBalls) {
 		ball->serialize(balls);
+	}
+
+	QDomElement cubes = parent.ownerDocument().createElement("cubes");
+	result.appendChild(cubes);
+	for (auto &&cube : mCubes) {
+		cube->serialize(cubes);
 	}
 
 	QDomElement colorFields = parent.ownerDocument().createElement("colorFields");
@@ -635,6 +673,14 @@ void WorldModel::deserialize(const QDomElement &element, const QDomElement &blob
 		}
 	}
 
+	for (QDomElement cubesNode = element.firstChildElement("cubes"); !cubesNode.isNull()
+			; cubesNode = cubesNode.nextSiblingElement("cubes")) {
+		for (QDomElement cubeNode = cubesNode.firstChildElement("cube"); !cubeNode.isNull()
+				; cubeNode = cubeNode.nextSiblingElement("cube")) {
+			createCube(cubeNode);
+		}
+	}
+
 	for (QDomElement colorFieldsNode = element.firstChildElement("colorFields"); !colorFieldsNode.isNull()
 			; colorFieldsNode = colorFieldsNode.nextSiblingElement("colorFields")) {
 		for (QDomElement elementNode = colorFieldsNode.firstChildElement(); !elementNode.isNull()
@@ -699,6 +745,10 @@ QSharedPointer<QGraphicsObject> WorldModel::findId(const QString &id) const
 		return mBalls[id];
 	}
 
+	if (mCubes.contains(id)) {
+		return mCubes[id];
+	}
+
 	if (mColorFields.contains(id)) {
 		return mColorFields[id];
 	}
@@ -738,6 +788,8 @@ void WorldModel::createElement(const QDomElement &element)
 		createSkittle(element);
 	} else if (element.tagName() == "ball") {
 		createBall(element);
+	} else if (element.tagName() == "cube") {
+		createCube(element);
 	} else if (element.tagName() == "region") {
 		createRegion(element);
 	} else if (element.tagName() == "comment") {
@@ -767,6 +819,14 @@ void WorldModel::createBall(const QDomElement &element)
 				mMetricCoordinateSystem, QPointF());
 	ball->deserialize(element);
 	addBall(ball);
+}
+
+void WorldModel::createCube(const QDomElement &element)
+{
+	auto cube = QSharedPointer<items::CubeItem>::create(
+				mMetricCoordinateSystem, QPointF());
+	cube->deserialize(element);
+	addCube(cube);
 }
 
 void WorldModel::createLine(const QDomElement &element)
@@ -873,6 +933,8 @@ void WorldModel::removeItem(const QString &id)
 		removeSkittle(skittleItem);
 	} else if (auto ballItem = qSharedPointerDynamicCast<items::BallItem>(item)) {
 		removeBall(ballItem);
+	} else if (auto cubeItem = qSharedPointerDynamicCast<items::CubeItem>(item)) {
+		removeCube(cubeItem);
 	} else if (auto image = qSharedPointerDynamicCast<items::ImageItem>(item)) {
 		removeImageItem(image);
 	} else if (auto comment = qSharedPointerDynamicCast<items::CommentItem>(item)) {

--- a/plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp
@@ -245,7 +245,7 @@ void WorldModel::removeBall(QSharedPointer<items::BallItem> ball)
 
 void WorldModel::addCube(const QSharedPointer<items::CubeItem> &cube)
 {
-	const QString id = cube->id();
+	const auto &id = cube->id();
 	if (mCubes.contains(id)) {
 		mErrorReporter->addError(tr("Trying to add an item with a duplicate id: %1").arg(id));
 		return; // probably better than having no way to delete those duplicate items on the scene
@@ -522,7 +522,7 @@ QDomElement WorldModel::serializeWorld(QDomElement &parent) const
 		ball->serialize(balls);
 	}
 
-	QDomElement cubes = parent.ownerDocument().createElement("cubes");
+	auto cubes = parent.ownerDocument().createElement("cubes");
 	result.appendChild(cubes);
 	for (auto &&cube : mCubes) {
 		cube->serialize(cubes);
@@ -673,9 +673,9 @@ void WorldModel::deserialize(const QDomElement &element, const QDomElement &blob
 		}
 	}
 
-	for (QDomElement cubesNode = element.firstChildElement("cubes"); !cubesNode.isNull()
+	for (auto cubesNode = element.firstChildElement("cubes"); !cubesNode.isNull()
 			; cubesNode = cubesNode.nextSiblingElement("cubes")) {
-		for (QDomElement cubeNode = cubesNode.firstChildElement("cube"); !cubeNode.isNull()
+		for (auto cubeNode = cubesNode.firstChildElement("cube"); !cubeNode.isNull()
 				; cubeNode = cubeNode.nextSiblingElement("cube")) {
 			createCube(cubeNode);
 		}

--- a/plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp
@@ -192,7 +192,8 @@ void TwoDModelEngineFacade::onStartInterpretation()
 	if (!mModel->settings().realisticPhysics() &&
 			(!mModel->worldModel().balls().isEmpty() || !mModel->worldModel().skittles().isEmpty()
 			 || !mModel->worldModel().cubes().isEmpty())) {
-		mModel->errorReporter()->addWarning(tr("Realistic physics' must be turned on to enjoy skittles, cubes and balls"));
+		mModel->errorReporter()->addWarning(
+					tr("Realistic physics' must be turned on to enjoy skittles, cubes and balls"));
 	}
 	mModel->timeline().start();
 }

--- a/plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp
@@ -190,8 +190,9 @@ TwoDModelEngineInterface &TwoDModelEngineFacade::engine()
 void TwoDModelEngineFacade::onStartInterpretation()
 {
 	if (!mModel->settings().realisticPhysics() &&
-			(!mModel->worldModel().balls().isEmpty() || !mModel->worldModel().skittles().isEmpty())) {
-		mModel->errorReporter()->addWarning(tr("Realistic physics' must be turned on to enjoy skittles and balls"));
+			(!mModel->worldModel().balls().isEmpty() || !mModel->worldModel().skittles().isEmpty()
+			 || !mModel->worldModel().cubes().isEmpty())) {
+		mModel->errorReporter()->addWarning(tr("Realistic physics' must be turned on to enjoy skittles, cubes and balls"));
 	}
 	mModel->timeline().start();
 }

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.h
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.h
@@ -87,7 +87,7 @@ public:
 	/// Categories of items include world model (walls, lines, etc.), sensors, robot position.
 	void setInteractivityFlags(kitBase::ReadOnlyFlags flags);
 
-public slots:
+public Q_SLOTS:
 	/// Sets a flag that next user mouse actions should draw a wall on the scene.
 	void addWall();
 
@@ -128,22 +128,22 @@ public slots:
 	/// @param removeRobot - if true robot graphics item will be fully recreated, its position will be nullified.
 	/// @param reason - reason for scene clearing --- user action or internal needs. Depending on this we can decide
 	///        whether to save changes into model.
-	void clearScene(bool removeRobot, Reason reason);
+	void clearScene(bool removeRobot, DevicesConfigurationProvider::Reason reason);
 
 	/// Aligns existing walls on the grid.
 	/// @todo: Walls that do not fit on the grid must not be removed.
 	void alignWalls();
 
 	/// Returns a pointer to a robot graphics item.
-	RobotItem *robot(model::RobotModel &robotModel);
+	twoDModel::view::RobotItem *robot(twoDModel::model::RobotModel &robotModel);
 
 	/// Focuses all graphics views on the robot if it is not visible.
-	void centerOnRobot(RobotItem *selectedItem = nullptr);
+	void centerOnRobot(twoDModel::view::RobotItem *selectedItem = nullptr);
 
 	/// Reread sensor configuration on given port, delete old sensor item and create new.
-	void reinitSensor(RobotItem *robotItem, const kitBase::robotModel::PortInfo &port);
+	void reinitSensor(twoDModel::view::RobotItem *robotItem, const kitBase::robotModel::PortInfo &port);
 
-signals:
+Q_SIGNALS:
 	/// Emitted each time when user presses mouse button somewhere on the scene.
 	void mousePressed();
 
@@ -154,9 +154,9 @@ signals:
 	void robotPressed();
 
 	/// Emitted at any changes of robot list (adding or removing)
-	void robotListChanged(RobotItem *robotItem);
+	void robotListChanged(twoDModel::view::RobotItem *robotItem);
 
-private slots:
+private Q_SLOTS:
 	/// Called after robot model was added and create new robot item
 	/// @param robotModel Robot model which was added
 	void onRobotAdd(model::RobotModel *robotModel);

--- a/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.h
+++ b/plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.h
@@ -49,6 +49,7 @@ class RectangleItem;
 class EllipseItem;
 class CommentItem;
 class ImageItem;
+class CubeItem;
 }
 
 namespace model {
@@ -95,6 +96,9 @@ public slots:
 
 	/// Sets a flag that next user mouse actions should draw a ball on the scene.
 	void addBall();
+
+	/// Sets a flag that next user mouse actions should draw a cube on the scene.
+	void addCube();
 
 	/// Sets a flag that next user mouse actions should draw a colored line on the scene.
 	void addLine();
@@ -170,6 +174,9 @@ private slots:
 	/// Called after new ball is added to a world model.
 	void onBallAdded(const QSharedPointer<items::BallItem> &ball);
 
+	/// Called after new cube is added to a world model.
+	void onCubeAdded(const QSharedPointer<items::CubeItem> &cube);
+
 //	/// Called after new color field item is added to a world model.
 //	void onColorItemAdded(const QSharedPointer<graphicsUtils::AbstractItem> &item);
 
@@ -190,6 +197,7 @@ private:
 		, wall
 		, skittle
 		, ball
+		, cube
 		, line
 		, bezier
 		, stylus
@@ -249,6 +257,7 @@ private:
 	QSharedPointer<items::WallItem> mCurrentWall;
 	QSharedPointer<items::SkittleItem> mCurrentSkittle;
 	QSharedPointer<items::BallItem> mCurrentBall;
+	QSharedPointer<items::CubeItem> mCurrentCube;
 	QSharedPointer<items::LineItem> mCurrentLine;
 	QSharedPointer<items::CurveItem> mCurrentCurve;
 	QSharedPointer<items::StylusItem> mCurrentStylus;

--- a/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp
@@ -43,6 +43,7 @@
 #include "src/engine/items/wallItem.h"
 #include "src/engine/items/skittleItem.h"
 #include "src/engine/items/ballItem.h"
+#include "src/engine/items/cubeItem.h"
 #include "src/engine/items/curveItem.h"
 #include "src/engine/items/rectangleItem.h"
 #include "src/engine/items/ellipseItem.h"
@@ -270,6 +271,7 @@ void TwoDModelWidget::initPalette()
 	QAction * const wallTool = items::WallItem::wallTool();
 	QAction * const skittleTool = items::SkittleItem::skittleTool();
 	QAction * const ballTool = items::BallItem::ballTool();
+	QAction * const cubeTool = items::CubeItem::cubeTool();
 	QAction * const lineTool = items::LineItem::lineTool();
 	QAction * const bezierTool = items::CurveItem::curveTool();
 	QAction * const rectangleTool = items::RectangleItem::rectangleTool();
@@ -281,6 +283,7 @@ void TwoDModelWidget::initPalette()
 	mUi->palette->registerTool(wallTool);
 	mUi->palette->registerTool(skittleTool);
 	mUi->palette->registerTool(ballTool);
+	mUi->palette->registerTool(cubeTool);
 	mUi->palette->registerTool(lineTool);
 	mUi->palette->registerTool(bezierTool);
 	mUi->palette->registerTool(rectangleTool);
@@ -296,6 +299,7 @@ void TwoDModelWidget::initPalette()
 	connect(wallTool, &QAction::triggered, &*mScene, &TwoDModelScene::addWall);
 	connect(skittleTool, &QAction::triggered, &*mScene, &TwoDModelScene::addSkittle);
 	connect(ballTool, &QAction::triggered, &*mScene, &TwoDModelScene::addBall);
+	connect(cubeTool, &QAction::triggered, &*mScene, &TwoDModelScene::addCube);
 	connect(lineTool, &QAction::triggered, &*mScene, &TwoDModelScene::addLine);
 	connect(bezierTool, &QAction::triggered, &*mScene, &TwoDModelScene::addBezier);
 	connect(rectangleTool, &QAction::triggered, &*mScene, &TwoDModelScene::addRectangle);
@@ -308,6 +312,7 @@ void TwoDModelWidget::initPalette()
 	connect(wallTool, &QAction::triggered, this, [this](){ setCursorTypeForDrawing(drawWall); });
 	connect(skittleTool, &QAction::triggered, this, [this](){ setCursorTypeForDrawing(drawSkittle); });
 	connect(ballTool, &QAction::triggered, this, [this](){ setCursorTypeForDrawing(drawBall); });
+	connect(cubeTool, &QAction::triggered, this, [this](){ setCursorTypeForDrawing(drawCube); });
 	connect(lineTool, &QAction::triggered, this, [this](){ setCursorTypeForDrawing(drawLine); });
 	connect(bezierTool, &QAction::triggered, this, [this](){ setCursorTypeForDrawing(drawBezier); });
 	connect(rectangleTool, &QAction::triggered, this, [this](){ setCursorTypeForDrawing(drawRectangle); });
@@ -432,6 +437,11 @@ void TwoDModelWidget::returnToStartMarker()
 	for (auto &&ball : mModel.worldModel().balls()) {
 		ball->returnToStartPosition();
 	}
+
+	for (auto &&cube : mModel.worldModel().cubes()) {
+		cube->returnToStartPosition();
+	}
+
 	saveWorldModelToRepo();
 }
 
@@ -879,6 +889,7 @@ QGraphicsView::DragMode TwoDModelWidget::cursorTypeToDragType(CursorType type) c
 	case drawWall:
 	case drawSkittle:
 	case drawBall:
+	case drawCube:
 	case drawBezier:
 	case drawRectangle:
 	case drawComment:
@@ -909,6 +920,8 @@ QCursor TwoDModelWidget::cursorTypeToCursor(CursorType type) const
 		return QCursor(QPixmap(":/icons/2d_drawCanCursor.png"), 0, 0);
 	case drawBall:
 		return QCursor(QPixmap(":/icons/2d_drawBallCursor.png"), 0, 0);
+	case drawCube:
+		return QCursor(QPixmap(":/icons/2d_none.png"), 0, 0);
 	case drawEllipse:
 		return QCursor(QPixmap(":/icons/2d_drawEllipseCursor.png"), 0, 0);
 	case drawStylus:

--- a/plugins/robots/common/twoDModel/twoDModel.pri
+++ b/plugins/robots/common/twoDModel/twoDModel.pri
@@ -67,6 +67,7 @@ HEADERS += \
 	$$PWD/include/twoDModel/robotModel/parts/lidar.h \
 	$$PWD/include/twoDModel/blocks/markerDownBlock.h \
 	$$PWD/include/twoDModel/blocks/markerUpBlock.h \
+	$$PWD/src/engine/items/cubeItem.h
 
 HEADERS += \
 	$$PWD/src/engine/twoDModelEngineApi.h \
@@ -135,6 +136,7 @@ HEADERS += \
 SOURCES += \
 	$$PWD/include/twoDModel/robotModel/parts/colorSensorAmbient.cpp \
 	$$PWD/include/twoDModel/robotModel/parts/colorSensorReflected.cpp \
+        $$PWD/src/engine/items/cubeItem.cpp \
 	$$PWD/src/engine/twoDModelEngineFacade.cpp \
 	$$PWD/src/engine/twoDModelEngineApi.cpp \
 	$$PWD/src/engine/twoDModelGuiFacade.cpp \

--- a/plugins/robots/interpreters/interpreterCore/icons/2d_cube.svg
+++ b/plugins/robots/interpreters/interpreterCore/icons/2d_cube.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="300" height="300" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="30" width="240" height="240" fill="#e74c3c" stroke="#c0392b" stroke-width="3"/>
+  <polygon points="30,30 270,30 285,45 45,45" fill="#c0392b"/>
+  <polygon points="270,30 270,270 285,285 285,45" fill="#a93226"/>
+</svg>

--- a/plugins/robots/interpreters/interpreterCore/icons/2d_cube.svg
+++ b/plugins/robots/interpreters/interpreterCore/icons/2d_cube.svg
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
-/* Copyright 2025 CyberTech Labs Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License. */
--->
-<svg width="300" height="300" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+<svg width="300" height="300" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:cc="http://creativecommons.org/ns#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+  <metadata>
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:title>Cube</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>CyberTech Labs Ltd</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:date>2025</dc:date>
+        <dc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+
   <rect x="30" y="30" width="240" height="240" fill="#e74c3c" stroke="#c0392b" stroke-width="3"/>
   <polygon points="30,30 270,30 285,45 45,45" fill="#c0392b"/>
   <polygon points="270,30 270,270 285,285 285,45" fill="#a93226"/>
+
 </svg>

--- a/plugins/robots/interpreters/interpreterCore/icons/2d_cube.svg
+++ b/plugins/robots/interpreters/interpreterCore/icons/2d_cube.svg
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/* Copyright 2025 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+-->
 <svg width="300" height="300" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
   <rect x="30" y="30" width="240" height="240" fill="#e74c3c" stroke="#c0392b" stroke-width="3"/>
   <polygon points="30,30 270,30 285,45 45,45" fill="#c0392b"/>

--- a/plugins/robots/interpreters/interpreterCore/interpreterCore.qrc
+++ b/plugins/robots/interpreters/interpreterCore/interpreterCore.qrc
@@ -69,5 +69,6 @@
         <file>icons/TRIKStudioLogo.png</file>
         <file>icons/2d_drawCommentCursor.png</file>
         <file>icons/2d_comment.svg</file>
+        <file>icons/2d_cube.svg</file>
     </qresource>
 </RCC>

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -324,7 +324,7 @@
 <context>
     <name>twoDModel::engine::TwoDModelEngineFacade</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+195"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+196"/>
         <source>Realistic physics&apos; must be turned on to enjoy skittles, cubes and balls</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -311,12 +311,12 @@
 <context>
     <name>twoDModel::constraints::ConstraintsChecker</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+118"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+119"/>
         <source>Error while parsing constraints: %1</source>
         <translation>Une erreur lors de l&apos;analyse des contraints est survenue : %1</translation>
     </message>
     <message>
-        <location line="+187"/>
+        <location line="+188"/>
         <source>Program has finished, but the task is not accomplished.</source>
         <translation>Le programme est terminé, mais la tache n&apos;est pas accomplie.</translation>
     </message>
@@ -324,8 +324,8 @@
 <context>
     <name>twoDModel::engine::TwoDModelEngineFacade</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+194"/>
-        <source>Realistic physics&apos; must be turned on to enjoy skittles and balls</source>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+195"/>
+        <source>Realistic physics&apos; must be turned on to enjoy skittles, cubes and balls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -342,6 +342,14 @@
     <message>
         <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="-141"/>
         <source>Text (T)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>twoDModel::items::CubeItem</name>
+    <message>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="+51"/>
+        <source>Cube (X)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -473,8 +481,9 @@
 <context>
     <name>twoDModel::model::WorldModel</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="+189"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="+195"/>
         <location line="+19"/>
+        <location line="+18"/>
         <location line="+18"/>
         <location line="+18"/>
         <location line="+43"/>
@@ -488,7 +497,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+508"/>
+        <location line="+544"/>
         <source>Unknown image with imageId %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -766,7 +775,7 @@
 <context>
     <name>twoDModel::view::TwoDModelScene</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+745"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+808"/>
         <source>Select images</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -316,7 +316,7 @@
         <translation>Une erreur lors de l&apos;analyse des contraints est survenue : %1</translation>
     </message>
     <message>
-        <location line="+188"/>
+        <location line="+191"/>
         <source>Program has finished, but the task is not accomplished.</source>
         <translation>Le programme est terminé, mais la tache n&apos;est pas accomplie.</translation>
     </message>
@@ -808,7 +808,7 @@
 <context>
     <name>twoDModel::view::TwoDModelWidget</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+343"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+348"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
@@ -826,7 +826,7 @@
         <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location line="-192"/>
+        <location line="-196"/>
         <source>cm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -836,7 +836,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
+        <location line="+277"/>
         <source>Training mode: solution will not be checked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -878,7 +878,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+204"/>
+        <location line="+207"/>
         <location line="+1"/>
         <source>No wheel</source>
         <translation>Pas de roue</translation>

--- a/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/twoDModel_fr.ts
@@ -348,7 +348,7 @@
 <context>
     <name>twoDModel::items::CubeItem</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="+51"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="+62"/>
         <source>Cube (X)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -620,7 +620,7 @@
 <context>
     <name>twoDModel::items::CubeItem</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="+51"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="+62"/>
         <source>Cube (X)</source>
         <translation>Куб (X)</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -588,7 +588,7 @@
         <translation>Ошибка чтения ограничений: %1</translation>
     </message>
     <message>
-        <location line="+188"/>
+        <location line="+191"/>
         <source>Program has finished, but the task is not accomplished.</source>
         <translation>Программа отработала, но задание не выполнено.</translation>
     </message>
@@ -1151,7 +1151,7 @@
 <context>
     <name>twoDModel::view::TwoDModelWidget</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+343"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+348"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
@@ -1169,7 +1169,7 @@
         <translation type="vanished">Отмена</translation>
     </message>
     <message>
-        <location line="-192"/>
+        <location line="-196"/>
         <source>cm</source>
         <translation>см</translation>
     </message>
@@ -1179,7 +1179,7 @@
         <translation>кг</translation>
     </message>
     <message>
-        <location line="+268"/>
+        <location line="+277"/>
         <source>Training mode: solution will not be checked</source>
         <translation>Режим тренировки: решение не будет проверяться</translation>
     </message>
@@ -1233,7 +1233,7 @@
         <translation>Показать детали</translation>
     </message>
     <message>
-        <location line="+204"/>
+        <location line="+207"/>
         <location line="+1"/>
         <source>No wheel</source>
         <translation>Отсутствует</translation>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -583,12 +583,12 @@
 <context>
     <name>twoDModel::constraints::ConstraintsChecker</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+118"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+119"/>
         <source>Error while parsing constraints: %1</source>
         <translation>Ошибка чтения ограничений: %1</translation>
     </message>
     <message>
-        <location line="+187"/>
+        <location line="+188"/>
         <source>Program has finished, but the task is not accomplished.</source>
         <translation>Программа отработала, но задание не выполнено.</translation>
     </message>
@@ -596,9 +596,13 @@
 <context>
     <name>twoDModel::engine::TwoDModelEngineFacade</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+194"/>
         <source>Realistic physics&apos; must be turned on to enjoy skittles and balls</source>
-        <translation>Реалистичная физика должна быть включена для взаимодействия с кеглями и мячами</translation>
+        <translation type="vanished">Реалистичная физика должна быть включена для взаимодействия с кеглями и мячами</translation>
+    </message>
+    <message>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+195"/>
+        <source>Realistic physics&apos; must be turned on to enjoy skittles, cubes and balls</source>
+        <translation>Реалистичная физика должна быть включена для взаимодействия с кеглями, кубами и мячами</translation>
     </message>
 </context>
 <context>
@@ -615,6 +619,14 @@
         <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="-141"/>
         <source>Text (T)</source>
         <translation>Текст (Т)</translation>
+    </message>
+</context>
+<context>
+    <name>twoDModel::items::CubeItem</name>
+    <message>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="+51"/>
+        <source>Cube (X)</source>
+        <translation>Куб (X)</translation>
     </message>
 </context>
 <context>
@@ -749,8 +761,9 @@
 <context>
     <name>twoDModel::model::WorldModel</name>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="+189"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="+195"/>
         <location line="+19"/>
+        <location line="+18"/>
         <location line="+18"/>
         <location line="+18"/>
         <location line="+43"/>
@@ -764,7 +777,7 @@
         <translation>Некорректное изображение, попробуйте другое</translation>
     </message>
     <message>
-        <location line="+508"/>
+        <location line="+544"/>
         <source>Unknown image with imageId %1</source>
         <translation>Неизвестное изображение с imageId %1</translation>
     </message>
@@ -1109,7 +1122,7 @@
         <translation type="vanished">Выберите картинку</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+745"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+808"/>
         <source>Select images</source>
         <translation>Выберите картинки</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/twoDModel_ru.ts
@@ -596,11 +596,7 @@
 <context>
     <name>twoDModel::engine::TwoDModelEngineFacade</name>
     <message>
-        <source>Realistic physics&apos; must be turned on to enjoy skittles and balls</source>
-        <translation type="vanished">Реалистичная физика должна быть включена для взаимодействия с кеглями и мячами</translation>
-    </message>
-    <message>
-        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+195"/>
+        <location filename="../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+196"/>
         <source>Realistic physics&apos; must be turned on to enjoy skittles, cubes and balls</source>
         <translation>Реалистичная физика должна быть включена для взаимодействия с кеглями, кубами и мячами</translation>
     </message>


### PR DESCRIPTION
Currently, it has the same functionality as other `SolidItem` on the scene. For example, `BallItem` or `SkittleItem` (Including setting restrictions). However, there is a request to set the `color` of the `cube`. It is suggested to simulate this in the future using `RectangleItem` in `CubeItem.cpp` instead of rendering svg. To change the color, enter a new entity of type `ColorFieldItem` that ignores the `thickness` parameter and change the `ColorItemPopup` accordingly. The last step will be to support the `Color Sensor` for such objects.