### PR TITLE
Fix the crash when objects intersect on the scene

### DIFF
--- a/plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp
+++ b/plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp
@@ -97,6 +97,7 @@ void CubeItem::drawExtractionForItem(QPainter *painter)
 void CubeItem::savePos()
 {
 	saveStartPosition();
+	rotater().savePos();
 	AbstractItem::savePos();
 }
 


### PR DESCRIPTION
When we overlap one object with another and there is an intersection, we want to restore its old position. The default position is (0, 0), (0, 0), which causes a crash when rendering the RotateItem of the cube