### PR TITLE
build(i18n): strip location from .ts files to avoid diff noise

### DIFF
--- a/features/autolupdate.prf
+++ b/features/autolupdate.prf
@@ -15,6 +15,10 @@
 defineTest(autoLupdateFiles) {
         FILES_TO_TRANSLATE = $$1
 
+        # Remove the location tag from generated ts files, which are useless in most contexts.
+        # Also, this should simplify the process of updating translations in case there are no new files in the pull request.
+        LUPDATE_ARGS += -locations none
+
         for(LUPDATE_INCLUDEPATH, INCLUDEPATH) {
                 LUPDATE_ARGS += -I$$system_quote($$system_path($$LUPDATE_INCLUDEPATH))
         }

--- a/qrtranslations/es/plugins/robots/checker/patcher_es.ts
+++ b/qrtranslations/es/plugins/robots/checker/patcher_es.ts
@@ -4,37 +4,30 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="25"/>
         <source>Patcher for save files, replaces world model with contents of a given XML world model</source>
         <translation>Parche para archivos guardados, reemplaza el modelo del mundo con el contenido de un modelo de mundo XML dado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="38"/>
         <source>TRIK Studio save file to be patched.</source>
         <translation>Archivo guardado de TRIK Studio que será parcheado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="40"/>
         <source>XML file with prepared 2D model field. Both world and robot configurations (position + ports) will be patched.</source>
         <translation>Archivo XML con campo de modelo 2D preparado. Se parchearán tanto la configuración del mundo como la del robot (posición + puertos).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="43"/>
         <source>Script file to be patched into save file.</source>
         <translation>Archivo de script que será insertado en el archivo guardado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="45"/>
         <source>XML file with prepared 2D model field. Only world configurations will be patched.</source>
         <translation>Archivo XML con campo de modelo 2D preparado. Solo se parchearán las configuraciones del mundo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="49"/>
         <source>XML file with prepared 2D model field. Only world configurations and robot position will be patched.</source>
         <translation>Archivo XML con campo de modelo 2D preparado. Solo se parchearán las configuraciones del mundo y la posición del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="53"/>
         <source>Reset robot position to start position</source>
         <translation>Restablecer la posición del robot a la posición inicial</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/checker/twoDModelRunner_es.ts
+++ b/qrtranslations/es/plugins/robots/checker/twoDModelRunner_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="30"/>
         <source>Emulates robot`s behaviour on TRIK Studio 2D model separately from programming environment. Passed .qrs will be interpreted just like when &apos;Run&apos; button was pressed in TRIK Studio. 
 In background mode the session will be terminated just after the execution ended and return code will then contain binary information about program correctness.Example: 
 </source>
@@ -13,82 +12,66 @@ En modo de fondo, la sesión finalizará inmediatamente tras la ejecución, y el
 </translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="102"/>
         <source>Save file to be interpreted.</source>
         <translation>Archivo guardado que será interpretado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="103"/>
         <source>Run emulation in background.</source>
         <translation>Ejecutar la emulación en segundo plano.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="105"/>
         <source>A path to file where checker results will be written (JSON).</source>
         <translation>Ruta al archivo donde se escribirán los resultados del comprobador (JSON).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="108"/>
         <source>A path to file where robot`s trajectory will be written. The writing will not be performed not immediately, each trajectory point will be written just when obtained by checker, so FIFOs are recommended to be targets for this option.</source>
         <translation>Ruta al archivo donde se escribirá la trayectoria del robot. La escritura no se realizará de forma inmediata; cada punto de la trayectoria se registrará tan pronto como sea obtenido por el comprobador, por lo que se recomienda usar archivos FIFO como destino para esta opción.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="112"/>
         <source>Inputs for JavaScript solution.</source>
         <translation>Entradas para la solución en JavaScript.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="114"/>
         <source>Set to &quot;script&quot; for execution of js/py from the project or set to &quot;diagram&quot; for block diagram.</source>
         <translation>Establezca &quot;script&quot; para ejecutar scripts js/py del proyecto o &quot;diagram&quot; para diagramas de bloques.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="118"/>
         <source>Speed factor, try from 5 to 20, or even 1000 (at your own risk!).</source>
         <translation>Factor de velocidad, pruebe desde 5 hasta 20, o incluso 1000 (¡bajo su propio riesgo!).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="121"/>
         <source>Close the window and exit if the diagram/script finishes without errors.</source>
         <translation>Cerrar la ventana y salir si el diagrama/escritura finaliza sin errores.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="124"/>
         <source>Close the window and exit after diagram/script finishes.</source>
         <translation>Cerrar la ventana y salir tras finalizar el diagrama/escritura.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="126"/>
         <source>Shows robot&apos;s console.</source>
         <translation>Muestra la consola del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="127"/>
         <source>Shows robot&apos;s display.</source>
         <translation>Muestra la pantalla del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="129"/>
         <source>The complete file path, including the filename, to save the generated JavaScript or Python code.</source>
         <translation>La ruta completa del archivo, incluyendo el nombre, para guardar el código JavaScript o Python generado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="132"/>
         <source>Select &quot;python&quot; or &quot;javascript&quot;.</source>
         <translation>Seleccione &quot;python&quot; o &quot;javascript&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="135"/>
         <source>The path to the Python or JavaScript file that will be used for interpretation.</source>
         <translation>La ruta al archivo Python o JavaScript que se utilizará para la interpretación.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="138"/>
         <source>Do not run the interpretation in any mode, this is a parameter that is only used to generate a file.</source>
         <translation>No ejecutar la interpretación en ningún modo; este parámetro solo se utiliza para generar un archivo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="141"/>
         <source>Add a delay in milliseconds after executing the script before closing the window</source>
         <translation>Añadir un retraso en milisegundos tras ejecutar el script antes de cerrar la ventana</translation>
     </message>
@@ -96,7 +79,6 @@ En modo de fondo, la sesión finalizará inmediatamente tras la ejecución, y el
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="241"/>
         <source>Robot console</source>
         <translation>Consola del robot</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/common/ev3Kit_es.ts
+++ b/qrtranslations/es/plugins/robots/common/ev3Kit_es.ts
@@ -4,17 +4,14 @@
 <context>
     <name>ev3::blocks::details::Ev3ReadRGBBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/blocks/details/ev3ReadRGBBlock.cpp" line="43"/>
         <source>Sensor reading should consist of three components</source>
         <translation>La lectura del sensor debe constar de tres componentes</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/blocks/details/ev3ReadRGBBlock.cpp" line="53"/>
         <source>Sensor reading failed</source>
         <translation>Error al leer el sensor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/blocks/details/ev3ReadRGBBlock.cpp" line="58"/>
         <source>Color raw sensor is not configured on port %2</source>
         <translation>El sensor de color en bruto no está configurado en el puerto %2</translation>
     </message>
@@ -22,7 +19,6 @@
 <context>
     <name>ev3::communication::BluetoothRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/bluetoothRobotCommunicationThread.cpp" line="82"/>
         <source>Cannot open port </source>
         <translation>No se puede abrir el puerto </translation>
     </message>
@@ -30,7 +26,6 @@
 <context>
     <name>ev3::communication::Ev3RobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/ev3RobotCommunicationThread.cpp" line="55"/>
         <source>EV3 limits filename length to %1 characters, but you have %2, please, rename your project.</source>
         <translation>EV3 limita la longitud del nombre de archivo a %1 caracteres, pero tienes %2; por favor, cambia el nombre de tu proyecto.</translation>
     </message>
@@ -38,7 +33,6 @@
 <context>
     <name>ev3::communication::UsbRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/usbRobotCommunicationThread.cpp" line="99"/>
         <source>Cannot find EV3 device. Check robot connected and turned on and try again.</source>
         <translation>No se puede encontrar el dispositivo EV3. Verifique que el robot esté conectado y encendido, y vuelva a intentarlo.</translation>
     </message>
@@ -46,7 +40,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3ACIRSeeker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3ACIRSeeker.h" line="27"/>
         <source>NXT IRSeeker V2 (AC)</source>
         <translation>NXT IRSeeker V2 (AC)</translation>
     </message>
@@ -54,7 +47,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Compass</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Compass.h" line="27"/>
         <source>Compass</source>
         <translation>Brújula</translation>
     </message>
@@ -62,7 +54,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3DCIRSeeker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3DCIRSeeker.h" line="27"/>
         <source>NXT IRSeeker V2 (DC)</source>
         <translation>NXT IRSeeker V2 (DC)</translation>
     </message>
@@ -70,7 +61,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Led</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Led.h" line="53"/>
         <source>LED</source>
         <translation>LED</translation>
     </message>
@@ -78,7 +68,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Motor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Motor.h" line="27"/>
         <source>Motor</source>
         <translation>Motor</translation>
     </message>
@@ -86,7 +75,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Color</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Color.h" line="27"/>
         <source>NXT color sensor V2 (color)</source>
         <translation>Sensor de color NXT V2 (color)</translation>
     </message>
@@ -94,7 +82,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Passive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Passive.h" line="27"/>
         <source>NXT color sensor V2 (passive)</source>
         <translation>Sensor de color NXT V2 (pasivo)</translation>
     </message>
@@ -102,7 +89,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2RGB</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2RGB.h" line="27"/>
         <source>NXT color sensor V2 (RGB)</source>
         <translation>Sensor de color NXT V2 (RGB)</translation>
     </message>
@@ -110,7 +96,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Raw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Raw.h" line="27"/>
         <source>NXT color sensor V2 (raw)</source>
         <translation>Sensor de color NXT V2 (bruto)</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/common/kitBase_es.ts
+++ b/qrtranslations/es/plugins/robots/common/kitBase_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/blocksBase/common/deviceBlock.h" line="47"/>
         <source>%1 is not configured.</source>
         <translation>%1 no está configurado.</translation>
     </message>
@@ -12,17 +11,14 @@
 <context>
     <name>kitBase::DevicesConfigurationWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/devicesConfigurationWidget.cpp" line="103"/>
         <source>%1:</source>
         <translation>%1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/devicesConfigurationWidget.cpp" line="103"/>
         <source>Port %1:</source>
         <translation>Puerto %1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/devicesConfigurationWidget.cpp" line="111"/>
         <source>Unused</source>
         <translation>No utilizado</translation>
     </message>
@@ -30,7 +26,6 @@
 <context>
     <name>kitBase::blocksBase::common::WaitForButtonBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/blocksBase/common/waitForButtonBlock.cpp" line="37"/>
         <source>Incorrect button port %1</source>
         <translation>Puerto de botón incorrecto %1</translation>
     </message>
@@ -38,7 +33,6 @@
 <context>
     <name>kitBase::blocksBase::common::WaitForSensorBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/blocksBase/common/waitForSensorBlock.cpp" line="46"/>
         <source>%1 is not configured on port %2</source>
         <translation>%1 no está configurado en el puerto %2</translation>
     </message>
@@ -46,7 +40,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::AccelerometerSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/accelerometerSensor.h" line="29"/>
         <source>Accelerometer</source>
         <translation>Acelerómetro</translation>
     </message>
@@ -54,7 +47,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Button</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/button.h" line="29"/>
         <source>Button</source>
         <translation>Botón</translation>
     </message>
@@ -62,7 +54,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensor.h" line="32"/>
         <source>Color sensor</source>
         <translation>Sensor de color</translation>
     </message>
@@ -70,7 +61,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorAmbient</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorAmbient.h" line="29"/>
         <source>EV3 color sensor (ambient)</source>
         <translation>Sensor de color EV3 (luz ambiental)</translation>
     </message>
@@ -78,7 +68,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorBlue</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorBlue.h" line="30"/>
         <source>NXT color sensor (blue)</source>
         <translation>Sensor de color NXT (azul)</translation>
     </message>
@@ -86,7 +75,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorFull</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorFull.h" line="33"/>
         <source>NXT / EV3 color sensor (full)</source>
         <translation>Sensor de color NXT / EV3 (color completo)</translation>
     </message>
@@ -94,7 +82,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorGreen</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorGreen.h" line="30"/>
         <source>NXT color sensor (green)</source>
         <translation>Sensor de color NXT (verde)</translation>
     </message>
@@ -102,7 +89,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorPassive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorPassive.h" line="33"/>
         <source>NXT color sensor (passive)</source>
         <translation>Sensor de color NXT (pasivo)</translation>
     </message>
@@ -110,7 +96,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorRaw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorRaw.h" line="29"/>
         <source>EV3 color sensor (raw)</source>
         <translation>Sensor de color EV3 (sin procesar)</translation>
     </message>
@@ -118,7 +103,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorRed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorRed.h" line="30"/>
         <source>NXT color sensor (red)</source>
         <translation>Sensor de color NXT (rojo)</translation>
     </message>
@@ -126,7 +110,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorReflected</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorReflected.h" line="29"/>
         <source>EV3 color sensor (reflected)</source>
         <translation>Sensor de color EV3 (luz reflejada)</translation>
     </message>
@@ -134,7 +117,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Communicator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h" line="29"/>
         <source>Communicator</source>
         <translation>Comunicador</translation>
     </message>
@@ -142,7 +124,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Display</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/display.h" line="29"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
@@ -150,7 +131,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::EncoderSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/encoderSensor.h" line="29"/>
         <source>Encoder</source>
         <translation>Codificador</translation>
     </message>
@@ -158,7 +138,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::GyroscopeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/gyroscopeSensor.h" line="29"/>
         <source>Gyroscope</source>
         <translation>Giroscopio</translation>
     </message>
@@ -166,7 +145,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::LidarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lidarSensor.h" line="29"/>
         <source>Lidar</source>
         <translation>Lidar</translation>
     </message>
@@ -174,7 +152,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::LightSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lightSensor.h" line="29"/>
         <source>Light sensor</source>
         <translation>Sensor de luz</translation>
     </message>
@@ -182,7 +159,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Motor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/motor.h" line="29"/>
         <source>Motor</source>
         <translation>Motor</translation>
     </message>
@@ -190,7 +166,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::MotorsAggregator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/motorsAggregator.h" line="29"/>
         <source>Motors aggregator</source>
         <translation>Agregador de motores</translation>
     </message>
@@ -198,7 +173,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Random</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/random.h" line="30"/>
         <source>Random</source>
         <translation>Número aleatorio</translation>
     </message>
@@ -206,7 +180,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::RangeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/rangeSensor.h" line="30"/>
         <source>Range sensor</source>
         <translation>Sensor de distancia</translation>
     </message>
@@ -214,7 +187,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Shell</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/shell.h" line="28"/>
         <source>Shell</source>
         <translation>Consola</translation>
     </message>
@@ -222,7 +194,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::SoundSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/soundSensor.h" line="30"/>
         <source>Sound sensor</source>
         <translation>Sensor de sonido</translation>
     </message>
@@ -230,7 +201,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Speaker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/speaker.h" line="29"/>
         <source>Speaker</source>
         <translation>Altavoz</translation>
     </message>
@@ -238,7 +208,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::TouchSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/touchSensor.h" line="30"/>
         <source>Touch sensor</source>
         <translation>Sensor táctil</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/common/nxtKit_es.ts
+++ b/qrtranslations/es/plugins/robots/common/nxtKit_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>nxt::communication::BluetoothRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/bluetoothRobotCommunicationThread.cpp" line="86"/>
         <source>Cannot open port </source>
         <translation>No se puede abrir el puerto </translation>
     </message>
@@ -12,32 +11,26 @@
 <context>
     <name>nxt::communication::NxtUsbDriverInstaller</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="54"/>
         <source>Driver for NXT is not installed. An attempt to attach TRIK Studio driver also failed (probably NXT tools package was not installer). No panic! Driver can still be installed manually, see documentation, chapter &quot;Installing NXT driver manually.&quot;. Also TRIK Studio supports &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>El controlador para NXT no está instalado. Un intento de adjuntar el controlador de TRIK Studio también falló (probablemente el paquete de herramientas NXT no fue instalado). ¡Sin pánico! El controlador aún puede instalarse manualmente, consulte la documentación, capítulo &quot;Instalación manual del controlador NXT&quot;. Además, TRIK Studio es compatible con el &lt;a href=&apos;%1&apos;&gt;controlador Lego Fantom&lt;/a&gt;, puede simplemente descargarlo e instalarlo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="63"/>
         <source>Driver installation cancelled. Please note that TRIK Studio also supports official &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>La instalación del controlador fue cancelada. Tenga en cuenta que TRIK Studio también admite el &lt;a href=&apos;%1&apos;&gt;controlador oficial Lego Fantom&lt;/a&gt;, puede simplemente descargarlo e instalarlo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="91"/>
         <source>An attempt to attach TRIK Studio driver failed. No panic! Driver can be still installed manually, see documentation, chapter &quot;Installing NXT driver manually.&quot;. Also TRIK Studio supports &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>Un intento de adjuntar el controlador de TRIK Studio falló. ¡Sin pánico! El controlador aún puede instalarse manualmente, consulte la documentación, capítulo &quot;Instalación manual del controlador NXT&quot;. Además, TRIK Studio es compatible con el &lt;a href=&apos;%1&apos;&gt;controlador Lego Fantom&lt;/a&gt;, puede simplemente descargarlo e instalarlo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="113"/>
         <source>NXT drivers not found</source>
         <translation>Controladores NXT no encontrados</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="114"/>
         <source>Drivers for LEGO NXT brick are not installed. TRIK Studio can install own drivers to communicate with NXT. Do you want to do it?</source>
         <translation>Los controladores para el bloque LEGO NXT no están instalados. TRIK Studio puede instalar sus propios controladores para comunicarse con el NXT. ¿Desea hacerlo?</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="116"/>
         <source>TRIK Studio drivers are not officially registered, so two red warning messages will be shown by Windows. Confirm them to proceed installation.</source>
         <translation>Los controladores de TRIK Studio no están oficialmente registrados, por lo que Windows mostrará dos mensajes de advertencia rojos. Confírmelos para continuar con la instalación.</translation>
     </message>
@@ -45,33 +38,26 @@
 <context>
     <name>nxt::communication::UsbRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="169"/>
         <source>USB Device configuration problem. Try to restart TRIK Studio and re-plug NXT.</source>
         <translation>Problema de configuración del dispositivo USB. Intente reiniciar TRIK Studio y vuelva a conectar el NXT.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="178"/>
         <source>NXT device is already used by another software.</source>
         <translation>El dispositivo NXT ya está siendo utilizado por otro software.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="199"/>
         <source>NXT handshake procedure failed. Please contact developers.</source>
         <translation>El procedimiento de handshake con NXT falló. Por favor, inténtelo de nuevo. Si este error vuelve a aparecer, contacte con los desarrolladores.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="216"/>
         <source>Cannot find NXT device. Check robot connected and turned on and try again.</source>
         <translation>No se puede encontrar el dispositivo NXT. Verifique que el robot esté conectado y encendido, y vuelva a intentarlo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="252"/>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="271"/>
         <source>Connection to NXT lost</source>
         <translation>Conexión con NXT perdida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="311"/>
         <source>Cannot find NXT device in resetted mode. Check robot resetted, connected and ticking and try again.</source>
         <translation>No se puede encontrar el dispositivo NXT en modo de restablecimiento. Verifique que el firmware del robot haya sido borrado, que esté conectado al ordenador y emitiendo sonidos repetitivos (tictac), y vuelva a intentarlo.</translation>
     </message>
@@ -79,7 +65,6 @@
 <context>
     <name>nxt::robotModel::parts::NxtMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/include/nxtKit/robotModel/parts/nxtMotor.h" line="27"/>
         <source>Motor</source>
         <translation>Motor</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/common/trikKit_es.ts
+++ b/qrtranslations/es/plugins/robots/common/trikKit_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::blocks::details::WaitForMessageBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="46"/>
         <source>Device not found for port name CommunicatorPort</source>
         <translation>Dispositivo no encontrado para el nombre de puerto CommunicatorPort</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>trik::blocks::details::WaitGamepadButtonBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/blocks/details/waitGamepadButtonBlock.cpp" line="41"/>
         <source>Incorrect port for gamepad button %1</source>
         <translation>Puerto incorrecto para el botón del mando %1</translation>
     </message>
@@ -20,13 +18,10 @@
 <context>
     <name>trik::robotModel::TrikRobotModelBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="93"/>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="305"/>
         <source>Video 2</source>
         <translation>Vídeo 2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="309"/>
         <source>Lidar</source>
         <translation>Lidar</translation>
     </message>
@@ -34,7 +29,6 @@
 <context>
     <name>trik::robotModel::parts::TrikColorSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikColorSensor.h" line="29"/>
         <source>Color Sensor</source>
         <translation>Sensor de color</translation>
     </message>
@@ -42,7 +36,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadButton</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadButton.h" line="28"/>
         <source>Android Gamepad Button</source>
         <translation>Botón del mando Android</translation>
     </message>
@@ -50,7 +43,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadConnectionIndicator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadConnectionIndicator.h" line="28"/>
         <source>Android Gamepad Connection Indicator</source>
         <translation>Indicador de conexión del mando Android</translation>
     </message>
@@ -58,7 +50,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadPad</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadPad.h" line="29"/>
         <source>Android Gamepad Pad</source>
         <translation>Área táctil del mando Android</translation>
     </message>
@@ -66,7 +57,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadPadPressSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadPadPressSensor.h" line="28"/>
         <source>Android Gamepad Pad as Button</source>
         <translation>Área táctil del mando Android como botón</translation>
     </message>
@@ -74,7 +64,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadWheel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadWheel.h" line="29"/>
         <source>Android Gamepad Wheel</source>
         <translation>Rueda del mando Android</translation>
     </message>
@@ -82,7 +71,6 @@
 <context>
     <name>trik::robotModel::parts::TrikInfraredSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikInfraredSensor.h" line="27"/>
         <source>Infrared Sensor</source>
         <translation>Sensor de distancia por infrarrojos</translation>
     </message>
@@ -90,7 +78,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLed.h" line="27"/>
         <source>Led</source>
         <translation>LED</translation>
     </message>
@@ -98,7 +85,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLightSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLightSensor.h" line="28"/>
         <source>Light sensor</source>
         <translation>Sensor de luminosidad</translation>
     </message>
@@ -106,7 +92,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLineSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLineSensor.h" line="28"/>
         <source>Line Sensor</source>
         <translation>Sensor de línea</translation>
     </message>
@@ -114,7 +99,6 @@
 <context>
     <name>trik::robotModel::parts::TrikMotionSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikMotionSensor.h" line="27"/>
         <source>Motion Sensor</source>
         <translation>Sensor de movimiento</translation>
     </message>
@@ -122,7 +106,6 @@
 <context>
     <name>trik::robotModel::parts::TrikMotorsAggregator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikMotorsAggregator.h" line="27"/>
         <source>Trik Motors Aggregator</source>
         <translation>Agregador de motores Trik</translation>
     </message>
@@ -130,7 +113,6 @@
 <context>
     <name>trik::robotModel::parts::TrikObjectSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikObjectSensor.h" line="28"/>
         <source>Object Sensor</source>
         <translation>Sensor de objeto</translation>
     </message>
@@ -138,7 +120,6 @@
 <context>
     <name>trik::robotModel::parts::TrikPowerMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikPowerMotor.h" line="27"/>
         <source>Power Motor</source>
         <translation>Motor de potencia</translation>
     </message>
@@ -146,7 +127,6 @@
 <context>
     <name>trik::robotModel::parts::TrikServoMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikServoMotor.h" line="27"/>
         <source>Servo Motor</source>
         <translation>Servomotor</translation>
     </message>
@@ -154,7 +134,6 @@
 <context>
     <name>trik::robotModel::parts::TrikSonarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikSonarSensor.h" line="27"/>
         <source>Sonic Sensor</source>
         <translation>Sensor de distancia por ultrasonidos</translation>
     </message>
@@ -162,7 +141,6 @@
 <context>
     <name>trik::robotModel::parts::TrikTouchSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikTouchSensor.h" line="28"/>
         <source>Touch sensor</source>
         <translation>Sensor táctil</translation>
     </message>
@@ -170,7 +148,6 @@
 <context>
     <name>trik::robotModel::parts::TrikVideoCamera</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikVideoCamera.h" line="27"/>
         <source>Video Camera</source>
         <translation>Cámara de vídeo</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/common/twoDModel_es.ts
+++ b/qrtranslations/es/plugins/robots/common/twoDModel_es.ts
@@ -4,370 +4,290 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/speedPopup.cpp" line="25"/>
         <source>Speed:&amp;nbsp;&amp;nbsp;&lt;b&gt;%1%&lt;/b&gt;</source>
         <translation>Velocidad:&amp;nbsp;&amp;nbsp;&lt;b&gt;%1%&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/colorFieldItem.cpp" line="52"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="181"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp" line="261"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/colorFieldItem.cpp" line="53"/>
         <source>Convert to region</source>
         <translation>Convertir a región</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/colorFieldItem.cpp" line="54"/>
         <source>Bind to region</source>
         <translation>Vincular a región</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="182"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="182"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="183"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="65"/>
         <source>Root element must be &quot;constraints&quot; tag</source>
         <translation>El elemento raíz debe ser la etiqueta &quot;constraints&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="102"/>
         <source>There must be a &quot;timelimit&quot; constraint.</source>
         <translation>Debe haber una restricción &quot;timelimit&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="107"/>
         <source>There must be only one &quot;timelimit&quot; tag.</source>
         <translation>Solo puede haber una etiqueta &quot;timelimit&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="156"/>
         <source>Event tag must have &quot;condition&quot; or &quot;conditions&quot; child tag. &quot;%1&quot; found instead.</source>
         <translation>La etiqueta &quot;event&quot; debe tener una etiqueta hija &quot;condition&quot; o &quot;conditions&quot;. En su lugar se encontró &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="162"/>
         <source>Event tag must have &quot;trigger&quot; or &quot;triggers&quot; child tag. &quot;%1&quot; found instead.</source>
         <translation>La etiqueta &quot;event&quot; debe tener una etiqueta hija &quot;trigger&quot; o &quot;triggers&quot;. En su lugar se encontró &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="228"/>
         <source>Program worked for too long time</source>
         <translation>El programa funcionó durante demasiado tiempo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="272"/>
         <source>&quot;Glue&quot; attribute must have value &quot;and&quot; or &quot;or&quot;.</source>
         <translation>El atributo &quot;glue&quot; debe tener el valor &quot;and&quot; o &quot;or&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="331"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="543"/>
         <source>Unknown tag &quot;%1&quot;.</source>
         <translation>Etiqueta desconocida &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="456"/>
         <source>There must be only one tag &quot;return&quot; in &quot;using&quot; expression.</source>
         <translation>Solo puede haber una etiqueta &quot;return&quot; en la expresión &quot;using&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="468"/>
         <source>There must be &quot;return&quot; tag in &quot;using&quot; expression.</source>
         <translation>Debe haber una etiqueta &quot;return&quot; en la expresión &quot;using&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="802"/>
         <source>Unknown value &quot;%1&quot;.</source>
         <translation>Valor desconocido &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="882"/>
         <source>Invalid integer value &quot;%1&quot;</source>
         <translation>Valor entero no válido &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="896"/>
         <source>Invalid floating point value &quot;%1&quot;</source>
         <translation>Valor de punto flotante no válido &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="909"/>
         <source>Invalid boolean value &quot;%1&quot; (expected &quot;true&quot; or &quot;false&quot;)</source>
         <translation>Valor booleano no válido &quot;%1&quot; (se esperaba &quot;true&quot; o &quot;false&quot;)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="925"/>
         <source>Duplicate id: &quot;%1&quot;</source>
         <translation>ID duplicado: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="936"/>
         <source>When using the extended form for the %1 tag, the number of arguments starting with _ must be %2, %3 was provided</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="949"/>
         <source>%1 tag must have exactly %2 child tag(s)</source>
         <translation>La etiqueta %1 debe tener exactamente %2 etiqueta(s) hija(s)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="961"/>
         <source>%1 tag must have at least %2 child tag(s)</source>
         <translation>La etiqueta %1 debe tener al menos %2 etiqueta(s) hija(s)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="972"/>
         <source>&quot;%1&quot; tag must have &quot;%2&quot; attribute.</source>
         <translation>La etiqueta &quot;%1&quot; debe tener el atributo &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="982"/>
         <source>Expected &quot;%1&quot; tag, got &quot;%2&quot;.</source>
         <translation>Se esperaba la etiqueta &quot;%1&quot;, se obtuvo &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="996"/>
         <source>Attribute &quot;%1&quot; of the tag &quot;%2&quot; must not be empty.</source>
         <translation>El atributo &quot;%1&quot; de la etiqueta &quot;%2&quot; no debe estar vacío.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="100"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="125"/>
         <source>No such object: %1</source>
         <translation>No existe tal objeto: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="105"/>
         <source>No such region: %1</source>
         <translation>No existe tal región: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="113"/>
         <source>%1 is not a region</source>
         <translation>%1 no es una región</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="169"/>
         <source>%1 has incorrect type for matching it with region</source>
         <translation>%1 tiene un tipo incorrecto para asociarlo con una región</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="178"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="190"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="112"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="124"/>
         <source>No such event: %1</source>
         <translation>No existe tal evento: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="94"/>
         <source>Invalid &lt;setState&gt; object type %1</source>
         <translation>Tipo de objeto %1 no válido en &lt;setState&gt;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="100"/>
         <source>Object %1 has no property %2</source>
         <translation>El objeto %1 no tiene la propiedad %2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="64"/>
         <source>Using special syntax with an empty variable name</source>
         <translation>Usando sintaxis especial con un nombre de variable vacío</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="74"/>
         <source>The name %1 is not a valid variable name or property chain for an object</source>
         <translation>El nombre %1 no es un nombre de variable válido ni una cadena de propiedades para un objeto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="86"/>
         <source>Requesting variable value with empty name</source>
         <translation>Solicitando valor de variable con nombre vacío</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="118"/>
         <source>Object path is empty!</source>
         <translation>¡La ruta del objeto está vacía!</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="249"/>
         <source>Unknown type of object &quot;%1&quot;</source>
         <translation>Tipo de objeto desconocido &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="256"/>
         <source>Object &quot;%1&quot; has no property &quot;%2&quot;</source>
         <translation>El objeto &quot;%1&quot; no tiene la propiedad &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="119"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="122"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="125"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="127"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="133"/>
         <source>Pixels</source>
         <translation>Píxeles</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="134"/>
         <source>Centimeters</source>
         <translation>Centímetros</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="135"/>
         <source>Meters</source>
         <translation>Metros</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="136"/>
         <source>Millimeters</source>
         <translation>Milímetros</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="35"/>
         <source>The &amp;lt;template&amp;gt; tag was provided, but the required &quot;name&quot; attribute was missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="45"/>
         <source>Redefinition a template %1 that already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="78"/>
         <source>the &amp;lt;templates&amp;gt; tag can only contain the &amp;lt;template&amp;gt; tag as a child tag, actual %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="31"/>
         <source>The &amp;lt;use&amp;gt; tag must contain a &quot;template&quot; attribute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="37"/>
         <source>Recursive template expansion detected: %1 -&gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="47"/>
         <source>The &amp;lt;use&amp;gt; tag contains a template=%1 attribute that is not the name of a declared template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="71"/>
         <source>After substituting the parameters for the template %1, it did not become a valid xml node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="156"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="171"/>
         <source>line %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="158"/>
         <source>template %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="174"/>
         <source>relative the beginning of the &amp;lt;constraints&amp;gt; tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="177"/>
         <source>relative to the beginning of the %1 template body</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="183"/>
         <source>Substitution chain: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="29"/>
         <source>Currently, this method of setting &amp;lt;content&amp;gt; tag for the template %1 is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="47"/>
         <source>When defining the template %1, the syntax %2 was used to substitute an offset %3 for an undeclared parameter %4.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="63"/>
         <source>the &amp;lt;params&amp;gt; tag can only contain the &amp;lt;param&amp;gt; tag as a child tag for template %1, actual tag is &amp;lt;%2&amp;gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="73"/>
         <source>The &amp;lt;param&amp;gt; tag of template %1 was provided, but the required &quot;name&quot; attribute was missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="130"/>
         <source>The &amp;lt;template&amp;gt; of template %1 tag was provided, but the required child tag &amp;lt;content&amp;gt; was missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="143"/>
         <source>The using an undeclared parameter %1 for template %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="170"/>
         <source>The &amp;lt;use&amp;gt; tag can only contain a child tag &amp;lt;with&amp;gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="210"/>
         <source>The parameter %1 of template %2 has no default value and was not explicitly specified by the user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/templateParserApi.cpp" line="101"/>
         <source>Error while template substitution: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/templateParserApi.cpp" line="110"/>
         <source>Error while parsing template: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp" line="262"/>
         <source>Change visibility</source>
         <translation>Cambiar visibilidad</translation>
     </message>
@@ -375,32 +295,26 @@
 <context>
     <name>TwoDModelWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="14"/>
         <source>2D Robot Model</source>
         <translation>Modelo de robot 2D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="95"/>
         <source>Run program</source>
         <translation>Ejecutar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="136"/>
         <source>Stop program</source>
         <translation>Detener programa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="393"/>
         <source>Left wheel:</source>
         <translation>Rueda izquierda:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="403"/>
         <source>Right wheel:</source>
         <translation>Rueda derecha:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="434"/>
         <source>Metric system units:</source>
         <translation>Unidades del sistema métrico:</translation>
     </message>
@@ -409,95 +323,74 @@
         <translation type="vanished">Píxeles por cm:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="199"/>
         <source>Edit Regions</source>
         <translation>Editar regiones</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="159"/>
         <source>Reset World</source>
         <translation>Restablecer mundo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="448"/>
         <source>Grid size:</source>
         <translation>Tamaño de cuadrícula:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="470"/>
         <source>Realistic physics</source>
         <translation>Física realista</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="477"/>
         <source>Realistic sensors</source>
         <translation>Sensores realistas</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="484"/>
         <source>Realistic engines</source>
         <translation>Motores realistas</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="543"/>
         <source>Robot height:</source>
         <translation>Altura del robot:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="556"/>
         <source>Robot mass:</source>
         <translation>Masa del robot:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="569"/>
         <source>Wheel diameter:</source>
         <translation>Diámetro de la rueda:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="620"/>
         <source>Robot track:</source>
         <translation>Separación entre ruedas:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="671"/>
         <source>Robot width:</source>
         <translation>Ancho del robot:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="678"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="685"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="692"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="706"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="699"/>
         <source>kg</source>
         <translation>kg</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="762"/>
         <source>Decrease speed</source>
         <translation>Disminuir velocidad</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="803"/>
         <source>Time in 2D model</source>
         <translation>Tiempo en el modelo 2D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="812"/>
         <source> sec.</source>
         <translation> seg.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="840"/>
         <source>Increase speed</source>
         <translation>Aumentar velocidad</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="948"/>
         <source>px</source>
         <translation>px</translation>
     </message>
@@ -505,17 +398,14 @@
 <context>
     <name>twoDModel::constraints::ConstraintsChecker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="127"/>
         <source>Error while parsing constraints: %1</source>
         <translation>Error al analizar restricciones: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="133"/>
         <source>Warning while parsing constraints: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="365"/>
         <source>Program has finished, but the task is not accomplished.</source>
         <translation>El programa ha finalizado, pero la tarea no se ha completado.</translation>
     </message>
@@ -523,7 +413,6 @@
 <context>
     <name>twoDModel::engine::TwoDModelEngineFacade</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="207"/>
         <source>Realistic physics&apos; must be turned on to enjoy skittles, cubes and balls</source>
         <translation>Debe activarse la física realista para interactuar con bolos, cubos y pelotas</translation>
     </message>
@@ -531,7 +420,6 @@
 <context>
     <name>twoDModel::items::BallItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/ballItem.cpp" line="54"/>
         <source>Ball (B)</source>
         <translation>Pelota (B)</translation>
     </message>
@@ -539,7 +427,6 @@
 <context>
     <name>twoDModel::items::CommentItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="42"/>
         <source>Text (T)</source>
         <translation>Texto (T)</translation>
     </message>
@@ -547,7 +434,6 @@
 <context>
     <name>twoDModel::items::CubeItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="62"/>
         <source>Cube (X)</source>
         <translation>Cubo (X)</translation>
     </message>
@@ -555,7 +441,6 @@
 <context>
     <name>twoDModel::items::CurveItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/curveItem.cpp" line="64"/>
         <source>Bezier Curve (Z)</source>
         <translation>Curva de Bézier (Z)</translation>
     </message>
@@ -563,7 +448,6 @@
 <context>
     <name>twoDModel::items::EllipseItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/ellipseItem.cpp" line="44"/>
         <source>Ellipse (E)</source>
         <translation>Elipse (E)</translation>
     </message>
@@ -571,7 +455,6 @@
 <context>
     <name>twoDModel::items::ImageItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/imageItem.cpp" line="80"/>
         <source>Image (I)</source>
         <translation>Imagen (I)</translation>
     </message>
@@ -579,7 +462,6 @@
 <context>
     <name>twoDModel::items::LineItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/lineItem.cpp" line="49"/>
         <source>Line (L)</source>
         <translation>Línea (L)</translation>
     </message>
@@ -587,7 +469,6 @@
 <context>
     <name>twoDModel::items::RectangleItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/rectangleItem.cpp" line="44"/>
         <source>Rectangle (R)</source>
         <translation>Rectángulo (R)</translation>
     </message>
@@ -595,7 +476,6 @@
 <context>
     <name>twoDModel::items::SkittleItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/skittleItem.cpp" line="54"/>
         <source>Can (C)</source>
         <translation>Lata (C)</translation>
     </message>
@@ -603,7 +483,6 @@
 <context>
     <name>twoDModel::items::StylusItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/stylusItem.cpp" line="62"/>
         <source>Stylus (S)</source>
         <translation>Estilógrafo (S)</translation>
     </message>
@@ -611,7 +490,6 @@
 <context>
     <name>twoDModel::items::WallItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="69"/>
         <source>Wall (W)</source>
         <translation>Pared (W)</translation>
     </message>
@@ -619,27 +497,22 @@
 <context>
     <name>twoDModel::model::Model</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="74"/>
         <source>The task was accomplished in %1 sec!</source>
         <translation>¡La tarea se completó en %1 seg!</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="100"/>
         <source>Error in checker: %1</source>
         <translation>Error en el verificador: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="203"/>
         <source>The &quot;version&quot; field of the &quot;root&quot; tag must not be empty.</source>
         <translation>El campo &quot;version&quot; de la etiqueta &quot;root&quot; no debe estar vacío.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="209"/>
         <source>The world model has version %1. The current version is %2. Please check that the world model behaves as expected.</source>
         <translation>El modelo del mundo tiene versión %1. La versión actual es %2. Por favor, verifique que el modelo del mundo se comporte como se espera.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="252"/>
         <source>This robot model already exists</source>
         <translation>Este modelo de robot ya existe</translation>
     </message>
@@ -682,24 +555,14 @@
 <context>
     <name>twoDModel::model::WorldModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="195"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="215"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="234"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="253"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="272"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="291"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="335"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="355"/>
         <source>Trying to add an item with a duplicate id: %1</source>
         <translation>Intentando agregar un elemento con ID duplicado: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="367"/>
         <source>Incorrect image, please try anouther one</source>
         <translation>Imagen incorrecta, por favor intente con otra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="910"/>
         <source>Unknown image with imageId %1</source>
         <translation>Imagen desconocida con imageId %1</translation>
     </message>
@@ -707,8 +570,6 @@
 <context>
     <name>twoDModel::robotModel::TwoDRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/robotModel/twoDRobotModel.cpp" line="74"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/robotModel/twoDRobotModel.cpp" line="77"/>
         <source>2D Model</source>
         <translation>Modelo 2D</translation>
     </message>
@@ -716,7 +577,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorAmbient</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorAmbient.h" line="33"/>
         <source>EV3 color sensor (ambient)</source>
         <translation>Sensor de color EV3 (luz ambiental)</translation>
     </message>
@@ -724,7 +584,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorBlue</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorBlue.h" line="36"/>
         <source>Color sensor (blue)</source>
         <translation>Sensor de color (azul)</translation>
     </message>
@@ -732,7 +591,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorFull</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorFull.h" line="37"/>
         <source>Color sensor (full)</source>
         <translation>Sensor de color (reconocimiento de colores)</translation>
     </message>
@@ -740,7 +598,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorGreen</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorGreen.h" line="36"/>
         <source>Color sensor (green)</source>
         <translation>Sensor de color (verde)</translation>
     </message>
@@ -748,7 +605,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorPassive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorPassive.h" line="37"/>
         <source>Color sensor (passive)</source>
         <translation>Sensor de color (pasivo)</translation>
     </message>
@@ -756,7 +612,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorRaw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorRaw.h" line="35"/>
         <source>Color sensor (raw)</source>
         <translation>Sensor de color (bruto)</translation>
     </message>
@@ -764,7 +619,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorRed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorRed.h" line="36"/>
         <source>Color sensor (red)</source>
         <translation>Sensor de color (rojo)</translation>
     </message>
@@ -772,7 +626,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorReflected</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorReflected.h" line="33"/>
         <source>EV3 color sensor (reflected)</source>
         <translation>Sensor de color EV3 (luz reflejada)</translation>
     </message>
@@ -780,7 +633,6 @@
 <context>
     <name>twoDModel::robotModel::parts::Marker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/marker.h" line="37"/>
         <source>Marker</source>
         <translation>Marcador</translation>
     </message>
@@ -788,42 +640,34 @@
 <context>
     <name>twoDModel::view::ActionsBox</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="26"/>
         <source>Hand dragging mode</source>
         <translation>Modo de arrastre manual</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="27"/>
         <source>Multiselection mode</source>
         <translation>Modo de selección múltiple</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="29"/>
         <source>Save world model...</source>
         <translation>Guardar modelo del mundo...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="30"/>
         <source>Load world model...</source>
         <translation>Cargar modelo del mundo...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="31"/>
         <source>Load templates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="33"/>
         <source>Load world model without robot configuration...</source>
         <translation>Cargar modelo del mundo sin configuración del robot...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="36"/>
         <source>Clear items</source>
         <translation>Limpiar elementos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="38"/>
         <source>Clear floor</source>
         <translation>Limpiar el suelo de rastros del robot</translation>
     </message>
@@ -831,22 +675,18 @@
 <context>
     <name>twoDModel::view::ColorItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="104"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="129"/>
         <source>Disable filling</source>
         <translation>Deshabilitar relleno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="129"/>
         <source>Enable filling</source>
         <translation>Habilitar relleno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="143"/>
         <source>Thickness</source>
         <translation>Grosor</translation>
     </message>
@@ -854,32 +694,26 @@
 <context>
     <name>twoDModel::view::DetailsTab</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="38"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="39"/>
         <source>Ports configuration</source>
         <translation>Configuración de puertos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="40"/>
         <source>Motors</source>
         <translation>Motores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="41"/>
         <source>Physics</source>
         <translation>Física</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="42"/>
         <source>Model parameters</source>
         <translation>Parámetros del modelo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="43"/>
         <source>Metric system</source>
         <translation>Sistema métrico</translation>
     </message>
@@ -887,7 +721,6 @@
 <context>
     <name>twoDModel::view::GridParameters</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/gridParameters.cpp" line="34"/>
         <source>Grid</source>
         <translation>Cuadrícula</translation>
     </message>
@@ -895,37 +728,30 @@
 <context>
     <name>twoDModel::view::ImageItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="58"/>
         <source>Image will be packed into save file. Warning: this will increase save file size.</source>
         <translation>La imagen se incluirá en el archivo guardado. Advertencia: esto aumentará el tamaño del archivo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="59"/>
         <source>Image will not be packed into a save file. Warning: if will use save file on other machine or rename file this image will disappear from 2D model.</source>
         <translation>La imagen no se incluirá en el archivo guardado. Advertencia: si usa el archivo guardado en otra máquina o renombra el archivo, esta imagen desaparecerá del modelo 2D.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="66"/>
         <source>The image will be in the background. Warning: the robot does not see this image.</source>
         <translation>La imagen estará en segundo plano. Advertencia: el robot no ve esta imagen.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="67"/>
         <source>The image will be in the foreground. Warning: robot sees this image with sensors.</source>
         <translation>La imagen estará en primer plano. Advertencia: el robot ve esta imagen con sus sensores.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="158"/>
         <source>Change image...</source>
         <translation>Cambiar imagen...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="162"/>
         <source>Select image</source>
         <translation>Seleccionar imagen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="164"/>
         <source>Graphics (*.*)</source>
         <translation>Gráficos (*.*)</translation>
     </message>
@@ -933,7 +759,6 @@
 <context>
     <name>twoDModel::view::Palette</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/palette.cpp" line="25"/>
         <source>Cursor (N)</source>
         <translation>Cursor (N)</translation>
     </message>
@@ -941,32 +766,26 @@
 <context>
     <name>twoDModel::view::RobotItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="78"/>
         <source>Camera folowing robot: %1</source>
         <translation>Cámara siguiendo al robot: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="79"/>
         <source>enabled</source>
         <translation>habilitado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="79"/>
         <source>disabled</source>
         <translation>deshabilitado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="86"/>
         <source>Return robot to the initial position</source>
         <translation>Devolver el robot a la posición inicial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="93"/>
         <source>Move start position here</source>
         <translation>Mover aquí la posición inicial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="112"/>
         <source>Marker thickness</source>
         <translation>Grosor del marcador</translation>
     </message>
@@ -974,7 +793,6 @@
 <context>
     <name>twoDModel::view::SpeedPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/speedPopup.cpp" line="30"/>
         <source>Reset to default</source>
         <translation>Restablecer valores predeterminados</translation>
     </message>
@@ -982,32 +800,26 @@
 <context>
     <name>twoDModel::view::TwoDModelScene</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="897"/>
         <source>Select images</source>
         <translation>Seleccionar imágenes</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="899"/>
         <source>Graphics (*.*)</source>
         <translation>Gráficos (*.*)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="913"/>
         <source>Warning</source>
         <translation>Advertencia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="914"/>
         <source>You are trying to load to big image, it may freeze execution for some time. Continue?</source>
         <translation>Está intentando cargar una imagen muy grande, lo que podría congelar la ejecución durante un tiempo. ¿Continuar?</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="923"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="924"/>
         <source>Cannot load %1. Try another file.</source>
         <translation>No se puede cargar %1. Intente con otro archivo.</translation>
     </message>
@@ -1019,70 +831,54 @@
         <translation type="vanished">cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="193"/>
         <source>kg</source>
         <translation>kg</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="385"/>
         <source>Warning</source>
         <translation>Advertencia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="386"/>
         <source>Do you really want to clear scene?</source>
         <translation>¿Realmente desea limpiar la escena?</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="496"/>
         <source>Training mode: solution will not be checked</source>
         <translation>Modo entrenamiento: la solución no será verificada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="497"/>
         <source>Checking mode: solution will be checked, errors will be reported</source>
         <translation>Modo verificación: la solución será comprobada, se informará de errores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="560"/>
         <source>Saving world and robot model</source>
         <translation>Guardando modelo del mundo y del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="560"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="580"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="605"/>
         <source>2D model saves (*.xml)</source>
         <translation>Guardados del modelo 2D (*.xml)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="580"/>
         <source>Loading world and robot model</source>
         <translation>Cargando modelo del mundo y del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="605"/>
         <source>Loading world without robot model</source>
         <translation>Cargando modelo del mundo sin modelo de robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="941"/>
         <source>Hide details</source>
         <translation>Ocultar detalles</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="941"/>
         <source>Show details</source>
         <translation>Mostrar detalles</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="1152"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="1153"/>
         <source>No wheel</source>
         <translation>Ausente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="1159"/>
         <source>%1 (port %2)</source>
         <translation>%1 (puerto %2)</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/editor/common_es.ts
+++ b/qrtranslations/es/plugins/robots/editor/common_es.ts
@@ -4,577 +4,422 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="26"/>
         <source>AbstractNode</source>
         <translation>Bloque base</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="61"/>
         <source>Clear Screen</source>
         <translation>Limpiar pantalla</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="63"/>
         <source>Clears everything drawn on the robot`s screen.</source>
         <translation>Borra todo lo dibujado en la pantalla del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="86"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="926"/>
         <source>Redraw</source>
         <translation>Actualizar imagen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="134"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="99"/>
         <source>This block can hold text notes that are ignored by generators and interpreters. Use it for improving the diagram readability.</source>
         <translation>Este bloque puede contener notas de texto que son ignoradas por los generadores e intérpretes. Úselo para mejorar la legibilidad del diagrama.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="134"/>
         <source>Enter some text here...</source>
         <translation>Introduzca texto aquí...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="145"/>
         <source>Link</source>
         <translation>Línea de conexión</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="147"/>
         <source>For creating a link between two elements A and B you can just hover a mouse above A, press the right mouse button and (without releasing it) draw a line to the element B. Alternatively you can just &apos;pull&apos; a link from a small blue circle next to the element.</source>
         <translation>Para crear un enlace entre dos elementos A y B, puede colocar el cursor sobre A, pulsar el botón derecho del ratón y (sin soltarlo) trazar una línea hasta el elemento B. Alternativamente, puede &apos;arrastrar&apos; un enlace desde el pequeño círculo azul junto al elemento.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="194"/>
         <source>Guard</source>
         <translation>Condición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="205"/>
         <source>EngineCommand</source>
         <translation>Bloque base de motores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="239"/>
         <source>EngineMovementCommand</source>
         <translation>Bloque base de activación de motores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="263"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="263"/>
         <source>Power (%)</source>
         <translation>Potencia (%)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="274"/>
         <source>End if</source>
         <translation>Fin de condición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="276"/>
         <source>Unites control flow from different condition branches.</source>
         <translation>Une las ramas del bloque &quot;Condición&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="309"/>
         <source>Final Node</source>
         <translation>Fin</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="311"/>
         <source>The final node of the program. If the program consists of some parallel execution lines the reachment of this block terminates the corresponding execution line. This block can`t have outgoing links.</source>
         <translation>Fin del programa. Si el programa consta de varios segmentos de ejecución paralelos, alcanzar este bloque finaliza el segmento correspondiente. Este bloque no puede tener enlaces salientes.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="344"/>
         <source>Fork</source>
         <translation>Tareas paralelas</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="346"/>
         <source>Separates program execution into a number of threads that will be executed concurrently from the programmers`s point of view. For example in such way signal from sensor and some time interval can be waited synchroniously. This block must have at least two outgoing links. &apos;Guard&apos; property of every link must contain unique thread identifiers, and one of those identifiers must be the same as the identifier of a thread where fork is placed (it must be &apos;main&apos; if it is the first fork in a program.</source>
         <translation>Divide la ejecución del programa en varias tareas que se ejecutarán en paralelo desde el punto de vista del programador. Por ejemplo, de esta forma se puede esperar simultáneamente una señal del sensor y un intervalo de tiempo. Este bloque debe tener al menos dos enlaces salientes. La propiedad &quot;Condición&quot; de cada enlace debe contener identificadores únicos de tareas, y uno de esos identificadores debe coincidir con el identificador de la tarea desde la que se coloca el bloque (debe ser &apos;main&apos; si es el primer bloque de bifurcación en el programa).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="379"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1297"/>
         <source>Expression</source>
         <translation>Expresión</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="381"/>
         <source>Evaluates a value of the given expression. Also new variables can be defined in this block. See the &apos;Expressions Syntax&apos; chapter in help for more information about &apos;Function&apos; block syntax.</source>
         <translation>Evalúa el valor de la expresión dada. También se pueden definir nuevas variables en este bloque. Consulte el capítulo &apos;Sintaxis de expresiones&apos; en la ayuda para obtener más información sobre la sintaxis del bloque &apos;Función&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="388"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1273"/>
         <source>Expression:</source>
         <translation>Expresión:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="424"/>
         <source>Get Button Code</source>
         <translation>Obtener código del botón</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="426"/>
         <source>Assigns a given variable a value of pressed button. If no button is pressed at the moment and &apos;Wait&apos; property is false when variable is set to -1.</source>
         <translation>Asigna a una variable dada el valor del botón pulsado. Si no se pulsa ningún botón en ese momento y la propiedad &apos;Esperar&apos; es falsa, la variable se establece en -1.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="433"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="574"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="948"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1010"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1371"/>
         <source>Variable:</source>
         <translation>Variable:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="441"/>
         <source>Wait:</source>
         <translation>Esperar:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="465"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="616"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="990"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1297"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1404"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="465"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="616"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="990"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1404"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="466"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="137"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="138"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="139"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="140"/>
         <source>Wait</source>
         <translation>Espera</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="477"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="511"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="864"/>
         <source>Condition</source>
         <translation>Condición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="479"/>
         <source>Separates program execution in correspondece with the given condition. The &apos;Condition&apos; parameter value must be some boolean expression that will determine subsequent program execution line. This block must have two outgoing links, at least one of them must have &apos;Guard&apos; parameter set to &apos;true&apos; or &apos;false&apos;. The execution will be proceed trough the link marked with the guard corresponding to &apos;Condition&apos; parameter of the block.</source>
         <translation>Divide la ejecución del programa según la condición dada. El valor del parámetro &apos;Condición&apos; debe ser una expresión booleana que determinará la siguiente línea de ejecución del programa. Este bloque debe tener dos enlaces salientes, al menos uno de ellos debe tener el parámetro &apos;Condición&apos; establecido en &apos;verdadero&apos; o &apos;falso&apos;. La ejecución continuará por el enlace marcado con la condición que corresponda al valor del parámetro &apos;Condición&apos; del bloque.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="486"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="840"/>
         <source>Condition:</source>
         <translation>Condición:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="511"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="864"/>
         <source>x &gt; 0</source>
         <translation>x &gt; 0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="522"/>
         <source>Initial Node</source>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="524"/>
         <source>The entry point of the program execution. Each diagram should have only one such block, it must not have incomming links and it must have only one outgoing link. The interpretation process starts from exactly this block.</source>
         <translation>Punto de entrada de la ejecución del programa. Cada diagrama debe tener solo un bloque de este tipo, no debe tener enlaces entrantes y debe tener solo un enlace saliente. El proceso de interpretación comienza exactamente en este bloque.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="565"/>
         <source>User Input</source>
         <translation>Entrada de usuario</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="567"/>
         <source>Reads a value into variable from an input dialog.</source>
         <translation>Lee un valor en una variable desde un cuadro de diálogo de entrada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="582"/>
         <source>Default:</source>
         <translation>Predeterminado:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="590"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="900"/>
         <source>Text:</source>
         <translation>Texto:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="627"/>
         <source>Join</source>
         <translation>Unión de tareas</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="629"/>
         <source>Joins a number of threads into one. &apos;Guard&apos; property of the single outgoing link must contain an identifier of one of threads being joined. The specified thread would wait until the rest of them finish execution, and then proceed in a normal way.</source>
         <translation>Une varias tareas en una. La propiedad &apos;Condición&apos; del único enlace saliente debe contener el identificador de una de las tareas que se están uniendo. La tarea especificada esperará hasta que las demás terminen su ejecución, y luego continuará normalmente.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="662"/>
         <source>Kill Thread</source>
         <translation>Finalizar tarea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="664"/>
         <source>Terminates execution of a specified thread.</source>
         <translation>Termina la ejecución de una tarea especificada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="671"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1121"/>
         <source>Thread:</source>
         <translation>Tarea:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="695"/>
         <source>main</source>
         <translation>main</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="695"/>
         <source>Thread</source>
         <translation>Tarea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="706"/>
         <source>Loop</source>
         <translation>Bucle</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="708"/>
         <source>This block executes a sequence of blocks for a given number of times. The number of repetitions is specified by the &apos;Iterations&apos; parameter. This block must have two outgoing links. One of them must be marked with the &apos;body&apos; guard (that means that the property &apos;Guard&apos; of the link must be set to &apos;body&apos; value). Another outgoing link must be unmarked: the program execution will be proceeded through this link when it will go through our &apos;Loop&apos; block for the given number of times.</source>
         <translation>Este bloque ejecuta una secuencia de bloques un número determinado de veces. El número de repeticiones se especifica mediante el parámetro &apos;Iteraciones&apos;. Este bloque debe tener dos enlaces salientes. Uno de ellos debe estar marcado con la condición &apos;cuerpo&apos; (es decir, la propiedad &apos;Condición&apos; del enlace debe establecerse en &apos;cuerpo&apos;). El otro enlace saliente debe quedar sin marcar: la ejecución del programa continuará por este enlace cuando haya pasado por el bloque &apos;Bucle&apos; el número de veces indicado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="715"/>
         <source>Iterations:</source>
         <translation>Iteraciones:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="741"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="989"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="741"/>
         <source>Iterations</source>
         <translation>Iteraciones</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="752"/>
         <source>Marker Down</source>
         <translation>Bajar marcador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="754"/>
         <source>Moves the marker of the 2D model robot down to the floor: the robot will draw its trace on the floor after that. If the marker of another color is already drawing at the moment it will be replaced.</source>
         <translation>Baja el marcador del robot en el modelo 2D hasta el suelo: el robot comenzará a dibujar su trayectoria sobre el suelo. Si ya hay un marcador de otro color bajado, será reemplazado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="761"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="785"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="796"/>
         <source>Marker Up</source>
         <translation>Subir marcador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="798"/>
         <source>Lifts the marker of the 2D model robot up: the robot stops drawing its trace on the floor after that.</source>
         <translation>Sube el marcador del robot en el modelo 2D: el robot deja de dibujar su trayectoria sobre el suelo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="831"/>
         <source>Pre-conditional Loop</source>
         <translation>Bucle con condición previa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="833"/>
         <source>This block executes a sequence of blocks while condition in &apos;Condition&apos; is true. This block must have two outgoing links. One of them must be marked with the &apos;body&apos; guard (that means that the property &apos;Guard&apos; of the link must be set to &apos;body&apos; value). Another outgoing link must be unmarked: the program execution will be proceeded through this link when condition becomes false.</source>
         <translation>Este bloque ejecuta una secuencia de bloques mientras la condición en &apos;Condición&apos; sea verdadera. Este bloque debe tener dos enlaces salientes. Uno de ellos debe estar marcado con la condición &apos;cuerpo&apos; (es decir, la propiedad &apos;Condición&apos; del enlace debe establecerse en &apos;cuerpo&apos;). El otro enlace saliente debe quedar sin marcar: la ejecución del programa continuará por este enlace cuando la condición se vuelva falsa.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="875"/>
         <source>Print Text</source>
         <translation>Imprimir texto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="877"/>
         <source>Prints a given line in the specified coordinates on the robot`s screen. The value of &apos;Text&apos; property is interpreted as a plain text unless &apos;Evaluate&apos; property is set to true, then it will be interpreted as an expression (that may be useful for example when debugging variables values).</source>
         <translation>Imprime una línea dada en las coordenadas especificadas de la pantalla del robot. El valor de la propiedad &apos;Texto&apos; se interpreta como texto plano, a menos que la propiedad &apos;Evaluar&apos; esté activada, en cuyo caso se interpretará como una expresión (lo que puede ser útil, por ejemplo, al depurar valores de variables).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="884"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="892"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="924"/>
         <source>Evaluate</source>
         <translation>Evaluar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="925"/>
         <source>Enter some text here</source>
         <translation>Introduzca texto aquí</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="925"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="927"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="928"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="927"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="928"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="939"/>
         <source>Random Initialization</source>
         <translation>Inicialización aleatoria</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="941"/>
         <source>Sets a variable value to a random value inside given interval.</source>
         <translation>Establece el valor de una variable en un valor aleatorio dentro del intervalo especificado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="956"/>
         <source>From:</source>
         <translation>Desde:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="964"/>
         <source>To:</source>
         <translation>Hasta:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="988"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1403"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="988"/>
         <source>From</source>
         <translation>Desde</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="989"/>
         <source>To</source>
         <translation>Hasta</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1001"/>
         <source>Receive Message From Thread</source>
         <translation>Recibir mensaje de la tarea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1003"/>
         <source>Receive a message sent to a thread from which this block is called.</source>
         <translation>Recibe un mensaje enviado a una tarea desde la cual se llama a este bloque.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1018"/>
         <source>Synchronized:</source>
         <translation>Esperar mensaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1042"/>
         <source>Synchronized</source>
         <translation>Esperar mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1054"/>
         <source>RobotsDiagramGroup</source>
         <translation>Diagrama de comportamiento de robots</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1069"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="111"/>
         <source>Robot`s Behaviour Diagram</source>
         <translation>Diagrama de comportamiento del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1112"/>
         <source>Send Message To Thread</source>
         <translation>Enviar mensaje a la tarea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1114"/>
         <source>Sends a message to a specified thread.</source>
         <translation>Envía un mensaje a una tarea especificada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1129"/>
         <source>Message:</source>
         <translation>Mensaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1165"/>
         <source>Subprogram</source>
         <translation>Subprograma</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1167"/>
         <source>Subprogram call. Subprograms are used for splitting repetitive program parts into a separate diagram and then calling it from main diagram or other subprograms. When this block is added into a diagram it will be suggested to enter subprogram name. The double click on subprogram call block may open the corresponding subprogram diagram. Moreover user palette will appear containing existing subrpograms, they can be dragged into a diagram like the usual blocks.</source>
         <translation>Llamada a subprograma. Los subprogramas se utilizan para separar partes repetitivas del programa en un diagrama independiente y luego invocarlos desde el diagrama principal u otros subprogramas. Al añadir este bloque al diagrama, se solicitará introducir el nombre del subprograma. Al hacer doble clic en el bloque de llamada al subprograma se puede abrir el diagrama correspondiente. Además, aparecerá una paleta de usuario con los subprogramas existentes, que pueden arrastrarse al diagrama como bloques normales.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1207"/>
         <source>Subprogram Diagram</source>
         <translation>Subprograma</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1249"/>
         <source>SubprogramDiagramGroup</source>
         <translation>Subprograma</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1264"/>
         <source>Switch</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1266"/>
         <source>Selects the program execution branch in correspondence with some expression value. The value of the expression written in &apos;Expression&apos; property is compared to the values on the outgoing links. If equal value is found then execution will be proceeded by that branch. Else branch without a marker will be selected.</source>
         <translation>Selecciona la rama de ejecución del programa según el valor de una expresión. El valor de la expresión escrita en la propiedad &apos;Expresión&apos; se compara con los valores en los enlaces salientes. Si se encuentra un valor igual, la ejecución continuará por esa rama. En caso contrario, se seleccionará la rama sin marcador.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1308"/>
         <source>Timer</source>
         <translation>Temporizador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1310"/>
         <source>Waits for a given time in milliseconds.</source>
         <translation>Espera un tiempo determinado en milisegundos.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1317"/>
         <source>Delay:</source>
         <translation>Retardo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1318"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1351"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1351"/>
         <source>Delay (ms)</source>
         <translation>Retardo (ms)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1362"/>
         <source>Variable Initialization</source>
         <translation>Inicialización de variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1364"/>
         <source>Assigns a given value to a given variable.</source>
         <translation>Asigna un valor determinado a una variable especificada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1379"/>
         <source>Value:</source>
         <translation>Valor:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1403"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="118"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="119"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="120"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="121"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="122"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="123"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="124"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="125"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="126"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="127"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="128"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="129"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="130"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="131"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="132"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="133"/>
         <source>Algorithms</source>
         <translation>Algoritmos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="134"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="135"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="136"/>
         <source>Actions</source>
         <translation>Acciones</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="141"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="143"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="144"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="145"/>
         <source>Drawing</source>
         <translation>Dibujo</translation>
     </message>
@@ -582,37 +427,30 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="413"/>
         <source>Expression</source>
         <translation>Expresión</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="614"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="615"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1043"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1101"/>
         <source>Devices configuration</source>
         <translation>Configuración de dispositivos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1153"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1154"/>
         <source>Thread</source>
         <translation>Tarea</translation>
     </message>
@@ -620,169 +458,134 @@
 <context>
     <name>RobotsMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="159"/>
         <source>norm</source>
         <translation>norma</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="159"/>
         <source>x-axis</source>
         <translation>eje x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="159"/>
         <source>y-axis</source>
         <translation>eje y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="159"/>
         <source>z-axis</source>
         <translation>eje z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="161"/>
         <source>Composite</source>
         <translation>Compuesto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="161"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="161"/>
         <source>Shared</source>
         <translation>Compartido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="163"/>
         <source>brake</source>
         <translation>freno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="163"/>
         <source>float</source>
         <translation>flotante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="165"/>
         <source>Concurrent</source>
         <translation>Concurrente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="165"/>
         <source>Guarded</source>
         <translation>Protegido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="165"/>
         <source>Sequential</source>
         <translation>Secuencial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>black</source>
         <translation>negro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>blue</source>
         <translation>azul</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>green</source>
         <translation>verde</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>red</source>
         <translation>rojo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>white</source>
         <translation>blanco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>yellow</source>
         <translation>amarillo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="169"/>
         <source>greater</source>
         <translation>mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="169"/>
         <source>less</source>
         <translation>menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="169"/>
         <source>not greater</source>
         <translation>no mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="169"/>
         <source>not less</source>
         <translation>no menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="171"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="177"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="171"/>
         <source>body</source>
         <translation>cuerpo del bucle</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="171"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="177"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="173"/>
         <source>In</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="173"/>
         <source>Inout</source>
         <translation>Entrada-salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="173"/>
         <source>Out</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="173"/>
         <source>Return</source>
         <translation>Devuelve</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="175"/>
         <source>Package</source>
         <translation>Paquete</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="175"/>
         <source>Private</source>
         <translation>Privado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="175"/>
         <source>Protected</source>
         <translation>Protegido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="175"/>
         <source>Public</source>
         <translation>Público</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/editor/ev3_es.ts
+++ b/qrtranslations/es/plugins/robots/editor/ev3_es.ts
@@ -4,297 +4,234 @@
 <context>
     <name>Ev3MetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="180"/>
         <source>norm</source>
         <translation>norma</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="180"/>
         <source>x-axis</source>
         <translation>eje x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="180"/>
         <source>y-axis</source>
         <translation>eje y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="180"/>
         <source>z-axis</source>
         <translation>eje z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="182"/>
         <source>Composite</source>
         <translation>Composición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="182"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="182"/>
         <source>Shared</source>
         <translation>Agregación</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="184"/>
         <source>brake</source>
         <translation>frenado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="184"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="198"/>
         <source>float</source>
         <translation>Valor de punto flotante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="186"/>
         <source>Concurrent</source>
         <translation>Concurrente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="186"/>
         <source>Guarded</source>
         <translation>Con vigilancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="186"/>
         <source>Sequential</source>
         <translation>Secuencial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
         <source>black</source>
         <translation>negro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
         <source>blue</source>
         <translation>azul</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>green</source>
         <translation>verde</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>red</source>
         <translation>rojo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
         <source>white</source>
         <translation>blanco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
         <source>yellow</source>
         <translation>amarillo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="190"/>
         <source>greater</source>
         <translation>mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="190"/>
         <source>less</source>
         <translation>menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="190"/>
         <source>not greater</source>
         <translation>no mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="190"/>
         <source>not less</source>
         <translation>no menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Down</source>
         <translation>Abajo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Enter</source>
         <translation>Adelante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Up</source>
         <translation>Arriba</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>green flash</source>
         <translation>verde parpadeante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>green pulse</source>
         <translation>verde pulsante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>off</source>
         <translation>apagar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>orange</source>
         <translation>naranja</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>orange flash</source>
         <translation>naranja parpadeante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>orange pulse</source>
         <translation>naranja pulsante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>red flash</source>
         <translation>rojo parpadeante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>red pulse</source>
         <translation>rojo pulsante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="196"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="196"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="196"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="196"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="198"/>
         <source>bool</source>
         <translation>Valor lógico</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="198"/>
         <source>int</source>
         <translation>Número entero</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="198"/>
         <source>string</source>
         <translation>Cadena</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="200"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="200"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="200"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="200"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="202"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="208"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="202"/>
         <source>body</source>
         <translation>cuerpo del bucle</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="202"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="208"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="204"/>
         <source>In</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="204"/>
         <source>Inout</source>
         <translation>Entrada-salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="204"/>
         <source>Out</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="204"/>
         <source>Return</source>
         <translation>Valor devuelto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="206"/>
         <source>Package</source>
         <translation>Paquete</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="206"/>
         <source>Private</source>
         <translation>Privado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="206"/>
         <source>Protected</source>
         <translation>Protegido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="206"/>
         <source>Public</source>
         <translation>Público</translation>
     </message>
@@ -302,1017 +239,706 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="26"/>
         <source>Beep</source>
         <translation>Pitido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="28"/>
         <source>Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.</source>
         <translation>Reproduce un sonido con frecuencia fija en el robot. Tiene dos parámetros: el primero es el volumen del sonido, el segundo indica si el programa debe esperar a que termine el sonido o pasar inmediatamente al siguiente bloque.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="35"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="911"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1972"/>
         <source>Volume:</source>
         <translation>Volumen:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="43"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="929"/>
         <source>Wait for Completion:</source>
         <translation>Esperar finalización:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="76"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="956"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="76"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="956"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2007"/>
         <source>Volume</source>
         <translation>Volumen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="77"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="957"/>
         <source>Wait for Completion</source>
         <translation>Esperar finalización</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="88"/>
         <source>Calibrate Black</source>
         <translation>Calibrar negro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="90"/>
         <source>Calibrates the black threshold for each sensor in the array. Place the array over the black surface with all sensors on the black area.</source>
         <translation>Calibra el umbral de negro para cada sensor del conjunto. Coloque el conjunto sobre la superficie negra con todos los sensores sobre la zona negra.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="141"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="185"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="292"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="977"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1030"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1083"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1154"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1313"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1357"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1401"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1498"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1552"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1631"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1694"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1757"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1899"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1964"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2027"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2072"/>
         <source>Port:</source>
         <translation>Puerto:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="121"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="165"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="271"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="316"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1009"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1062"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1133"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1186"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1293"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1337"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1381"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1433"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1532"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1610"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1672"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1736"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1807"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1943"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2005"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2052"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2096"/>
         <source>Port</source>
         <translation>Puerto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="132"/>
         <source>Calibrate gyroscope</source>
         <translation>Calibrar giroscopio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="134"/>
         <source>Sets gyroscope&apos;s angle to zero in current position.</source>
         <translation>Establece el ángulo del giroscopio a cero en la posición actual.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="176"/>
         <source>Calibrate PID</source>
         <translation>Calibrar controlador PID</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="178"/>
         <source>Sets set point, P, I, D value of PID control and P factor, I factor, D factor for P, I, D value of PID control.</source>
         <translation>Establece el punto de ajuste, valores P, I, D del control PID y factores P, I, D para los valores P, I, D del control PID.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="193"/>
         <source>Set point:</source>
         <translation>Punto de ajuste:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="201"/>
         <source>P:</source>
         <translation>P:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="209"/>
         <source>P factor:</source>
         <translation>Factor P:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="217"/>
         <source>I:</source>
         <translation>I:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="225"/>
         <source>I factor:</source>
         <translation>Factor I:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="233"/>
         <source>D:</source>
         <translation>D:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="241"/>
         <source>D factor:</source>
         <translation>Factor D:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="265"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="266"/>
         <source>D factor</source>
         <translation>Factor D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="267"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="268"/>
         <source>I factor</source>
         <translation>Factor I</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="269"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="270"/>
         <source>P factor</source>
         <translation>Factor P</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="272"/>
         <source>Set point</source>
         <translation>Punto medio del sensor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="283"/>
         <source>Calibrate White</source>
         <translation>Calibrar blanco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="285"/>
         <source>Calibrates the white threshold for each sensor in the array. Place the array over the white surface with all sensors on the white area.</source>
         <translation>Calibra el umbral de blanco para cada sensor del conjunto. Coloque el conjunto sobre la superficie blanca con todos los sensores sobre la zona blanca.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="327"/>
         <source>Clear Encoder</source>
         <translation>Borrar codificador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="329"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Anula el valor del contador de revoluciones de los motores en los puertos indicados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="336"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="696"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="750"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="804"/>
         <source>Ports:</source>
         <translation>Puertos:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="361"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="837"/>
         <source>A, B, C, D</source>
         <translation>A, B, C, D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="361"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="675"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="729"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="783"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="837"/>
         <source>Ports</source>
         <translation>Puertos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="372"/>
         <source>Draw Circle</source>
         <translation>Dibujar círculo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="374"/>
         <source>Draws on the robot screen a circle with the given center and radius.</source>
         <translation>Dibuja en la pantalla del robot un círculo con el centro y radio dados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="381"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="525"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="579"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="389"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="533"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="587"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="397"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="405"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="611"/>
         <source>Filled:</source>
         <translation>Relleno:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="429"/>
         <source>Radius</source>
         <translation>Radio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="430"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="635"/>
         <source>Filled</source>
         <translation>Relleno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="431"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="501"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="557"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="637"/>
         <source>Redraw</source>
         <translation>Actualizar imagen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="432"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="558"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="639"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="433"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="559"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="640"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="444"/>
         <source>Draw Line</source>
         <translation>Dibujar línea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="446"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Dibuja un segmento en la pantalla del robot. Los parámetros especifican los extremos del segmento.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="453"/>
         <source>X1:</source>
         <translation>X1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="461"/>
         <source>Y1:</source>
         <translation>Y1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="469"/>
         <source>X2:</source>
         <translation>X2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="477"/>
         <source>Y2:</source>
         <translation>Y2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="502"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="503"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="504"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="505"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="516"/>
         <source>Draw Pixel</source>
         <translation>Dibujar píxel</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="518"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Dibuja un píxel en las coordenadas especificadas en la pantalla del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="570"/>
         <source>Draw Rectangle</source>
         <translation>Dibujar rectángulo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="572"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Dibuja un rectángulo en la pantalla del robot. Los parámetros especifican las coordenadas de la esquina superior izquierda, el ancho y la altura del rectángulo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="595"/>
         <source>Width:</source>
         <translation>Ancho:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="603"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="636"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="638"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="651"/>
         <source>Ev3EngineMovementCommand</source>
         <translation>Bloque base de motores EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="675"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="729"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="783"/>
         <source>B, C</source>
         <translation>B, C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="676"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="730"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="784"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="676"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="730"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="784"/>
         <source>Power (%)</source>
         <translation>Potencia (%)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="687"/>
         <source>Motors Backward</source>
         <translation>Motores hacia atrás</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="689"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Habilita los motores en los puertos indicados en modo inverso con la potencia especificada. Los puertos se indican con las letras A, B o C, separadas por comas. La potencia se especifica en porcentaje con un número de -100 a 100; si se indica un número negativo, el motor se activa en modo normal.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="704"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="758"/>
         <source>Power:</source>
         <translation>Potencia:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="741"/>
         <source>Motors Forward</source>
         <translation>Motores hacia adelante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="743"/>
         <source>Enables motors on the given ports with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Habilita los motores en los puertos indicados con la potencia especificada. Los puertos se indican con las letras A, B o C, separadas por comas. La potencia se especifica en porcentaje con un número de -100 a 100; si se indica un número negativo, el motor se activa en modo inverso.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="795"/>
         <source>Stop Motors</source>
         <translation>Detener motores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="797"/>
         <source>Disables motors on the given ports.</source>
         <translation>Desactiva los motores en los puertos indicados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="836"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="848"/>
         <source>Led</source>
         <translation>LED</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="850"/>
         <source>Sets the color of the LED on the robot`s front panel.</source>
         <translation>Establece el color del LED en el panel frontal del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="857"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1506"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="882"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1531"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="893"/>
         <source>Play Tone</source>
         <translation>Reproducir tono</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="895"/>
         <source>Plays on the robot a sound with the given frequency and duration. This block is similar to the &apos;Beep&apos; block wuth the only difference that here you can specify sound parameters.</source>
         <translation>Reproduce en el robot un sonido con la frecuencia y duración indicadas. Este bloque es similar al bloque &apos;Beep&apos;, con la única diferencia de que aquí puedes especificar los parámetros del sonido.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="902"/>
         <source>Frequency:</source>
         <translation>Frecuencia:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="903"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="912"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="920"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="954"/>
         <source>Duration</source>
         <translation>Duración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="921"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="954"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="955"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="955"/>
         <source>Frequency</source>
         <translation>Frecuencia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="968"/>
         <source>Read Sensor to Array</source>
         <translation>Leer sensor al arreglo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="970"/>
         <source>Read the values from the Line Leader.  Amount of light or dark each sensor sees.  Typically between 0-20.  0=black, 100=white.</source>
         <translation>Lee los valores del sensor Line Leader. Cantidad de luz u oscuridad que detecta cada sensor. Normalmente entre 0 y 20. 0=negro, 100=blanco.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="985"/>
         <source>Array:</source>
         <translation>Arreglo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1010"/>
         <source>a</source>
         <translation>a</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1010"/>
         <source>Array Variable</source>
         <translation>Variable de arreglo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1021"/>
         <source>Read Average to Variable</source>
         <translation>Leer promedio ponderado a variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1023"/>
         <source>Read the Weighted Average value from the sensor.  This value is calculated internally by the sensor where each of the eight sensors is either triggered or not and multiplied by a factor to help determine if the line is left, right or on center of the line (according to the set point). EXPECTED VALUES: 0-80 (-1=ERROR)</source>
         <translation>Lee el valor promedio ponderado del sensor. Este valor se calcula internamente por el sensor, donde cada uno de los ocho sensores se activa o no y se multiplica por un factor para ayudar a determinar si la línea está a la izquierda, a la derecha o en el centro (según el punto de ajuste). VALORES ESPERADOS: 0-80 (-1=ERROR)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1038"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1162"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1409"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1844"/>
         <source>Variable:</source>
         <translation>Variable:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1063"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1187"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1063"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1187"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1074"/>
         <source>Read RGB into Variables</source>
         <translation>Leer valores RGB a variables</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1076"/>
         <source>Reads R, G, B channels values into given variables</source>
         <translation>Lee los valores de los canales R, G, B a las variables indicadas</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1091"/>
         <source>R Variable:</source>
         <translation>Variable R:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1099"/>
         <source>G Variable:</source>
         <translation>Variable G:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1107"/>
         <source>B Variable:</source>
         <translation>Variable B:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1131"/>
         <source>b</source>
         <translation>b</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1131"/>
         <source>B Variable</source>
         <translation>Variable B</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1132"/>
         <source>g</source>
         <translation>g</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1132"/>
         <source>G Variable</source>
         <translation>Variable G</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1134"/>
         <source>r</source>
         <translation>r</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1134"/>
         <source>R Variable</source>
         <translation>Variable R</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1145"/>
         <source>Read Steering to Variable</source>
         <translation>Leer valor de dirección a variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1147"/>
         <source>Read the Steering value from the sensor.  This value is calculated internally and can directly be used to set turning values for the robot&apos;s motors. EXPECTED VALUES: -100 to 100 (-101=ERROR)</source>
         <translation>Lee el valor de dirección del sensor. Este valor se calcula internamente y puede usarse directamente para establecer los valores de giro de los motores del robot. VALORES ESPERADOS: -100 a 100 (-101=ERROR)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1198"/>
         <source>Send Mail</source>
         <translation>Enviar correo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1200"/>
         <source>Sends mail (message) to another robot. If Receiver name left empty, message will be sent to all connected robots</source>
         <translation>Envía un correo (mensaje) a otro robot. Si el nombre del destinatario se deja vacío, el mensaje se enviará a todos los robots conectados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1207"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1828"/>
         <source>Message type:</source>
         <translation>Tipo de mensaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1215"/>
         <source>Message:</source>
         <translation>Mensaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1223"/>
         <source>Receiver name:</source>
         <translation>Nombre del destinatario:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1231"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1836"/>
         <source>Mailbox name:</source>
         <translation>Nombre del buzón:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1255"/>
         <source>42</source>
         <translation>42</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1255"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1256"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1877"/>
         <source>Message type</source>
         <translation>Tipo de mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1257"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1876"/>
         <source>EV3MailBox</source>
         <translation>BuzónEV3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1257"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1876"/>
         <source>Mailbox name</source>
         <translation>Nombre del buzón</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1269"/>
         <source>Ev3SensorBlock</source>
         <translation>Bloque sensor EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1304"/>
         <source>Sleep Line Leader</source>
         <translation>Poner sensor de línea en modo reposo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1306"/>
         <source>Puts the line leader to sleep conserve power</source>
         <translation>Pone el sensor de línea en modo reposo para ahorrar energía</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1348"/>
         <source>Start Compass Calibration</source>
         <translation>Iniciar calibración de la brújula</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1350"/>
         <source>Starts compass calibration under program control. To calibrate, robot needs to spin &gt;=540 clockwise and counterclockwise with minimum 20 seconds duration for each direction. Atfer robot rotation add Stop Compass Сalibration block.</source>
         <translation>Inicia la calibración de la brújula mediante programa. Para calibrar, el robot debe girar al menos 540 grados en sentido horario y antihorario, con una duración mínima de 20 segundos por cada dirección. Tras la rotación, añada el bloque &apos;Detener calibración de la brújula&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1392"/>
         <source>Stop Compass Calibration</source>
         <translation>Detener calibración de la brújula</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1394"/>
         <source>Ends compass calibration process. Stores result of calibration into the given variable. Not zero means success.</source>
         <translation>Finaliza el proceso de calibración de la brújula. Almacena el resultado de la calibración en la variable indicada. Un valor distinto de cero indica éxito.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1445"/>
         <source>Wait for button</source>
         <translation>Esperar pulsación de botón</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1447"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Espera a que se pulse un botón en el ladrillo del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1454"/>
         <source>Button:</source>
         <translation>Botón:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1478"/>
         <source>Button</source>
         <translation>Botón</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1489"/>
         <source>Wait for Color</source>
         <translation>Esperar color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1491"/>
         <source>Waits till the color sensor on the given port will recognize the given color.</source>
         <translation>Espera hasta que el sensor de color en el puerto indicado reconozca el color especificado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1543"/>
         <source>Wait for Color Intensity</source>
         <translation>Esperar intensidad de color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1545"/>
         <source>Waits till the value returned by the color sensor on the given port will be greater or less than the given in the &apos;Intensity&apos; parameter value (the intensity is specified in percents, 0 to 100).</source>
         <translation>Espera hasta que el valor devuelto por el sensor de color en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Intensidad&apos; (la intensidad se indica en porcentaje, de 0 a 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1560"/>
         <source>Intensity:</source>
         <translation>Intensidad:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1568"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1647"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1710"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1773"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1916"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1980"/>
         <source>Sign:</source>
         <translation>Signo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1609"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1806"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1942"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2007"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1609"/>
         <source>Intensity</source>
         <translation>Intensidad</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1611"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1673"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1737"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1808"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1944"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2006"/>
         <source>Sign</source>
         <translation>Signo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1622"/>
         <source>Wait for Encoder</source>
         <translation>Esperar codificador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1624"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Espera hasta que el límite del cuentarrevoluciones del motor en el puerto indicado alcance el valor del parámetro &apos;Límite de cuentarrevoluciones&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1639"/>
         <source>Tacho Limit:</source>
         <translation>Límite de cuentarrevoluciones:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1685"/>
         <source>Wait for Gyroscope</source>
         <translation>Esperar giroscopio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1687"/>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given.</source>
         <translation>Espera hasta que el valor devuelto por el giroscopio en el puerto indicado sea mayor o menor que el valor especificado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1702"/>
         <source>Value:</source>
         <translation>Valor:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1735"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1735"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1748"/>
         <source>Wait for Light</source>
         <translation>Esperar luz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1750"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Espera hasta que el valor devuelto por el sensor de luz en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Porcentaje&apos; (0 a 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1765"/>
         <source>Percents:</source>
         <translation>Porcentaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1806"/>
         <source>Percents</source>
         <translation>Porcentaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1819"/>
         <source>Wait for Mail Receiving</source>
         <translation>Esperar recepción de mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1821"/>
         <source>Stores a message from another robot (fom mailbox) into a given variable. When no incoming messages are present at the moment, a robot will wait for incoming message if &apos;Synchronized&apos; property is true, and doing nothing otherwise.</source>
         <translation>Almacena un mensaje de otro robot (del buzón) en una variable dada. Si no hay mensajes entrantes en ese momento, el robot esperará un mensaje si la propiedad &apos;Sincronizado&apos; es verdadera; en caso contrario, no hará nada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1852"/>
         <source>Synchronized:</source>
         <translation>Sincronizado:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1878"/>
         <source>Synchronized</source>
         <translation>Sincronizado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1890"/>
         <source>Wait for Range Sensor</source>
         <translation>Esperar sensor de distancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1892"/>
         <source>Waits till the value returned by the ultrasonic or infrared range sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, 0 to 255).</source>
         <translation>Espera hasta que el valor devuelto por el sensor de distancia ultrasónico o infrarrojo en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Distancia&apos; (la distancia se indica en centímetros, de 0 a 255).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1907"/>
         <source>Distance:</source>
         <translation>Distancia:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1908"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1942"/>
         <source>Distance</source>
         <translation>Distancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1955"/>
         <source>Wait for Sound Sensor</source>
         <translation>Esperar sensor de sonido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1957"/>
         <source>Waits till the loudness obtained by the sound sensor on the given port will be greater or less than the given value.</source>
         <translation>Espera hasta que el nivel de sonido obtenido por el sensor de sonido en el puerto indicado sea mayor o menor que el valor especificado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2018"/>
         <source>Wait for Touch Sensor</source>
         <translation>Esperar sensor táctil</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2020"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Espera hasta que se pulse el sensor táctil. El único parámetro es el número del puerto del sensor (1, 2, 3 o 4).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2063"/>
         <source>Wake Up Line Leader</source>
         <translation>Activar sensor de línea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2065"/>
         <source>Wakes the line leader to prepare for use.</source>
         <translation>Activa el sensor de línea para prepararlo para su uso.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="122"/>
         <source>RobotsDiagram</source>
         <translation>Diagrama de comportamiento del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="129"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="130"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="131"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="132"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="133"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="134"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="135"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="136"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="137"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="138"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="139"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="140"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="141"/>
         <source>Actions</source>
         <translation>Acciones</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="143"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="144"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="145"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="146"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="147"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="148"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="149"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="150"/>
         <source>Line Leader</source>
         <translation>Sensor de línea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="151"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="152"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="153"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="154"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="155"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="156"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="157"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="158"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="159"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="160"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="161"/>
         <source>Wait</source>
         <translation>Espera</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="162"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="163"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="164"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="165"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="166"/>
         <source>Drawing</source>
         <translation>Dibujo</translation>
     </message>
@@ -1320,18 +946,14 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1258"/>
         <source>Receiver name</source>
         <translation>Nombre del receptor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1434"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1879"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1674"/>
         <source>Tacho Limit</source>
         <translation>Límite de cuentarrevoluciones</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/editor/nxt_es.ts
+++ b/qrtranslations/es/plugins/robots/editor/nxt_es.ts
@@ -4,209 +4,166 @@
 <context>
     <name>NxtMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="120"/>
         <source>norm</source>
         <translation>norma</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="120"/>
         <source>x-axis</source>
         <translation>eje x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="120"/>
         <source>y-axis</source>
         <translation>eje y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="120"/>
         <source>z-axis</source>
         <translation>eje z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="122"/>
         <source>Composite</source>
         <translation>Composición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="122"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="122"/>
         <source>Shared</source>
         <translation>Agregación</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="124"/>
         <source>brake</source>
         <translation>frenado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="124"/>
         <source>float</source>
         <translation>flotar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="126"/>
         <source>Concurrent</source>
         <translation>Concurrente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="126"/>
         <source>Guarded</source>
         <translation>Con vigilancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="126"/>
         <source>Sequential</source>
         <translation>Secuencial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>black</source>
         <translation>negro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>blue</source>
         <translation>azul</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>green</source>
         <translation>verde</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>red</source>
         <translation>rojo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>white</source>
         <translation>blanco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>yellow</source>
         <translation>amarillo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="130"/>
         <source>greater</source>
         <translation>mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="130"/>
         <source>less</source>
         <translation>menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="130"/>
         <source>not greater</source>
         <translation>no mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="130"/>
         <source>not less</source>
         <translation>no menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="132"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="142"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="132"/>
         <source>body</source>
         <translation>cuerpo del bucle</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="132"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="142"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="134"/>
         <source>Enter</source>
         <translation>Enter</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="134"/>
         <source>Escape</source>
         <translation>Escape</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="134"/>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="134"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="136"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="136"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="136"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="136"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="138"/>
         <source>In</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="138"/>
         <source>Inout</source>
         <translation>Entrada-salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="138"/>
         <source>Out</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="138"/>
         <source>Return</source>
         <translation>Valor devuelto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="140"/>
         <source>Package</source>
         <translation>Paquete</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="140"/>
         <source>Private</source>
         <translation>Privado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="140"/>
         <source>Protected</source>
         <translation>Protegido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="140"/>
         <source>Public</source>
         <translation>Público</translation>
     </message>
@@ -214,578 +171,398 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="26"/>
         <source>Beep</source>
         <translation>Pitido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="28"/>
         <source>Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.</source>
         <translation>Reproduce en el robot un sonido con frecuencia fija. Hay dos parámetros. El primero es el volumen del sonido, el segundo indica si el programa debe esperar a que termine el sonido o pasar al siguiente bloque inmediatamente.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="35"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="613"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1098"/>
         <source>Volume:</source>
         <translation>Volumen:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="43"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="631"/>
         <source>Wait for Completion:</source>
         <translation>Esperar finalización:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="76"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="658"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="76"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="658"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1133"/>
         <source>Volume</source>
         <translation>Volumen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="77"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="659"/>
         <source>Wait for Completion</source>
         <translation>Esperar finalización</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="88"/>
         <source>Clear Encoder</source>
         <translation>Borrar codificador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="90"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Anula el límite del tacómetro de los motores en los puertos indicados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="440"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="496"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="552"/>
         <source>Ports:</source>
         <translation>Puertos:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="122"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="584"/>
         <source>A, B, C</source>
         <translation>A, B, C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="122"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="419"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="475"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="531"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="584"/>
         <source>Ports</source>
         <translation>Puertos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="133"/>
         <source>Draw Circle</source>
         <translation>Dibujar círculo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="135"/>
         <source>Draws on the robot screen a circle with the given center and radius.</source>
         <translation>Dibuja en la pantalla del robot un círculo con el centro y el radio dados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="277"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="331"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="150"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="285"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="339"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="158"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="182"/>
         <source>Radius</source>
         <translation>Radio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="183"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="253"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="309"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="380"/>
         <source>Redraw</source>
         <translation>Redibujar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="184"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="310"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="382"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="185"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="311"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="383"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="196"/>
         <source>Draw Line</source>
         <translation>Dibujar línea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="198"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Dibuja un segmento en la pantalla del robot. Los parámetros especifican los extremos del segmento.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="205"/>
         <source>X1:</source>
         <translation>X1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="213"/>
         <source>Y1:</source>
         <translation>Y1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="221"/>
         <source>X2:</source>
         <translation>X2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="229"/>
         <source>Y2:</source>
         <translation>Y2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="254"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="255"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="256"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="257"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="268"/>
         <source>Draw Pixel</source>
         <translation>Dibujar píxel</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="270"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Dibuja un píxel en las coordenadas especificadas en la pantalla del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="322"/>
         <source>Draw Rectangle</source>
         <translation>Dibujar rectángulo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="324"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Dibuja un rectángulo en la pantalla del robot. Los parámetros especifican las coordenadas de la esquina superior izquierda, el ancho y la altura del rectángulo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="347"/>
         <source>Width:</source>
         <translation>Ancho:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="355"/>
         <source>Height:</source>
         <translation>Alto:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="379"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="381"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="394"/>
         <source>NxtEngineMovementCommand</source>
         <translation>Bloque base de motores NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="418"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="474"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="530"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="419"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="475"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="531"/>
         <source>B, C</source>
         <translation>B, C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="420"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="476"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="532"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="420"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="476"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="532"/>
         <source>Power (%)</source>
         <translation>Potencia (%)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="431"/>
         <source>Motors Backward</source>
         <translation>Motores en reversa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="433"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Habilita los motores en los puertos indicados en modo reversa con la potencia especificada. Los puertos se indican con las letras A, B o C, separadas por comas. La potencia se especifica en porcentaje con un número del -100 al 100; si se indica un número negativo, el motor se activa en modo normal.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="448"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="504"/>
         <source>Power:</source>
         <translation>Potencia:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="449"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="505"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="614"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="487"/>
         <source>Motors Forward</source>
         <translation>Motores hacia adelante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="489"/>
         <source>Enables motors on the given ports with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Habilita los motores en los puertos indicados con la potencia especificada. Los puertos se indican con las letras A, B o C, separadas por comas. La potencia se especifica en porcentaje con un número del -100 al 100; si se indica un número negativo, el motor se activa en modo reversa.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="543"/>
         <source>Stop Motors</source>
         <translation>Detener motores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="545"/>
         <source>Disables motors on the given ports.</source>
         <translation>Desactiva los motores en los puertos indicados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="595"/>
         <source>Play Tone</source>
         <translation>Reproducir tono</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="597"/>
         <source>Plays on the robot a sound with the given frequency and duration. This block is similar to the &apos;Beep&apos; block wuth the only difference that here you can specify sound parameters.</source>
         <translation>Reproduce en el robot un sonido con la frecuencia y duración indicadas. Este bloque es similar al bloque &apos;Beep&apos;, con la diferencia de que aquí se pueden especificar los parámetros del sonido.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="604"/>
         <source>Frequency:</source>
         <translation>Frecuencia:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="605"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="622"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="656"/>
         <source>Duration</source>
         <translation>Duración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="623"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="656"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="657"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="657"/>
         <source>Frequency</source>
         <translation>Frecuencia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="670"/>
         <source>NxtSensorBlock</source>
         <translation>Bloque sensor base NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="694"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="792"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="870"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="932"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1004"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1069"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1131"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1178"/>
         <source>Port</source>
         <translation>Puerto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="705"/>
         <source>Wait for Button</source>
         <translation>Esperar pulsación de botón</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="707"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Espera a que se pulse un botón en el ladrillo del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="714"/>
         <source>Button:</source>
         <translation>Botón:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="738"/>
         <source>Button</source>
         <translation>Botón</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="749"/>
         <source>Wait for Color</source>
         <translation>Esperar color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="751"/>
         <source>Waits till the color sensor on the given port will recognize the given color.</source>
         <translation>Espera hasta que el sensor de color en el puerto indicado reconozca el color especificado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="758"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="812"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="891"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="954"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1025"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1090"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1153"/>
         <source>Port:</source>
         <translation>Puerto:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="766"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="791"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="803"/>
         <source>Wait for Color Intensity</source>
         <translation>Esperar intensidad de color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="805"/>
         <source>Waits till the value returned by the color sensor on the given port will be greater or less than the given in the &apos;Intensity&apos; parameter value (the intensity is specified in percents, 0 to 100).</source>
         <translation>Espera hasta que el valor devuelto por el sensor de color en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Intensidad&apos; (la intensidad se especifica en porcentaje, de 0 a 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="820"/>
         <source>Intensity:</source>
         <translation>Intensidad:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="828"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="907"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="970"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1042"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1106"/>
         <source>Sign:</source>
         <translation>Valor leído:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="869"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1003"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1068"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1133"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="869"/>
         <source>Intensity</source>
         <translation>Intensidad</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="871"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="933"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1005"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1070"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1132"/>
         <source>Sign</source>
         <translation>Valor leído</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="882"/>
         <source>Wait for Encoder</source>
         <translation>Esperar codificador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="884"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Espera hasta que el límite del tacómetro del motor en el puerto indicado alcance el valor del parámetro &apos;Límite del tacómetro&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="899"/>
         <source>Tacho Limit:</source>
         <translation>Límite del tacómetro:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="932"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="945"/>
         <source>Wait for Light</source>
         <translation>Esperar luz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="947"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Espera hasta que el valor devuelto por el sensor de luz en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Porcentaje&apos; (0 a 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="962"/>
         <source>Percents:</source>
         <translation>Porcentaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1003"/>
         <source>Percents</source>
         <translation>Porcentaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1016"/>
         <source>Wait for Sonar Distance</source>
         <translation>Esperar distancia del sonar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1018"/>
         <source>Waits till the value returned by the ultrasonic sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, 0 to 255).</source>
         <translation>Espera hasta que el valor devuelto por el sensor ultrasónico en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Distancia&apos; (la distancia se especifica en centímetros, de 0 a 255).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1033"/>
         <source>Distance:</source>
         <translation>Distancia:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1034"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1068"/>
         <source>Distance</source>
         <translation>Distancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1081"/>
         <source>Wait for Sound Sensor</source>
         <translation>Esperar sensor de sonido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1083"/>
         <source>Waits till the loudness obtained by the sound sensor on the given port will be greater or less than the given value.</source>
         <translation>Espera hasta que el nivel de volumen obtenido por el sensor de sonido en el puerto indicado sea mayor o menor que el valor especificado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1144"/>
         <source>Wait for Touch Sensor</source>
         <translation>Esperar sensor táctil</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1146"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Espera hasta que se active el sensor táctil. El único parámetro es el número del puerto del sensor (1, 2, 3 o 4).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="79"/>
         <source>RobotsDiagram</source>
         <translation>Diagrama de comportamiento del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="86"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="87"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="88"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="89"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="90"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="91"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="92"/>
         <source>Actions</source>
         <translation>Acciones</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="93"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="94"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="95"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="96"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="98"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="99"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="100"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="101"/>
         <source>Wait</source>
         <translation>Esperar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="102"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="103"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="104"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="105"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="106"/>
         <source>Drawing</source>
         <translation>Dibujo</translation>
     </message>
@@ -793,7 +570,6 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="934"/>
         <source>Tacho Limit</source>
         <translation>Límite del tacómetro</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/editor/pioneer_es.ts
+++ b/qrtranslations/es/plugins/robots/editor/pioneer_es.ts
@@ -4,209 +4,166 @@
 <context>
     <name>PioneerMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="126"/>
         <source>norm</source>
         <translation>normal</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="126"/>
         <source>x-axis</source>
         <translation>eje x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="126"/>
         <source>y-axis</source>
         <translation>eje y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="126"/>
         <source>z-axis</source>
         <translation>eje z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="128"/>
         <source>Composite</source>
         <translation>Composición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="128"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="128"/>
         <source>Shared</source>
         <translation>Agregación</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="130"/>
         <source>brake</source>
         <translation>frenado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="130"/>
         <source>float</source>
         <translation>float</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="132"/>
         <source>Concurrent</source>
         <translation>Concurrente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="132"/>
         <source>Guarded</source>
         <translation>Con vigilancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="132"/>
         <source>Sequential</source>
         <translation>Secuencial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>black</source>
         <translation>negro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>blue</source>
         <translation>azul</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>green</source>
         <translation>verde</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>red</source>
         <translation>rojo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>white</source>
         <translation>blanco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>yellow</source>
         <translation>amarillo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="136"/>
         <source>greater</source>
         <translation>mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="136"/>
         <source>less</source>
         <translation>menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="136"/>
         <source>not greater</source>
         <translation>no mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="136"/>
         <source>not less</source>
         <translation>no menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="138"/>
         <source>Altfu</source>
         <translation>Altfu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="138"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="138"/>
         <source>Output</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="148"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="142"/>
         <source>body</source>
         <translation>cuerpo del bucle</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="148"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="144"/>
         <source>In</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="144"/>
         <source>Inout</source>
         <translation>Entrada-salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="144"/>
         <source>Out</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="144"/>
         <source>Return</source>
         <translation>Retorno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="146"/>
         <source>Package</source>
         <translation>Paquete</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="146"/>
         <source>Private</source>
         <translation>Privado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="146"/>
         <source>Protected</source>
         <translation>Protegido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="146"/>
         <source>Public</source>
         <translation>Público</translation>
     </message>
@@ -214,616 +171,446 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="26"/>
         <source>Landing</source>
         <translation>Aterrizaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="28"/>
         <source>Orders quadcopter to land.</source>
         <translation>Ordena al cuadricóptero que aterrice.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="61"/>
         <source>Takeoff</source>
         <translation>Despegue</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="63"/>
         <source>Orders quadcopter to takeoff.</source>
         <translation>Ordena al cuadricóptero que despegue.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="96"/>
         <source>Go to point</source>
         <translation>Ir al punto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="98"/>
         <source>Orders quadcopter to fly to given GPS coordinates.</source>
         <translation>Ordena al cuadricóptero volar a las coordenadas GPS indicadas.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="105"/>
         <source>Latitude:</source>
         <translation>Latitud:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="113"/>
         <source>Longitude:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="121"/>
         <source>Altitude:</source>
         <translation>Altitud:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="145"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="145"/>
         <source>Altitude</source>
         <translation>Altitud</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="146"/>
         <source>600859810</source>
         <translation>600859810</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="146"/>
         <source>Latitude</source>
         <translation>Latitud</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="147"/>
         <source>304206500</source>
         <translation>304206500</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="147"/>
         <source>Longitude</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="158"/>
         <source>Go to local point</source>
         <translation>Ir al punto (coordenadas locales)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="160"/>
         <source>Orders quadcopter to fly to given coordinates.</source>
         <translation>Ordena al cuadricóptero volar a las coordenadas indicadas.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="167"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="310"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="372"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="434"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="496"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="175"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="318"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="380"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="442"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="504"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="183"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="326"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="388"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="450"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="512"/>
         <source>Z:</source>
         <translation>Z:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="191"/>
         <source>Time:</source>
         <translation>Tiempo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="217"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="218"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="219"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="715"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="217"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="350"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="412"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="474"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="536"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="218"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="351"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="413"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="475"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="537"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="219"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="352"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="414"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="476"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="538"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="230"/>
         <source>GPIO Initialization</source>
         <translation>Inicialización de GPIO</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="232"/>
         <source>Create GPIO in settings port.</source>
         <translation>Crea un GPIO en el puerto con la configuración especificada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="239"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="817"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="916"/>
         <source>Pin name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="247"/>
         <source>Port:</source>
         <translation>Puerto:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="255"/>
         <source>Pin:</source>
         <translation>Pin:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="263"/>
         <source>Mode:</source>
         <translation>Modo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="287"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="288"/>
         <source>Pin</source>
         <translation>Número de pin</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="289"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="849"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="940"/>
         <source>pin_name</source>
         <translation>pin_name</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="289"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="849"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="940"/>
         <source>Pin name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="290"/>
         <source>Port</source>
         <translation>Puerto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="301"/>
         <source>Get Accelerometer</source>
         <translation>Leer acelerómetro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="303"/>
         <source>Returns accelerometer.</source>
         <translation>Devuelve los datos del acelerómetro del cuadricóptero en los tres ejes.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="350"/>
         <source>aX</source>
         <translation>aX</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="351"/>
         <source>aY</source>
         <translation>aY</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="352"/>
         <source>aZ</source>
         <translation>aZ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="363"/>
         <source>Get Gyroscope</source>
         <translation>Leer giroscopio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="365"/>
         <source>Returns gyroscope.</source>
         <translation>Devuelve los datos del giroscopio del cuadricóptero en los tres ejes.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="412"/>
         <source>gX</source>
         <translation>gX</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="413"/>
         <source>gY</source>
         <translation>gY</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="414"/>
         <source>gZ</source>
         <translation>gZ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="425"/>
         <source>Get LPS Position</source>
         <translation>Obtener posición (LPS)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="427"/>
         <source>Returns position (local positioning system).</source>
         <translation>Devuelve la posición actual en el sistema de coordenadas local.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="474"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="850"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="475"/>
         <source>y</source>
         <translation>y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="476"/>
         <source>z</source>
         <translation>z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="487"/>
         <source>Get LPS Velocity</source>
         <translation>Leer velocidad (LPS)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="489"/>
         <source>Returns velocity (local position system).</source>
         <translation>Devuelve los valores actuales de velocidad en el sistema de coordenadas local.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="536"/>
         <source>velX</source>
         <translation>velX</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="537"/>
         <source>velY</source>
         <translation>velY</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="538"/>
         <source>velZ</source>
         <translation>velZ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="549"/>
         <source>Get LPS Yaw</source>
         <translation>Leer ángulo de guiñada (LPS)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="551"/>
         <source>Returns yaw (local position system).</source>
         <translation>Devuelve el ángulo actual de guiñada en el sistema de coordenadas local.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="558"/>
         <source>Yaw:</source>
         <translation>Guiñada:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="582"/>
         <source>yaw</source>
         <translation>guiñada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="582"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="997"/>
         <source>Yaw</source>
         <translation>Guiñada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="593"/>
         <source>Get Orientation</source>
         <translation>Leer orientación</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="595"/>
         <source>Returns orientation.</source>
         <translation>Devuelve la orientación del cuadricóptero en el espacio: alabeo, cabeceo y guiñada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="602"/>
         <source>Roll:</source>
         <translation>Alabeo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="610"/>
         <source>Pitch:</source>
         <translation>Cabeceo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="618"/>
         <source>Azimuth:</source>
         <translation>Guiñada:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="642"/>
         <source>azimuth</source>
         <translation>guiñada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="642"/>
         <source>Azimuth</source>
         <translation>Guiñada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="643"/>
         <source>pitch</source>
         <translation>cabeceo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="643"/>
         <source>Pitch</source>
         <translation>Cabeceo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="644"/>
         <source>roll</source>
         <translation>alabeo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="644"/>
         <source>Roll</source>
         <translation>Alabeo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="655"/>
         <source>Led</source>
         <translation>LED</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="657"/>
         <source>Sets the color of the specified LED on a quadcopter.</source>
         <translation>Establece el color del LED especificado en el cuadricóptero.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="664"/>
         <source>Number:</source>
         <translation>Número:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="672"/>
         <source>Red:</source>
         <translation>Rojo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="680"/>
         <source>Green:</source>
         <translation>Verde:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="688"/>
         <source>Blue:</source>
         <translation>Azul:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="713"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="714"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="716"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="1030"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="713"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="714"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="715"/>
         <source>Number</source>
         <translation>Número</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="716"/>
         <source>Red</source>
         <translation>Rojo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="727"/>
         <source>Magnet</source>
         <translation>Imán</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="729"/>
         <source>Controls magnet on a quadcopter.</source>
         <translation>Controla el imán en un cuadricóptero.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="752"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="941"/>
         <source>State on</source>
         <translation>Encendido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="763"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="765"/>
         <source>Prints given string on a console.</source>
         <translation>Imprime la cadena dada en la consola.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="772"/>
         <source>Text:</source>
         <translation>Texto:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="796"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="986"/>
         <source>Evaluate</source>
         <translation>Evaluar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="797"/>
         <source>Enter some text here</source>
         <translation>Introduzca texto aquí</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="797"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="808"/>
         <source>Read GPIO</source>
         <translation>Leer valor de GPIO</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="810"/>
         <source>Returns GPIO value.</source>
         <translation>Devuelve el valor del estado de GPIO.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="825"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="870"/>
         <source>Variable:</source>
         <translation>Variable:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="850"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="896"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="861"/>
         <source>Read Range Sensor</source>
         <translation>Leer sensor de distancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="863"/>
         <source>Reads distance from rangefinder.</source>
         <translation>Lee la distancia del sensor de rango.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="896"/>
         <source>dist</source>
         <translation>dist</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="907"/>
         <source>Set GPIO state</source>
         <translation>Establecer estado de GPIO</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="909"/>
         <source>Set GPIO value in &quot;true/false&quot;.</source>
         <translation>Establece el valor de GPIO en &quot;verdadero/falso&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="952"/>
         <source>System</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="954"/>
         <source>Executes given Lua script.</source>
         <translation>Ejecuta el script Lua indicado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="961"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="985"/>
         <source>print(&apos;Hello&apos;)</source>
         <translation>print(&apos;Hola&apos;)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="985"/>
         <source>Command</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="999"/>
         <source>Sets yaw for quadcopter</source>
         <translation>Establece el ángulo de guiñada del cuadricóptero. El parámetro &quot;ángulo&quot; se especifica en grados</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="1006"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="1030"/>
         <source>Angle (degrees)</source>
         <translation>Ángulo (grados)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="88"/>
         <source>RobotsDiagram</source>
         <translation>Diagrama</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="95"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="96"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="98"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="99"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="100"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="101"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="102"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="103"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="104"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="105"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="106"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="107"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="108"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="109"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="110"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="111"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="112"/>
         <source>Actions</source>
         <translation>Acciones</translation>
     </message>
@@ -831,7 +618,6 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="216"/>
         <source>Time</source>
         <translation>Tiempo</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/editor/trik_es.ts
+++ b/qrtranslations/es/plugins/robots/editor/trik_es.ts
@@ -4,1259 +4,846 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="26"/>
         <source>TrikAnalogSensorBlock</source>
         <translation>Sensor Analógico</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="50"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="276"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="788"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1732"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2145"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2264"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2335"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2493"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2539"/>
         <source>Port</source>
         <translation>Puerto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="61"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1583"/>
         <source>Angular Servo</source>
         <translation>Servomotor Angular</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="63"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1585"/>
         <source>Manages angular servomotor. Sets up rotation angle on the given port in degrees. Values from 0 to 90 are correspond to a clockwise rotation and values from -90 to 0 correspond to counterclockwise rotation.</source>
         <translation>Controla el servomotor angular. Establece el ángulo de rotación del eje del motor en el puerto indicado (en grados). Los valores de 0 a 90 corresponden a una rotación en sentido horario, y los valores de -90 a 0 corresponden a una rotación en sentido antihorario.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="70"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1592"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1646"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1754"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1835"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1890"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1945"/>
         <source>Ports:</source>
         <translation>Puertos:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="78"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1600"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2701"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="79"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1601"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="103"/>
         <source>E1</source>
         <translation>E1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="103"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1625"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1671"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1779"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1814"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1869"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1924"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1978"/>
         <source>Ports</source>
         <translation>Puertos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="104"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="365"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="366"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="438"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="439"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="508"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="510"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="637"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="638"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1626"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2038"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2200"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2263"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2334"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2492"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2733"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="104"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1626"/>
         <source>Angle (degrees)</source>
         <translation>Ángulo (grados)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="115"/>
         <source>Calibrate gyroscope</source>
         <translation>Calibrar giroscopio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="117"/>
         <source>Sets gyroscope&apos;s angle to zero in current position.</source>
         <translation>Establece el ángulo del giroscopio a cero en la posición actual.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="150"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="161"/>
         <source>Detect by Videocamera</source>
         <translation>Detectar por cámara de video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="152"/>
         <source>Initializes videocamera line or object detector with the color of the object in the middle of the camera`s sight.</source>
         <translation>Inicializa el detector de líneas u objetos por cámara de video con el color del objeto en el centro del campo de visión de la cámara.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="159"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="658"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1453"/>
         <source>Mode:</source>
         <translation>Modo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="190"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="690"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1484"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1977"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="201"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="204"/>
         <source>Line Detector into Variable</source>
         <translation>Detector de línea en variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="203"/>
         <source>Stores videocamera line detector`s value into a given variable.</source>
         <translation>Guarda el valor del detector de línea por cámara de video en una variable dada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="217"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1026"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2356"/>
         <source>Variable:</source>
         <translation>Variable:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="241"/>
         <source>err</source>
         <translation>err</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="241"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1050"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="252"/>
         <source>TrikDigitalSensorBlock</source>
         <translation>Bloque básico de sensores digitales TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="287"/>
         <source>Draw Arc</source>
         <translation>Dibujar arco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="289"/>
         <source>Draws the arc defined by the rectangle beginning at (x, y) with the specified width and height, and the given startAngle and spanAngle.</source>
         <translation>Dibuja en la pantalla un arco delimitado por un rectángulo que comienza en (x, y) con anchura y altura especificadas, y con ángulo inicial y ángulo final dados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="296"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="386"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="531"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="585"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="953"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="304"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="394"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="539"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="593"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="961"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="312"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="402"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="601"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1372"/>
         <source>Width:</source>
         <translation>Anchura:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="320"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="410"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="609"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="328"/>
         <source>Start Angle:</source>
         <translation>Ángulo inicial:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="336"/>
         <source>Span Angle:</source>
         <translation>Ángulo final:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="360"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="364"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="435"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="437"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="564"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="565"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="634"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="636"/>
         <source>5</source>
         <translation>5</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="360"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="435"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="634"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="361"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="436"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="507"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="563"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="635"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1004"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1308"/>
         <source>Redraw</source>
         <translation>Actualizar imagen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="362"/>
         <source>SpanAngle</source>
         <translation>Ángulo final</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="363"/>
         <source>StartAngle</source>
         <translation>Ángulo inicial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="364"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="437"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="636"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1396"/>
         <source>Width</source>
         <translation>Anchura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="365"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="438"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="564"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="637"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1005"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="366"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="439"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="565"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="638"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1006"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="377"/>
         <source>Draw Ellipse</source>
         <translation>Dibujar elipse</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="379"/>
         <source>Draws the ellipse defined by the rectangle beginning at (x, y) with the given width and height.</source>
         <translation>Dibuja en la pantalla una elipse delimitada por un rectángulo que comienza en (x, y) con anchura y altura especificadas.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="434"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="633"/>
         <source>Filled</source>
         <translation>Relleno</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="450"/>
         <source>Draw Line</source>
         <translation>Dibujar línea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="452"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Dibuja en la pantalla un segmento. Los parámetros indican los extremos del segmento.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="459"/>
         <source>X1:</source>
         <translation>X1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="467"/>
         <source>Y1:</source>
         <translation>Y1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="475"/>
         <source>X2:</source>
         <translation>X2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="483"/>
         <source>Y2:</source>
         <translation>Y2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="508"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="509"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="511"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="509"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="510"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="511"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="522"/>
         <source>Draw Pixel</source>
         <translation>Dibujar píxel</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="524"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Dibuja un píxel en las coordenadas especificadas en la pantalla del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="576"/>
         <source>Draw Rectangle</source>
         <translation>Dibujar rectángulo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="578"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Dibuja un rectángulo en la pantalla del robot. Los parámetros indican las coordenadas de la esquina superior izquierda, la anchura y la altura del rectángulo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="649"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="660"/>
         <source>Initialize Videocamera</source>
         <translation>Activar cámara de video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="651"/>
         <source>Enables line or object or color detector by videocamera and draws videostream on the robot`s screen.</source>
         <translation>Activa el detector de líneas, objetos o colores mediante cámara de video y muestra la transmisión de video en la pantalla del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="689"/>
         <source>Draw stream</source>
         <translation>Mostrar en pantalla</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="701"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="704"/>
         <source>Enable Video Streaming</source>
         <translation>Activar transmisión de video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="703"/>
         <source>Enables video stream on robot. Video then can be watched on TRIK gamepad or in browser using URL http://ROBOT.IP.ADDRESS:8080/?action=stream</source>
         <translation>Activa la transmisión de video en el robot. El video puede visualizarse, por ejemplo, en el mando de control TRIK o en un navegador mediante la URL http://IP.DEL.ROBOT:8080/?action=stream</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="733"/>
         <source>Grayscaled</source>
         <translation>Imagen en escala de grises</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="734"/>
         <source>Quality</source>
         <translation>Calidad</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="745"/>
         <source>Join Network</source>
         <translation>Conectarse a la red</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="747"/>
         <source>Sets the hull number and connects with a peer by a (host)name or an IP-address. Target IP-port can be changed too if required.</source>
         <translation>Establece el número de casco y se conecta a otro robot mediante un nombre (de host) o una dirección IP. Si es necesario, también puede cambiarse el puerto IP de destino.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="754"/>
         <source>Address:</source>
         <translation>Dirección:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="762"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1204"/>
         <source>Hull number:</source>
         <translation>Número de casco:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="786"/>
         <source>192.168.77.1</source>
         <translation>192.168.77.1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="786"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="787"/>
         <source>Hull Number</source>
         <translation>Número de casco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="799"/>
         <source>Led</source>
         <translation>LED</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="801"/>
         <source>Sets the color of the LED on the robot`s front panel.</source>
         <translation>Establece el color del LED en el panel frontal del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="808"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1283"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1328"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="833"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1307"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1352"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="844"/>
         <source>Play Sound</source>
         <translation>Reproducir archivo de sonido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="846"/>
         <source>Plays on the robot a sound file (.wav or .mp3) previously uploaded to it.</source>
         <translation>Reproduce en el robot un archivo de sonido (formato .wav o .mp3) que debe haber sido previamente cargado.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="853"/>
         <source>File name:</source>
         <translation>Nombre del archivo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="878"/>
         <source>media/beep.wav</source>
         <translation>media/beep.wav</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="878"/>
         <source>File Name</source>
         <translation>Nombre del archivo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="889"/>
         <source>Play Tone</source>
         <translation>Reproducir tono</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="891"/>
         <source>Plays on the robot a sound with the given frequency and duration.</source>
         <translation>Reproduce en el robot un sonido con la frecuencia y duración indicadas.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="898"/>
         <source>Frequency:</source>
         <translation>Frecuencia:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="899"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="907"/>
         <source>Duration:</source>
         <translation>Duración:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="908"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="932"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="933"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="932"/>
         <source>Duration</source>
         <translation>Duración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="933"/>
         <source>Frequency</source>
         <translation>Frecuencia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="944"/>
         <source>Print Text</source>
         <translation>Imprimir texto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="946"/>
         <source>Prints a given line in the specified coordinates and font size on the robot`s screen. The value of &apos;Text&apos; property is interpreted as a plain text unless &apos;Evaluate&apos; property is set to true, then it will be interpreted as an expression (that may be useful for example when debugging variables values).</source>
         <translation>Imprime una línea dada en las coordenadas especificadas y con el tamaño de fuente indicado en la pantalla del robot. El valor de la propiedad &quot;Texto&quot; se interpreta como texto plano, a menos que la propiedad &quot;Evaluar&quot; esté activada, en cuyo caso se interpretará como una expresión (lo que puede ser útil, por ejemplo, al depurar valores de variables).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="969"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1151"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2813"/>
         <source>Text:</source>
         <translation>Texto:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="977"/>
         <source>Font size:</source>
         <translation>Tamaño de fuente:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1001"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1175"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1572"/>
         <source>Evaluate</source>
         <translation>Evaluar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1002"/>
         <source>20</source>
         <translation>20</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1002"/>
         <source>Font size</source>
         <translation>Tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1003"/>
         <source>Enter some text here</source>
         <translation>Introduzca texto aquí</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1003"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1176"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1005"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1006"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1396"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1017"/>
         <source>Read Lidar To Variable</source>
         <translation>Leer LIDAR a variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1019"/>
         <source>Assigns a value from lidar to a given variable.</source>
         <translation>Asigna un valor del LIDAR a una variable dada.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1050"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1061"/>
         <source>Remove File</source>
         <translation>Eliminar archivo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1063"/>
         <source>Removes a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
         <translation>Elimina un archivo. La ruta del archivo puede ser absoluta o relativa al directorio que contiene el ejecutable de TRIK Studio.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1070"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2805"/>
         <source>File:</source>
         <translation>Archivo:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1094"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2837"/>
         <source>output.txt</source>
         <translation>output.txt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1094"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2837"/>
         <source>File</source>
         <translation>Archivo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1105"/>
         <source>Sad Smile</source>
         <translation>Cara triste</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1107"/>
         <source>Draws a sad smile on the robot`s screen :(</source>
         <translation>Dibuja una cara triste en la pantalla del robot :(</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1142"/>
         <source>Say</source>
         <translation>Decir</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1144"/>
         <source>Synthesizes the given phrase and plays it on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Text&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
         <translation>Sintetiza la frase dada y la reproduce en el robot. Si la propiedad &quot;Evaluar&quot; es verdadera, el valor de la propiedad &quot;Texto&quot; se interpreta como una fórmula; de lo contrario, se interpreta como una cadena de texto.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1176"/>
         <source>Hi!</source>
         <translation>¡Hola!</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1187"/>
         <source>Send message</source>
         <translation>Enviar mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1189"/>
         <source>Sends message to another robot.</source>
         <translation>Envía un mensaje a otro robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1196"/>
         <source>Message:</source>
         <translation>Mensaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1240"/>
         <source>TrikSensorBlock</source>
         <translation>Bloque básico de sensores TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1274"/>
         <source>Background Color</source>
         <translation>Color de fondo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1276"/>
         <source>Sets the background color of the current picture on the robot`s screen.</source>
         <translation>Establece el color de fondo de la imagen actual en la pantalla del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1319"/>
         <source>Painter Color</source>
         <translation>Color del pincel</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1321"/>
         <source>Sets the painter color.</source>
         <translation>Establece el color del pincel.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1363"/>
         <source>Painter Width</source>
         <translation>Anchura del pincel</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1365"/>
         <source>Sets the painter width.</source>
         <translation>Establece la anchura del pincel.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1407"/>
         <source>Smile</source>
         <translation>Sonrisa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1409"/>
         <source>Draws a smile on the robot`s screen :)</source>
         <translation>Dibuja una sonrisa en la pantalla del robot :)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1444"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1455"/>
         <source>Stop Videocamera</source>
         <translation>Detener cámara de video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1446"/>
         <source>Stops line or object or color detector by videocamera.</source>
         <translation>Detiene el detector de líneas, objetos o colores por cámara de video.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1495"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1498"/>
         <source>Disable Video Streaming</source>
         <translation>Desactivar transmisión de video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1497"/>
         <source>Disables video stream on robot.</source>
         <translation>Detiene la transmisión de video del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1537"/>
         <source>System Call</source>
         <translation>Llamada al sistema</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1539"/>
         <source>Invokes bash script-style command on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Command&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
         <translation>Ejecuta un comando tipo script de bash en el robot. Si la propiedad &quot;Evaluar&quot; es verdadera, el valor de la propiedad &quot;Comando&quot; se interpreta como una fórmula; de lo contrario, se interpreta como una cadena de texto.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1546"/>
         <source>Command:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1570"/>
         <source>Code</source>
         <translation>Código</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1571"/>
         <source>echo 123</source>
         <translation>echo 123</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1571"/>
         <source>Command</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1625"/>
         <source>S1</source>
         <translation>S1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1637"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1745"/>
         <source>Clear Encoder</source>
         <translation>Borrar contador del codificador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1639"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1747"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Reinicia las lecturas del contador de vueltas de los motores en los puertos indicados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1671"/>
         <source>E1, E2, E3, E4</source>
         <translation>E1, E2, E3, E4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1682"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2095"/>
         <source>Wait for Encoder</source>
         <translation>Esperar al codificador</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1684"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2097"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Espera hasta que las lecturas del contador de vueltas del motor en el puerto indicado alcancen el valor del parámetro &apos;Límite de vueltas&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1691"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2104"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2221"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2285"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2409"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2452"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2514"/>
         <source>Port:</source>
         <translation>Puerto:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1699"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2112"/>
         <source>Tacho Limit:</source>
         <translation>Límite de vueltas:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1707"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2006"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2120"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2175"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2237"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2301"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2468"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2709"/>
         <source>Sign:</source>
         <translation>Valor leído:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1733"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2040"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2146"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2201"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2265"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2336"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2494"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2734"/>
         <source>Sign</source>
         <translation>Valor leído</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1779"/>
         <source>B1, B2, B3, B4</source>
         <translation>B1, B2, B3, B4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1790"/>
         <source>TrikV6EngineMovementCommand</source>
         <translation>Bloque base de motores TRIK v6</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1814"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1869"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1924"/>
         <source>M3, M4</source>
         <translation>M3, M4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1815"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1870"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1925"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1815"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1870"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1925"/>
         <source>Power (%)</source>
         <translation>Velocidad (%)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1826"/>
         <source>Motors Backward</source>
         <translation>Motores atrás</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1828"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified in accordance with TRIK controller notations (for example M1, E2) and divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Activa los motores en modo reversa en los puertos indicados con la potencia especificada. Los puertos se indican según la notación del controlador TRIK (por ejemplo, M1, E2) y se separan por comas. La potencia se especifica en porcentaje con un número de -100 a 100; si se indica un número negativo, el motor se activa en modo normal.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1843"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1898"/>
         <source>Power:</source>
         <translation>Velocidad:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1844"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1899"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1881"/>
         <source>Motors Forward</source>
         <translation>Motores adelante</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1883"/>
         <source>Enables motors on the given ports with the given power. Ports are specified in accordance with TRIK controller notations (for example M1, E2) and divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Activa los motores en los puertos indicados con la potencia especificada. Los puertos se indican según la notación del controlador TRIK (por ejemplo, M1, E2) y se separan por comas. La potencia se especifica en porcentaje con un número de -100 a 100; si se indica un número negativo, el motor se activa en modo reversa.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1936"/>
         <source>Stop Motors</source>
         <translation>Detener motores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1938"/>
         <source>Disables motors on the given ports.</source>
         <translation>Desactiva los motores en los puertos indicados.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1978"/>
         <source>M1, M2, M3, M4</source>
         <translation>M1, M2, M3, M4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1989"/>
         <source>Wait for Accelerometer</source>
         <translation>Esperar acelerómetro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1998"/>
         <source>Acceleration:</source>
         <translation>Aceleración:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2014"/>
         <source>Axis:</source>
         <translation>Eje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2038"/>
         <source>Acceleration</source>
         <translation>Aceleración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2039"/>
         <source>Acceleration Axis</source>
         <translation>Eje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2051"/>
         <source>Wait for Button</source>
         <translation>Esperar pulsación de botón</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2053"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Espera a que se pulse un botón en el cuerpo del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2060"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2566"/>
         <source>Button:</source>
         <translation>Botón:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2084"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2590"/>
         <source>Button</source>
         <translation>Botón</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2158"/>
         <source>Wait for Gyroscope</source>
         <translation>Esperar giroscopio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2160"/>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;Degrees&apos; parameter value.</source>
         <translation>Espera hasta que el valor devuelto por el giroscopio en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Grados&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2167"/>
         <source>Degrees:</source>
         <translation>Grados:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2200"/>
         <source>Degrees</source>
         <translation>Grados</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2212"/>
         <source>Wait for Infrared Distance</source>
         <translation>Esperar sensor infrarrojo de distancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2214"/>
         <source>Waits till the value returned by the infrared sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value. By default on ports A1 and A2 the distance is specified in centimeters (from 0 to 100). It is not recommended to plug IR sensor into other ports because its raw value will be processed by software on robot with expectation of another sensor type.</source>
         <translation>Espera hasta que el valor devuelto por el sensor infrarrojo de distancia en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Distancia&apos;. Por defecto, en los puertos A1 y A2 la distancia se indica en centímetros (de 0 a 100). No se recomienda conectar el sensor IR a otros puertos porque su valor bruto será procesado por el software del robot esperando otro tipo de sensor.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2229"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2460"/>
         <source>Distance:</source>
         <translation>Distancia:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2263"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2492"/>
         <source>Distance</source>
         <translation>Distancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2276"/>
         <source>Wait for Light</source>
         <translation>Esperar sensor de luz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2278"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Espera hasta que el valor devuelto por el sensor de luz en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Porcentaje&apos; (0 a 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2293"/>
         <source>Percents:</source>
         <translation>Porcentaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2334"/>
         <source>Percents</source>
         <translation>Porcentaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2347"/>
         <source>Wait for Message</source>
         <translation>Recibir mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2349"/>
         <source>Stores a message from another robot into a given variable. When no incoming messages are present at the moment, a robot will wait for incoming message if &apos;Synchronized&apos; property is true, and empty string will be assigned to a variable otherwise.</source>
         <translation>Almacena un mensaje de otro robot en una variable dada. Si no hay mensajes entrantes en ese momento, el robot esperará un mensaje si la propiedad &apos;Sincronizado&apos; es verdadera; de lo contrario, se asignará una cadena vacía a la variable.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2364"/>
         <source>Synchronized:</source>
         <translation>Esperar mensaje:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2388"/>
         <source>Synchronized</source>
         <translation>Esperar mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2400"/>
         <source>Wait for Motion</source>
         <translation>Esperar sensor de movimiento</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2402"/>
         <source>Waits till the motion sensor on the given port is triggered.</source>
         <translation>Espera hasta que el sensor de movimiento en el puerto indicado se active.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2403"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2443"/>
         <source>Wait for Ultrasonic Distance</source>
         <translation>Esperar sensor ultrasónico de distancia</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2445"/>
         <source>Waits till the value returned by the ultrasonic sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, from 0 to 300).</source>
         <translation>Espera hasta que el valor devuelto por el sensor ultrasónico en el puerto indicado sea mayor o menor que el valor especificado en el parámetro &apos;Distancia&apos; (la distancia se indica en centímetros, de 0 a 300).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2505"/>
         <source>Wait for Touch Sensor</source>
         <translation>Esperar sensor táctil</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2507"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Espera hasta que se presione el sensor táctil. El único parámetro es el número del puerto del sensor (1, 2, 3 o 4).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2550"/>
         <source>Wait Gamepad Button</source>
         <translation>Esperar botón del mando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2552"/>
         <source>Waits for Android gamepad &apos;magic button&apos; press. Buttons are identified by numbers from 1 to 5 (from left to right)</source>
         <translation>Espera la pulsación de una &apos;tecla mágica&apos; del mando Android. Los botones se identifican con números del 1 al 5 (de izquierda a derecha)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2553"/>
         <source>Wait gamepad button</source>
         <translation>Esperar botón del mando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2601"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2604"/>
         <source>Wait for Gamepad Connect</source>
         <translation>Esperar conexión del mando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2603"/>
         <source>Waits until Android gamepad is connected.</source>
         <translation>Espera hasta que el mando Android se conecte.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2643"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2646"/>
         <source>Wait for Gamepad Disconnect</source>
         <translation>Esperar desconexión del mando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2645"/>
         <source>Waits until Android gamepad is disconnected.</source>
         <translation>Espera hasta que el mando Android se desconecte.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2685"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2688"/>
         <source>Wait for Gamepad Wheel</source>
         <translation>Esperar &apos;volante&apos; del mando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2687"/>
         <source>Waits till the value returned by gamepad wheel be greater or less than the given in the &apos;Angle&apos; parameter value. Angle is measured from -100 (max left) to 100 (max right).</source>
         <translation>Espera hasta que el valor devuelto por el &apos;volante&apos; del mando sea mayor o menor que el valor especificado en el parámetro &apos;Ángulo&apos;. El ángulo se mide desde -100 (máximo a la izquierda) hasta 100 (máximo a la derecha).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2733"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2745"/>
         <source>Wait Pad Press</source>
         <translation>Esperar pulsación en el mando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2747"/>
         <source>Waits for Android gamepad pad press (left pad has number 1, right pad - number 2).</source>
         <translation>Espera la pulsación en una zona activa del mando Android (la zona izquierda tiene número 1, la derecha número 2).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2748"/>
         <source>Wait pad press</source>
         <translation>Esperar pulsación en el mando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2761"/>
         <source>Pad:</source>
         <translation>Mando:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2785"/>
         <source>Pad</source>
         <translation>Mando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2796"/>
         <source>Write To File</source>
         <translation>Escribir en archivo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2798"/>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
         <translation>Escribe un mensaje dado en un archivo. La ruta del archivo puede ser absoluta o relativa al directorio que contiene el ejecutable de TRIK Studio.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="160"/>
         <source>RobotsDiagram</source>
         <translation>Diagrama de comportamiento del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="167"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="168"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="169"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="170"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="171"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="172"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="173"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="174"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="175"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="176"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="177"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="178"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="179"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="180"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="181"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="182"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="183"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="184"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="185"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="186"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="187"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="188"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="189"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="190"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="191"/>
         <source>Actions</source>
         <translation>Acciones</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="192"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="193"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="194"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="195"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="196"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="197"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="198"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="199"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="200"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="201"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="202"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="203"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="204"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="205"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="206"/>
         <source>Wait</source>
         <translation>Espera</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="207"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="208"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="209"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="210"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="211"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="212"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="213"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="214"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="215"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="216"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="217"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="218"/>
         <source>Drawing</source>
         <translation>Dibujo</translation>
     </message>
@@ -1264,28 +851,22 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1228"/>
         <source>Hull Number</source>
         <translation>Número de casco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1229"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1734"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2147"/>
         <source>Tacho Limit</source>
         <translation>Límite de revoluciones</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2389"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2838"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
@@ -1293,389 +874,302 @@
 <context>
     <name>TrikMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="232"/>
         <source>norm</source>
         <translation>normal</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="232"/>
         <source>x-axis</source>
         <translation>eje x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="232"/>
         <source>y-axis</source>
         <translation>eje y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="232"/>
         <source>z-axis</source>
         <translation>eje z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="234"/>
         <source>Composite</source>
         <translation>Composición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="234"/>
         <source>None</source>
         <translation>Ausente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="234"/>
         <source>Shared</source>
         <translation>Compartida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
         <source>black</source>
         <translation>negro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
         <source>blue</source>
         <translation>azul</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>cyan</source>
         <translation>cian</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark blue</source>
         <translation>azul oscuro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark cyan</source>
         <translation>cian oscuro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark gray</source>
         <translation>gris oscuro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark green</source>
         <translation>verde oscuro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark magenta</source>
         <translation>magenta oscuro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark red</source>
         <translation>rojo oscuro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark yellow</source>
         <translation>amarillo oscuro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>gray</source>
         <translation>gris</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="256"/>
         <source>green</source>
         <translation>verde</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>light gray</source>
         <translation>gris claro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>magenta</source>
         <translation>magenta</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="256"/>
         <source>red</source>
         <translation>rojo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
         <source>white</source>
         <translation>blanco</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
         <source>yellow</source>
         <translation>amarillo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="238"/>
         <source>brake</source>
         <translation>frenado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="238"/>
         <source>float</source>
         <translation>deslizamiento</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="240"/>
         <source>Concurrent</source>
         <translation>Concurrente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="240"/>
         <source>Guarded</source>
         <translation>Protegido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="240"/>
         <source>Sequential</source>
         <translation>Secuencial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="244"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="266"/>
         <source>Line sensor</source>
         <translation>Sensor de línea</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="244"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="266"/>
         <source>Object sensor</source>
         <translation>Sensor de objeto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="246"/>
         <source>greater</source>
         <translation>mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="246"/>
         <source>less</source>
         <translation>menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="246"/>
         <source>not greater</source>
         <translation>no mayor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="246"/>
         <source>not less</source>
         <translation>no menor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="248"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="270"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="248"/>
         <source>body</source>
         <translation>cuerpo del bucle</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="248"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="270"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="250"/>
         <source>15</source>
         <translation>15</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="250"/>
         <source>30</source>
         <translation>30</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="250"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="250"/>
         <source>80</source>
         <translation>80</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="252"/>
         <source>In</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="252"/>
         <source>Inout</source>
         <translation>Entrada-salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="252"/>
         <source>Out</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="252"/>
         <source>Return</source>
         <translation>Devuelve</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Down</source>
         <translation>Abajo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Enter</source>
         <translation>Intro</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Esc</source>
         <translation>Esc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Up</source>
         <translation>Arriba</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="256"/>
         <source>off</source>
         <translation>apagado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="256"/>
         <source>orange</source>
         <translation>naranja</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="258"/>
         <source>E1</source>
         <translation>E1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="258"/>
         <source>E2</source>
         <translation>E2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="258"/>
         <source>E3</source>
         <translation>E3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="258"/>
         <source>E4</source>
         <translation>E4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A5</source>
         <translation>A5</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A6</source>
         <translation>A6</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="262"/>
         <source>D1</source>
         <translation>D1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="262"/>
         <source>D2</source>
         <translation>D2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="264"/>
         <source>B1</source>
         <translation>B1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="264"/>
         <source>B2</source>
         <translation>B2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="264"/>
         <source>B3</source>
         <translation>B3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="264"/>
         <source>B4</source>
         <translation>B4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="266"/>
         <source>Color sensor</source>
         <translation>Sensor de color</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="268"/>
         <source>Package</source>
         <translation>Paquete</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="268"/>
         <source>Private</source>
         <translation>Privado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="268"/>
         <source>Protected</source>
         <translation>Protegido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="268"/>
         <source>Public</source>
         <translation>Público</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/ev3/ev3GeneratorBase_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/ev3/ev3GeneratorBase_es.ts
@@ -4,13 +4,10 @@
 <context>
     <name>ev3::Ev3GeneratorFactory</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/sendMailGenerator.cpp" line="35"/>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/receiveMailGenerator.cpp" line="38"/>
         <source>There is already mailbox with same name, but different msg type</source>
         <translation>Ya existe un buzón con el mismo nombre, pero con un tipo de mensaje diferente</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/receiveMailGenerator.cpp" line="42"/>
         <source>There are too many mailboxes, max size is 30</source>
         <translation>Hay demasiados buzones, el tamaño máximo es 30</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/ev3/ev3RbfGenerator_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/ev3/ev3RbfGenerator_es.ts
@@ -4,22 +4,18 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfMasterGenerator.cpp" line="60"/>
         <source>There is no opened diagram</source>
         <translation>No hay ningún diagrama abierto</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="821"/>
         <source>/* Warning: cast from string to numeric type is not supported */ 0</source>
         <translation>/* Advertencia: la conversión de tipo de cadena a tipo numérico no está soportada */ 0</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="825"/>
         <source>/* Warning: autocast from array to other type is not supported */ 0</source>
         <translation>/* Advertencia: la conversión automática de tipo de arreglo a otro tipo no está soportada */ 0</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="829"/>
         <source>/* Warning: autocast is supported only for numeric types */ 0</source>
         <translation>/* Advertencia: la conversión automática de tipos solo es compatible con tipos numéricos */ 0</translation>
     </message>
@@ -27,92 +23,74 @@
 <context>
     <name>ev3::rbf::Ev3RbfGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="34"/>
         <source>Autonomous mode (USB)</source>
         <translation>Modo autónomo (USB)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="35"/>
         <source>Autonomous mode (Bluetooth)</source>
         <translation>Modo autónomo (Bluetooth)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="41"/>
         <source>Generate to Ev3 Robot Byte Code File</source>
         <translation>Generar archivo de código de bytes para el robot EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="45"/>
         <source>Upload program</source>
         <translation>Subir programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="56"/>
         <source>Run program</source>
         <translation>Ejecutar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="64"/>
         <source>Stop robot</source>
         <translation>Detener programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="69"/>
         <source>EV3 Source Code language</source>
         <translation>Archivo con código de bytes EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="99"/>
         <source>Generate Ev3 Robot Byte Code File</source>
         <translation>Generar archivo de código de bytes para el robot EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="100"/>
         <source>Upload EV3 Program</source>
         <translation>Subir programa EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="101"/>
         <source>Run EV3 Program</source>
         <translation>Ejecutar programa en EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="102"/>
         <source>Stop EV3 Program</source>
         <translation>Detener programa en EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="141"/>
         <source>Can&apos;t write source code files to disk!</source>
         <translation>No se pueden escribir los archivos de código fuente en el disco.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="147"/>
         <source>Compilation error occured.</source>
         <translation>Ocurrió un error de compilación.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="166"/>
         <source>The program has been uploaded</source>
         <translation>El programa ha sido cargado</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="167"/>
         <source>Do you want to run it?</source>
         <translation>¿Desea ejecutarlo?</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="282"/>
         <source>Could not upload file to robot. Connect to a robot via %1.</source>
         <translation>No se pudo cargar el archivo al robot. Conéctese a un robot mediante %1.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="283"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="283"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/generatorBase_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/generatorBase_es.ts
@@ -4,127 +4,102 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="79"/>
         <source>There is no opened diagram</source>
         <translation>No hay ningún diagrama abierto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="44"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>No hay nada que generar, el diagrama no tiene un nodo inicial</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="49"/>
         <source>Initial node must not have incoming links</source>
         <translation>Al nodo inicial no deben llegar enlaces</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="83"/>
         <source>This element must have exactly ONE outgoing link</source>
         <translation>Este elemento debe tener exactamente UN enlace saliente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="93"/>
         <source>Final node must not have outgoing links</source>
         <translation>Del nodo final no deben salir enlaces</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="101"/>
         <source>If block must have exactly TWO outgoing links</source>
         <translation>Del bloque condicional deben salir exactamente DOS enlaces</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="116"/>
         <source>Two outgoing links marked with &apos;true&apos; found</source>
         <translation>Se encontraron dos enlaces salientes marcados con &quot;verdadero&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="125"/>
         <source>Two outgoing links marked with &apos;false&apos; found</source>
         <translation>Se encontraron dos enlaces salientes marcados con &quot;falso&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="134"/>
         <source>There must be at least one link with &quot;true&quot; or &quot;false&quot; marker on it</source>
         <translation>Debe haber al menos un enlace con el marcador &quot;verdadero&quot; o &quot;falso&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="163"/>
         <source>Loop block must have exactly TWO outgoing links</source>
         <translation>Del bloque de ciclo deben salir exactamente DOS enlaces</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="177"/>
         <source>Two outgoing links marked with &quot;body&quot; found</source>
         <translation>Se encontraron dos enlaces salientes marcados con &quot;cuerpo&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="185"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Debe haber un enlace con el marcador &quot;cuerpo del ciclo&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="195"/>
         <source>Outgoing links from loop block must be connected to different blocks</source>
         <translation>Los enlaces salientes del bloque de ciclo deben conectarse a bloques diferentes</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="213"/>
         <source>There must be at list TWO links outgoing from switch block</source>
         <translation>Del bloque de selección deben salir al menos DOS enlaces</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="223"/>
         <source>There must be exactly one link without marker on it (default branch)</source>
         <translation>Debe haber exactamente un enlace sin marcador (rama predeterminada)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="230"/>
         <source>Duplicate case branch: &apos;%1&apos;</source>
         <translation>Rama de caso duplicada: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="239"/>
         <source>There must be a link without marker on it (default branch)</source>
         <translation>Debe haber un enlace sin marcador (rama predeterminada)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="246"/>
         <source>Unknown block type</source>
         <translation>Tipo de bloque desconocido</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="252"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Del bloque de tareas paralelas deben salir al menos DOS enlaces</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="278"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace saliente no está conectado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/parts/subprograms.cpp" line="83"/>
         <source>Graphical diagram instance not found</source>
         <translation>No se encontró la instancia gráfica del diagrama con el subprograma</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/parts/subprograms.cpp" line="220"/>
         <source>Please enter valid c-style name for subprogram &quot;</source>
         <translation>Introduzca un nombre válido estilo C para el subprograma &quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/parts/subprograms.cpp" line="226"/>
         <source>Subprograms should have unique names, please rename</source>
         <translation>Los subprogramas deben tener nombres únicos, cámbielos, por favor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/converters/reservedVariablesConverter.cpp" line="64"/>
         <source>Device on port %1 is not configured. Please select it on the &quot;Configure devices&quot; panel on the right-hand side.</source>
         <translation>El dispositivo en el puerto %1 no está configurado. Seleccione su tipo en el panel &quot;Configurar dispositivos&quot; a la derecha.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/converters/reservedVariablesConverter.cpp" line="68"/>
         <source>/* ERROR: SELECT DEVICE TYPE */</source>
         <translation>/* ERROR: SELECCIONE EL TIPO DE DISPOSITIVO */</translation>
     </message>
@@ -132,17 +107,14 @@
 <context>
     <name>generatorBase::MasterGeneratorBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="119"/>
         <source>This diagram cannot be generated into the structured code. Generating it into the code with &apos;goto&apos; statements.</source>
         <translation>Este diagrama no puede generarse en código estructurado. Generando código con sentencias &apos;goto&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="134"/>
         <source>This diagram cannot be even generated into the code with &apos;goto&apos;statements. Please contact the developers.</source>
         <translation>Este diagrama ni siquiera puede generarse en código con sentencias &apos;goto&apos;. Por favor, contacte con los desarrolladores.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="136"/>
         <source>This diagram cannot be generated into the structured code.</source>
         <translation>Este diagrama no puede generarse en código estructurado.</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/nxt/nxtOsekCGenerator_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/nxt/nxtOsekCGenerator_es.ts
@@ -4,132 +4,106 @@
 <context>
     <name>nxt::NxtFlashTool</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="75"/>
         <source>Robot is already being flashed</source>
         <translation>El robot ya está siendo actualizado</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="83"/>
         <source>Firmware file not found in nxt-tools directory.</source>
         <translation>No se encontró el archivo de firmware en el directorio nxt-tools.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="96"/>
         <source>Flashing robot is possible only by USB. Please switch to USB mode.</source>
         <translation>La actualización del robot solo es posible por USB. Por favor, cambie al modo USB.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="106"/>
         <source>Firmware flash started. Please don&apos;t disconnect robot during the process</source>
         <translation>Inicio de la actualización del firmware. Por favor, no desconecte el robot durante el proceso</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="117"/>
         <source>Could not open %1 for reading.</source>
         <translation>No se pudo abrir %1 para lectura.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="125"/>
         <source>Firmware file is too large to fit into NXT brick memory.</source>
         <translation>El archivo de firmware es demasiado grande para caber en la memoria del NXT.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="135"/>
         <source>Could not write firmware into NXT memory.</source>
         <translation>No se pudo escribir el firmware en la memoria del NXT.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="142"/>
         <source>Firmware successfully flashed into robot, but starting it failed.</source>
         <translation>El firmware se actualizó correctamente en el robot, pero no se pudo iniciar. Intente reiniciar el robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="148"/>
         <source>Flashing process completed successfully.</source>
         <translation>El proceso de actualización se completó correctamente.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="154"/>
         <source>Flashing NXT brick...</source>
         <translation>Actualizando el NXT...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="213"/>
         <source>The program has been uploaded</source>
         <translation>El programa ha sido cargado</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="214"/>
         <source>Do you want to run it?</source>
         <translation>¿Desea ejecutarlo?</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="220"/>
         <source>Uploading is already running</source>
         <translation>La carga ya está en curso</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="247"/>
         <source>Uploading program started. Please don&apos;t disconnect robot during the process</source>
         <translation>Inicio de la carga del programa. Por favor, no desconecte el robot durante el proceso</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="258"/>
         <source>Uploading failed. Make sure that X-server allows root to run GUI applications</source>
         <translation>La carga falló. Asegúrese de que TRIKStudio se esté ejecutando con los permisos adecuados</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="260"/>
         <source>You need to have superuser privileges to flash NXT robot</source>
         <translation>La carga del programa falló. Quizás debería intentar reiniciar el entorno con privilegios de superusuario</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="303"/>
         <source>Compilation error occured. Please check your function blocks syntax. If you sure in their validness contact developers</source>
         <translation>Ocurrió un error de compilación. Verifique la sintaxis de las expresiones dentro de los bloques &quot;Función&quot;. Si está seguro de su corrección, contacte a los desarrolladores</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="306"/>
         <source>Could not upload program. Make sure the robot is connected and ON</source>
         <translation>No se pudo cargar el programa. Asegúrese de que el robot esté encendido y conectado al ordenador</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="308"/>
         <source>If you are using GNU/Linux visit https://help.trikset.com/nxt/run-upload-programs to get instructions</source>
         <translation>Si está usando GNU/Linux, visite https://help.trikset.com/nxt/run-upload-programs para obtener instrucciones</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="315"/>
         <source>QReal requires superuser privileges to upload programs on NXT robot</source>
         <translation>Se requieren privilegios de administrador para cargar programas en el robot NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="349"/>
         <source>Error in reading from firmware file: %1</source>
         <translation>Error al leer el archivo de firmware: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="572"/>
         <source>Could not find %1. Check your program was compiled and try again.</source>
         <translation>No se pudo encontrar %1. Verifique que el programa se haya compilado, que la ruta no contenga espacios ni letras rusas e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="581"/>
         <source>Could not delete old file. Make sure the robot is connected, turned on.</source>
         <translation>No se pudo eliminar el archivo antiguo del robot. Por favor, verifique que el robot esté encendido y conectado al ordenador e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="587"/>
         <source>Could not upload program. Make sure the robot is connected, turned on and has enough free memory.</source>
         <translation>No se pudo cargar el programa. Verifique que el robot esté encendido, conectado al ordenador y que tenga suficiente memoria libre.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="600"/>
         <source>Could not close file on brick. Probably connection to NXT lost at the last stage of uploading</source>
         <translation>No se pudo cerrar el archivo en el robot tras escribir los datos. Probablemente se perdió la conexión con el NXT en la última etapa de la carga</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="606"/>
         <source>Uploading completed successfully</source>
         <translation>La carga del programa se completó correctamente</translation>
     </message>
@@ -137,43 +111,34 @@
 <context>
     <name>nxt::osekC::NxtOsekCGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="32"/>
         <source>Generation (NXT OSEK C)</source>
         <translation>Generación (C)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="89"/>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="220"/>
         <source>NXT tools package is not installed</source>
         <translation>El paquete de herramientas NXT no está instalado</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="135"/>
         <source>Generate code</source>
         <translation>Generar código</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="140"/>
         <source>Flash robot</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="145"/>
         <source>Upload program</source>
         <translation>Cargar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="155"/>
         <source>Generate NXT OSEK code</source>
         <translation>Generar código NXT OSEK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="156"/>
         <source>Upload program to NXT device</source>
         <translation>Cargar programa en el dispositivo NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="209"/>
         <source>flash.sh not found. Make sure it is present in QReal installation directory</source>
         <translation>No se encontró el script flash.sh. Asegúrese de que el paquete nxt-tools esté instalado correctamente</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/pioneer/pioneerLuaGenerator_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/pioneer/pioneerLuaGenerator_es.ts
@@ -4,27 +4,22 @@
 <context>
     <name>PioneerAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Formulario</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="35"/>
         <source>Connection Settings</source>
         <translation>Configuración de conexión</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="50"/>
         <source>Base station IP:</source>
         <translation>IP de la estación base:</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="64"/>
         <source>Base station port:</source>
         <translation>Puerto de la estación base:</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="78"/>
         <source>Base station connection mode:</source>
         <translation>Modo de conexión de la estación base:</translation>
     </message>
@@ -32,28 +27,22 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaMasterGenerator.cpp" line="111"/>
         <source>There is no opened diagram</source>
         <translation>No hay ningún diagrama abierto</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="121"/>
         <source>Generation internal error, please send bug report to developers.Additional info: zone node %1 can not be used as labeled node.</source>
         <translation>Error interno de generación, envíe un informe de error a los desarrolladores. Información adicional: el nodo de zona %1 no puede usarse como nodo etiquetado.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="159"/>
         <source>Generation internal error, synchronous zone parent is a zone node.</source>
         <translation>Error interno de generación. Información adicional: en el árbol semántico, el nodo padre de una zona es también un nodo de zona.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="165"/>
         <source>Generation internal error, synchronous fragment zone is absent.</source>
         <translation>Error interno de generación. Información adicional: no se encontró la zona para el nodo de inicio del fragmento sincrónico.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="175"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="283"/>
         <source>Generation internal error, zone contains zone node.</source>
         <translation>Error interno de generación. Información adicional: en el árbol semántico, un nodo de zona contiene directamente como hijo a otro nodo de zona.</translation>
     </message>
@@ -61,50 +50,38 @@
 <context>
     <name>pioneer::lua::HttpCommunicator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="60"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="100"/>
         <source>Pioneer base station IP address is not set. It can be set in Settings window.</source>
         <translation>La dirección IP de la estación base Pioneer no está configurada. Puede establecerse en la ventana de Configuración -&gt; Robots -&gt; Pioneer.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="66"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="106"/>
         <source>Pioneer base station port is not set. It can be set in Settings window.</source>
         <translation>El puerto de la estación base Pioneer no está configurado. Puede establecerse en la ventana de Configuración -&gt; Robots -&gt; Pioneer.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="72"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="81"/>
         <source>Generation failed, upload aborted.</source>
         <translation>La generación falló, la carga fue cancelada.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="87"/>
         <source>Uploading to: %1, please wait...</source>
         <translation>Cargando en: %1, por favor espere...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="111"/>
         <source>Starting program. Senging request to: %1, please wait...</source>
         <translation>Iniciando programa. Enviando solicitud a: %1, por favor espere...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="121"/>
         <source>Stopping program is not supported for HTTP communication mode.</source>
         <translation>La detención del programa no es compatible con el modo de comunicación HTTP. Use la herramienta &quot;controller&quot; para comunicarse con el robot (activable en la configuración).</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="134"/>
         <source>Uploading finished.</source>
         <translation>Carga finalizada.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="142"/>
         <source>Start finished.</source>
         <translation>Inicio finalizado.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="153"/>
         <source>Pioneer base station took too long to respond. Request aborted.</source>
         <translation>La estación base Pioneer tardó demasiado en responder. Solicitud cancelada.</translation>
     </message>
@@ -112,62 +89,50 @@
 <context>
     <name>pioneer::lua::PioneerLuaGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="45"/>
         <source>Pioneer model (real copter)</source>
         <translation>Modelo Pioneer (cuadricóptero real)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="52"/>
         <source>Generate to Pioneer Lua</source>
         <translation>Generar a Pioneer Lua</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="66"/>
         <source>Upload generated program to Pioneer</source>
         <translation>Cargar el programa generado al Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="105"/>
         <source>Generate Lua script for Pioneer Quadcopter</source>
         <translation>Generar script Lua para el cuadricóptero Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="110"/>
         <source>Upload Pioneer program</source>
         <translation>Cargar programa al cuadricóptero Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="163"/>
         <source>Choose robot`s mode</source>
         <translation>Elija el modo del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="184"/>
         <source>Robot`s IP-address</source>
         <translation>Dirección IP del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="193"/>
         <source>Robot`s port</source>
         <translation>Puerto del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="288"/>
         <source>Sorry, but uploading works only on Windows</source>
         <translation>Lo sentimos, pero la carga solo funciona en Windows</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="293"/>
         <source>site</source>
         <translation>sitio web</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="294"/>
         <source>Please download uploader from </source>
         <translation>Descargue el cargador desde </translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="322"/>
         <source>Exit code </source>
         <translation>Código de salida </translation>
     </message>
@@ -175,7 +140,6 @@
 <context>
     <name>pioneer::lua::PioneerLuaMasterGenerator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaMasterGenerator.cpp" line="145"/>
         <source>Generation failed. Possible causes are internal error in generator or too complex program structure.</source>
         <translation>La generación falló. Posibles causas: error interno del generador o estructura de programa demasiado compleja. Póngase en contacto con los desarrolladores.</translation>
     </message>
@@ -183,63 +147,50 @@
 <context>
     <name>pioneer::lua::PioneerStateMachineGenerator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="53"/>
         <source>The diagram must have the same number of &quot;Conditonal&quot; and &quot;End If&quot; blocks.</source>
         <translation>El diagrama debe tener la misma cantidad de bloques &quot;Condición&quot; y &quot;Fin de condición&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="152"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="237"/>
         <source>&quot;End If&quot; block occurs before &quot;If block&quot;</source>
         <translation>No se permite el uso del bloque &quot;Fin de condición&quot; sin un bloque &quot;Condición&quot; previo</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="195"/>
         <source>Generation internal error, failed to create a node.</source>
         <translation>Error interno de generación. Información adicional: no se pudo crear un nodo en el árbol semántico.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="308"/>
         <source>Nested If&apos;s constructions is not allowed.</source>
         <translation>No se permiten construcciones condicionales anidadas.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="373"/>
         <source>Generation internal error, zone node corresponds to a block in a diagram.</source>
         <translation>Error interno de generación. Información adicional: un nodo de zona en el árbol semántico corresponde a un bloque en el diagrama. Un nodo de zona solo puede ser parte de la representación de un bloque.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="388"/>
         <source>Generation internal error, non-zone node is a start of a fragment.</source>
         <translation>Error interno de generación. Información adicional: un fragmento sincrónico comienza con un nodo que no es de zona.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="440"/>
         <source>Generation internal error, program ends abruptly.</source>
         <translation>Error interno de generación. Información adicional: el programa terminó inesperadamente. Este tipo de errores debería detectarse durante la verificación previa del programa.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="467"/>
         <source>Generation internal error, asynchronous node does not have target node.</source>
         <translation>Error interno de generación. Información adicional: el nodo asíncrono no tiene un nodo destino al que transferir el control tras la operación asíncrona.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="488"/>
         <source>There is a problem with If construction or with loops (loops without sending requests to the autopilot through &quot;Takeoff&quot;, &quot;Landing&quot;, &quot;Go to local point&quot; blocks are not supported yet).</source>
         <translation>Hay un problema con la construcción condicional o con los bucles (los bucles sin envío de solicitudes al piloto automático mediante bloques &quot;Despegar&quot;, &quot;Aterrizar&quot;, &quot;Ir a punto local&quot; aún no están soportados).</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="529"/>
         <source>The blocks (&quot;Takeoff&quot;, &quot;Landing&quot;, &quot;Go to local point&quot;) which work with autopilot were observed in both (or only in one) conditional branches.</source>
         <translation>Se han detectado bloques (&quot;Despegar&quot;, &quot;Aterrizar&quot;, &quot;Ir a punto local&quot;) que interactúan con el piloto automático del cuadricóptero en una o varias ramas del diagrama.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="531"/>
         <source>Such blocks must appear and finish both branches (the &quot;End if&quot; block must have two such parents) or not appear at branches at all.</source>
         <translation>Estos bloques deben aparecer y finalizar ambas ramas de la construcción condicional (el bloque &quot;Fin de condición&quot; debe tener dos de estos padres) o no aparecer en absoluto.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="533"/>
         <source>Such blocks may appear in each branch several times but one of them must finish it in each branch.</source>
         <translation>Estos bloques pueden aparecer varias veces en cada rama, pero uno de ellos debe finalizar cada rama.</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/trik/trikGeneratorBase_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/trik/trikGeneratorBase_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikGeneratorBase/src/trikBlocksValidator.cpp" line="111"/>
         <source>Property should not be empty.</source>
         <translation>La propiedad no debe estar vacía.</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/trik/trikPythonGeneratorLibrary_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/trik/trikPythonGeneratorLibrary_es.ts
@@ -4,63 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonControlFlowValidator.cpp" line="35"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>No hay nada que generar, el diagrama no tiene un nodo inicial</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="141"/>
         <source>Trying to join a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Intentando unir un hilo con un identificador desconocido. Posibles causas: llamar a fork desde un subprograma o intentar fusionar dos hilos sin un bloque join</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="148"/>
         <source>Join block must have exactly one outgoing link</source>
         <translation>El bloque de unión debe tener exactamente un enlace de salida</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="154"/>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="199"/>
         <source>Guard property of a link outgoing from a join must contain an id of one of joined threads</source>
         <translation>La propiedad de guarda de un enlace que sale de un bloque de unión debe contener el identificador de uno de los hilos unidos</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="161"/>
         <source>Joining threads in a loop is forbidden</source>
         <translation>Está prohibido unir hilos dentro de un bucle</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="223"/>
         <source>Trying to fork from a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Intentando crear un fork desde un hilo con identificador desconocido. Posibles causas: llamar a fork desde un subprograma o intentar fusionar dos hilos sin un bloque join</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="229"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>El bloque fork debe tener al menos DOS enlaces de salida</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="258"/>
         <source>Links outgoing from a fork block must have different thread ids</source>
         <translation>Los enlaces que salen del bloque fork deben tener identificadores de hilo diferentes</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="273"/>
         <source>Fork block must have a link marked with an id of a thread from which the fork is called, &apos;%1&apos; in this case</source>
         <translation>El bloque fork debe tener un enlace marcado con el identificador del hilo desde el cual se llama al fork, en este caso &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="284"/>
         <source>Trying to create a thread with an already occupied id &apos;%1&apos;</source>
         <translation>Intentando crear un hilo con un identificador ya ocupado &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="294"/>
         <source>Creation of threads in a cycle is forbidden, check for links to before a fork</source>
         <translation>Está prohibida la creación de hilos en un ciclo, verifique los enlaces que conducen a bloques anteriores al bloque fork</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="330"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace de salida no está conectado</translation>
     </message>
@@ -68,57 +55,46 @@
 <context>
     <name>trik::python::TrikPythonGeneratorPluginBase</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="73"/>
         <source>Network operation timed out</source>
         <translation>La operación de red ha excedido el tiempo de espera, verifique la configuración y asegúrese de que el robot esté encendido</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="100"/>
         <source>Casing model mismatch, check TRIK Studio settings, &quot;Robots&quot; page. It seems that TRIK casing version selected in TRIK Studio differs from version on robot.</source>
         <translation>El modelo del chasis no coincide, verifique la configuración en TRIK Studio, pestaña &quot;Robots&quot;. Parece que la versión del chasis seleccionada en TRIK Studio es diferente de la del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="109"/>
         <source>Generate python code</source>
         <translation>Generar código en Python</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="116"/>
         <source>Upload program</source>
         <translation>Cargar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="123"/>
         <source>Run program</source>
         <translation>Cargar y ejecutar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="130"/>
         <source>Stop robot</source>
         <translation>Detener robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="146"/>
         <source>Generate Python code</source>
         <translation>Generar código para TRIK en QtScript</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="147"/>
         <source>Upload Python program</source>
         <translation>Cargar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="148"/>
         <source>Run Python program</source>
         <translation>Ejecutar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="149"/>
         <source>Stop Python program</source>
         <translation>Detener la ejecución del programa para TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="221"/>
         <source>There are no files to upload. You must open or generate at least one *.js or *.py file.</source>
         <translation>No hay archivos para cargar. Debe abrir o generar al menos un archivo *.js o *.py.</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/trik/trikQtsGeneratorLibrary_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/trik/trikQtsGeneratorLibrary_es.ts
@@ -4,63 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsControlFlowValidator.cpp" line="37"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>No hay nada que generar, el diagrama no tiene un nodo inicial</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="141"/>
         <source>Trying to join a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Intentando unir un hilo con un identificador desconocido. Posibles causas: llamar a fork desde un subprograma o intentar fusionar dos hilos sin un bloque join</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="148"/>
         <source>Join block must have exactly one outgoing link</source>
         <translation>El bloque de unión debe tener exactamente un enlace de salida</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="154"/>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="199"/>
         <source>Guard property of a link outgoing from a join must contain an id of one of joined threads</source>
         <translation>La propiedad de guarda de un enlace que sale de un bloque de unión debe contener el identificador de uno de los hilos unidos</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="161"/>
         <source>Joining threads in a loop is forbidden</source>
         <translation>Está prohibido unir hilos dentro de un bucle</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="223"/>
         <source>Trying to fork from a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Intentando crear un fork desde un hilo con identificador desconocido. Posibles causas: llamar a fork desde un subprograma o intentar fusionar dos hilos sin un bloque join</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="229"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>El bloque fork debe tener al menos DOS enlaces de salida</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="258"/>
         <source>Links outgoing from a fork block must have different thread ids</source>
         <translation>Los enlaces que salen del bloque fork deben tener identificadores de hilo diferentes</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="273"/>
         <source>Fork block must have a link marked with an id of a thread from which the fork is called, &apos;%1&apos; in this case</source>
         <translation>El bloque fork debe tener un enlace marcado con el identificador del hilo desde el cual se llama al fork, en este caso &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="284"/>
         <source>Trying to create a thread with an already occupied id &apos;%1&apos;</source>
         <translation>Intentando crear un hilo con un identificador ya ocupado &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="294"/>
         <source>Creation of threads in a cycle is forbidden, check for links to before a fork</source>
         <translation>Está prohibida la creación de hilos en un ciclo, verifique los enlaces que conducen a bloques anteriores al fork</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="330"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace de salida no está conectado</translation>
     </message>
@@ -68,57 +55,46 @@
 <context>
     <name>trik::qts::TrikQtsGeneratorPluginBase</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="73"/>
         <source>Network operation timed out</source>
         <translation>La operación de red ha excedido el tiempo de espera, verifique la configuración y asegúrese de que el robot esté encendido</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="100"/>
         <source>Casing model mismatch, check TRIK Studio settings, &quot;Robots&quot; page. It seems that TRIK casing version selected in TRIK Studio differs from version on robot.</source>
         <translation>El modelo del chasis no coincide, verifique la configuración en TRIK Studio, pestaña &quot;Robots&quot;. Parece que la versión del chasis seleccionada en TRIK Studio es diferente de la del robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="109"/>
         <source>Generate TRIK code</source>
         <translation>Generar código JavaScript</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="116"/>
         <source>Upload program</source>
         <translation>Cargar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="123"/>
         <source>Run program</source>
         <translation>Cargar y ejecutar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="130"/>
         <source>Stop robot</source>
         <translation>Detener robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="146"/>
         <source>Generate TRIK Code</source>
         <translation>Generar código JavaScript para TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="147"/>
         <source>Upload TRIK Program</source>
         <translation>Cargar programa TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="148"/>
         <source>Run TRIK Program</source>
         <translation>Ejecutar programa TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="149"/>
         <source>Stop TRIK Robot</source>
         <translation>Detener la ejecución del programa para TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="221"/>
         <source>There are no files to upload. You must open or generate at least one *.js or *.py file.</source>
         <translation>No hay archivos para cargar. Debe abrir o generar al menos un archivo *.js o *.py.</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/trik/trikV62PythonGenerator_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/trik/trikV62PythonGenerator_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::python::TrikV62PythonGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikV62PythonGenerator/trikV62PythonGeneratorPlugin.cpp" line="29"/>
         <source>Generation (Python)</source>
         <translation>Generación (Python)</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/generators/trik/trikV62QtsGenerator_es.ts
+++ b/qrtranslations/es/plugins/robots/generators/trik/trikV62QtsGenerator_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::qts::TrikV62QtsGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikV62QtsGenerator/trikV62QtsGeneratorPlugin.cpp" line="29"/>
         <source>Generation (Java Script)</source>
         <translation>Generación (JavaScript)</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/interpreters/ev3KitInterpreter_es.ts
+++ b/qrtranslations/es/plugins/robots/interpreters/ev3KitInterpreter_es.ts
@@ -4,48 +4,38 @@
 <context>
     <name>Ev3AdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Configuración EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="36"/>
         <source>Robot&apos;s Folders</source>
         <translation>Carpetas del Robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="51"/>
         <source>ts</source>
         <translation>ts</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="64"/>
         <source>Common folder:</source>
         <translation>Carpeta común:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="71"/>
         <source>Use common folder for all projects</source>
         <translation>Usar carpeta común para todos los proyectos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="81"/>
         <source>Bluetooth Settings</source>
         <translation>Configuración de Bluetooth</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="87"/>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="104"/>
         <source>COM Port:</source>
         <translation>Puerto COM:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="94"/>
         <source>No COM ports found. If you have a Bluetooth connection with active virtual COM port, please enter its name. Example: COM3</source>
         <translation>No se encontraron puertos COM. Si tiene una conexión Bluetooth con un puerto COM virtual activo, ingrese su nombre. Ejemplo: COM3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="124"/>
         <source>Specify COM port manually</source>
         <translation>Especificar puerto COM manualmente</translation>
     </message>
@@ -53,7 +43,6 @@
 <context>
     <name>Ev3DisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3DisplayWidget.ui" line="435"/>
         <source>tr(Ev3Display)</source>
         <translation>Pantalla EV3</translation>
     </message>
@@ -61,7 +50,6 @@
 <context>
     <name>ev3::Ev3AdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.cpp" line="29"/>
         <source>2D robot image:</source>
         <translation>Imagen 2D del robot:</translation>
     </message>
@@ -69,7 +57,6 @@
 <context>
     <name>ev3::Ev3KitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3KitInterpreterPlugin.cpp" line="108"/>
         <source>Lego EV3</source>
         <translation>Lego EV3</translation>
     </message>
@@ -77,7 +64,6 @@
 <context>
     <name>ev3::robotModel::real::BluetoothRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/bluetoothRealRobotModel.cpp" line="34"/>
         <source>Interpretation (Bluetooth)</source>
         <translation>Interpretación (Bluetooth)</translation>
     </message>
@@ -85,7 +71,6 @@
 <context>
     <name>ev3::robotModel::real::UsbRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/usbRealRobotModel.cpp" line="34"/>
         <source>Interpretation (USB)</source>
         <translation>Interpretación (USB)</translation>
     </message>
@@ -93,7 +78,6 @@
 <context>
     <name>ev3::robotModel::real::parts::RangeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/parts/rangeSensor.h" line="31"/>
         <source>Sonar sensor</source>
         <translation>Sensor de sonar</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/interpreters/interpreterCore_es.ts
+++ b/qrtranslations/es/plugins/robots/interpreters/interpreterCore_es.ts
@@ -4,77 +4,62 @@
 <context>
     <name>PreferencesRobotSettingsPage</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="23"/>
         <source>Graphics Watcher update intervals</source>
         <translation>Intervalos de actualización del observador de gráficos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="35"/>
         <source>Sensors  (ms)</source>
         <translation>Sensores (ms)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="63"/>
         <source>Autoscaling  (ms)</source>
         <translation>Escala automática (ms)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="91"/>
         <source>Text info (ms)</source>
         <translation>Información de texto (ms)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="223"/>
         <source>Uploading &amp;&amp; Running</source>
         <translation>Cargando y ejecutando</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="229"/>
         <source>Running after uploading:</source>
         <translation>Ejecutar tras la carga:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="237"/>
         <source>Ask</source>
         <translation>Preguntar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="242"/>
         <source>Always run</source>
         <translation>Ejecutar siempre</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="247"/>
         <source>Never run</source>
         <translation>Nunca ejecutar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="258"/>
         <source>2D-model Editor Settings</source>
         <translation>Configuración del Editor de Modelos 2D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="264"/>
         <source>Enable Region Editor Mode</source>
         <translation>Modo Editor de Regiones</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="271"/>
         <source>Advanced settings for creating restrictions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="192"/>
         <source>Sensors Settings</source>
         <translation>Configuración de sensores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="137"/>
         <source>Robotics construction kit</source>
         <translation>Plataforma</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="151"/>
         <source>Robot model</source>
         <translation>Modelo de robot</translation>
     </message>
@@ -82,107 +67,86 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="27"/>
         <source>TRIK Studio</source>
         <translation>TRIK Studio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="81"/>
         <source>Subprograms</source>
         <translation>Subprogramas</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="86"/>
         <source>The list of all declared subprograms in the project</source>
         <translation>Lista de todos los subprogramas declarados en el proyecto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/details/autoconfigurer.cpp" line="60"/>
         <source>%2 has been auto configured to port %1</source>
         <translation>%2 ha sido configurado automáticamente en el puerto %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/details/autoconfigurer.cpp" line="64"/>
         <source>Sensor on port %1 does not correspond to blocks on the diagram.</source>
         <translation>El sensor en el puerto %1 no corresponde a los bloques del diagrama.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="32"/>
         <source>Run</source>
         <translation>Ejecutar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="33"/>
         <source>Stop robot</source>
         <translation>Detener</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="34"/>
         <source>Connect to robot</source>
         <translation>Conectar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="35"/>
         <source>Robot settings</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="36"/>
         <source>Save as task...</source>
         <translation>Guardar como ejercicio...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="39"/>
         <source>Debug</source>
         <translation>Depuración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="43"/>
         <source>Edit</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="113"/>
         <source>Switch to edit mode</source>
         <translation>Cambiar al modo de edición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="114"/>
         <source>Switch to debug mode</source>
         <translation>Cambiar al modo de depuración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="115"/>
         <source>Run interpreter</source>
         <translation>Iniciar intérprete</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="116"/>
         <source>Stop interpreter</source>
         <translation>Detener intérprete</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="63"/>
         <source>Blocks</source>
         <translation>Bloques</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="112"/>
         <source>Configure devices</source>
         <translation>Configuración de sensores</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="126"/>
         <source>Sensors state</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/exerciseExportManager.cpp" line="53"/>
         <source>Select file to export save to</source>
         <translation>Seleccione el archivo donde guardar el ejercicio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/exerciseExportManager.cpp" line="55"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Archivo de guardado TRIK Studio (*.qrs)</translation>
     </message>
@@ -190,17 +154,14 @@
 <context>
     <name>interpreterCore::ActionsManager</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="45"/>
         <source>To main page</source>
         <translation>Ir a la página principal</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="291"/>
         <source>Real robot</source>
         <translation>Robot real</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="292"/>
         <source>2D model</source>
         <translation>Modelo 2D</translation>
     </message>
@@ -208,7 +169,6 @@
 <context>
     <name>interpreterCore::DefaultRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/defaultRobotModel.cpp" line="31"/>
         <source>Empty model</source>
         <translation>Modelo vacío</translation>
     </message>
@@ -216,27 +176,22 @@
 <context>
     <name>interpreterCore::RobotsPluginFacade</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="159"/>
         <source>Robots</source>
         <translation>Robots</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="202"/>
         <source>Cannot export exercise to the given location (try to change location)</source>
         <translation>No se puede exportar el ejercicio a la ubicación indicada (intente cambiar la ubicación)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="317"/>
         <source>The specified script file could not be opened for reading </source>
         <translation>No se pudo abrir el archivo de script especificado para lectura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="329"/>
         <source>No saved code found in the qrs file</source>
         <translation>No se encontró código guardado en el archivo qrs</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="427"/>
         <source>Toggle robot console panel</source>
         <translation>Mostrar/ocultar panel de consola del robot</translation>
     </message>
@@ -244,37 +199,30 @@
 <context>
     <name>interpreterCore::UiManager</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="60"/>
         <source>Miscellaneous</source>
         <translation>Varios</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="61"/>
         <source>Robot console</source>
         <translation>Consola del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="93"/>
         <source>edit mode</source>
         <translation>modo de edición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="94"/>
         <source>debug mode</source>
         <translation>modo de depuración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="245"/>
         <source>Edit mode</source>
         <translation>Modo de edición</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="248"/>
         <source>Debug mode</source>
         <translation>Modo de depuración</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="394"/>
         <source>Modes</source>
         <translation>Modos</translation>
     </message>
@@ -282,38 +230,30 @@
 <context>
     <name>interpreterCore::interpreter::BlockInterpreter</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="92"/>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="166"/>
         <source>No connection to robot</source>
         <translation>Sin conexión al robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="98"/>
         <source>Interpreter is already running</source>
         <translation>El intérprete ya está en ejecución</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="150"/>
         <source>Connected successfully</source>
         <translation>Conexión exitosa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="154"/>
         <source>Can&apos;t connect to a robot.</source>
         <translation>No se puede conectar al robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="198"/>
         <source>Cannot create new thread with already occupied id %1</source>
         <translation>No se puede crear un nuevo hilo con el identificador %1 ya ocupado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="212"/>
         <source>Threads limit exceeded. Maximum threads count is %1</source>
         <translation>Límite de hilos excedido. El número máximo de hilos es %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="234"/>
         <source>Killing non-existent thread %1</source>
         <translation>Intentando finalizar el hilo inexistente %1</translation>
     </message>
@@ -321,42 +261,34 @@
 <context>
     <name>interpreterCore::ui::ExerciseExportDialog</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="31"/>
         <source>Select non-modifiable parts of exercize</source>
         <translation>Seleccione las partes no modificables del ejercicio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="33"/>
         <source>2D model world is read-only</source>
         <translation>El mundo del modelo 2D es de solo lectura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="34"/>
         <source>Sensors are read-only</source>
         <translation>Los sensores son de solo lectura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="35"/>
         <source>2D model robot position is read-only</source>
         <translation>La posición del robot en el modelo 2D es de solo lectura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="36"/>
         <source>Motors to wheels binding is read-only</source>
         <translation>La relación motor-rueda es de solo lectura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="37"/>
         <source>2D model simulation settings are read-only</source>
         <translation>Los parámetros de simulación son de solo lectura</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="58"/>
         <source>Ok</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="62"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -364,7 +296,6 @@
 <context>
     <name>interpreterCore::ui::ModeStripe</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/modeStripe.cpp" line="22"/>
         <source>press %2 or click here to switch to %3</source>
         <translation>pulse %2 o haga clic aquí para cambiar a %3</translation>
     </message>
@@ -372,22 +303,18 @@
 <context>
     <name>interpreterCore::ui::RobotsSettingsPage</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="58"/>
         <source>Templates directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="60"/>
         <source>Choose templates directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="94"/>
         <source>No constructor kit plugins loaded</source>
         <translation>No se ha cargado ningún plugin de plataforma robótica</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="238"/>
         <source>No robot models available for </source>
         <translation>No hay modelos de robot disponibles para </translation>
     </message>

--- a/qrtranslations/es/plugins/robots/interpreters/nullKitInterpreter_es.ts
+++ b/qrtranslations/es/plugins/robots/interpreters/nullKitInterpreter_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>nullKitInterpreter::NullKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nullKitInterpreter/src/nullKitInterpreterPlugin.cpp" line="33"/>
         <source>Empty Kit</source>
         <translation>Kit vacío</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>nullKitInterpreter::NullRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nullKitInterpreter/src/nullRobotModel.cpp" line="31"/>
         <source>Null model</source>
         <translation>Modelo nulo</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/interpreters/nxtKitInterpreter_es.ts
+++ b/qrtranslations/es/plugins/robots/interpreters/nxtKitInterpreter_es.ts
@@ -4,38 +4,30 @@
 <context>
     <name>NxtAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Configuración NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="35"/>
         <source>nxtOSEK Generator Settings</source>
         <translation>Configuración del generador nxtOSEK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="41"/>
         <source>TextLabel</source>
         <translation>Etiqueta de texto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="54"/>
         <source>Bluetooth Settings</source>
         <translation>Configuración de Bluetooth</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="70"/>
         <source>No COM ports found. If you have a Bluetooth connection with active virtual COM port, please enter its name. Example: COM3</source>
         <translation>No se encontraron puertos COM. Si tiene una conexión Bluetooth con un puerto COM virtual activo, introduzca su nombre. Ejemplo: COM3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="83"/>
         <source>Specify COM port manually</source>
         <translation>Especificar puerto COM manualmente</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="90"/>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="97"/>
         <source>COM Port:</source>
         <translation>Puerto COM:</translation>
     </message>
@@ -43,7 +35,6 @@
 <context>
     <name>NxtDisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtDisplayWidget.ui" line="435"/>
         <source>tr(NxtDisplay)</source>
         <translation>Pantalla NXT</translation>
     </message>
@@ -51,17 +42,14 @@
 <context>
     <name>nxt::NxtAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.cpp" line="33"/>
         <source>2D robot image:</source>
         <translation>Imagen 2D del robot:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.cpp" line="36"/>
         <source>Path to arm-none-eabi:</source>
         <translation>Ruta a arm-none-eabi:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.cpp" line="61"/>
         <source>WARNING: Current directory doesn&apos;t exist. 
 Open &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;link&lt;/a&gt; for instructions</source>
         <translation>ADVERTENCIA: El directorio actual no existe. 
@@ -71,7 +59,6 @@ Abra el &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&
 <context>
     <name>nxt::NxtKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtKitInterpreterPlugin.cpp" line="107"/>
         <source>Lego NXT</source>
         <translation>Lego NXT</translation>
     </message>
@@ -79,7 +66,6 @@ Abra el &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&
 <context>
     <name>nxt::robotModel::real::BluetoothRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/bluetoothRealRobotModel.cpp" line="35"/>
         <source>Interpretation (Bluetooth)</source>
         <translation>Interpretación (Bluetooth)</translation>
     </message>
@@ -87,7 +73,6 @@ Abra el &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&
 <context>
     <name>nxt::robotModel::real::UsbRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/usbRealRobotModel.cpp" line="34"/>
         <source>Interpretation (USB)</source>
         <translation>Interpretación (USB)</translation>
     </message>
@@ -95,7 +80,6 @@ Abra el &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&
 <context>
     <name>nxt::robotModel::real::parts::SonarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/parts/sonarSensor.h" line="31"/>
         <source>Sonar sensor</source>
         <translation>Sensor de sonar</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/interpreters/pioneerKitInterpreter_es.ts
+++ b/qrtranslations/es/plugins/robots/interpreters/pioneerKitInterpreter_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>pioneerKitInterpreter::PioneerKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/pioneerKitInterpreter/src/pioneerKitInterpreterPlugin.cpp" line="33"/>
         <source>Pioneer Kit</source>
         <translation>Kit Pionero</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/interpreters/robotsPlugin_es.ts
+++ b/qrtranslations/es/plugins/robots/interpreters/robotsPlugin_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/robotsPlugin/robotsPlugin.cpp" line="51"/>
         <source>Robots</source>
         <translation>Robots</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/interpreters/trikKitInterpreterCommon_es.ts
+++ b/qrtranslations/es/plugins/robots/interpreters/trikKitInterpreterCommon_es.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="166"/>
         <source>Bogus input values</source>
         <translation>Valores de entrada no válidos</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="188"/>
         <source>Error: File %1 couldn&apos;t be opened!</source>
         <translation>Error: ¡No se pudo abrir el archivo %1!</translation>
     </message>
@@ -17,62 +15,50 @@
 <context>
     <name>TrikAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Configuración de TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="35"/>
         <source>TCP Settings</source>
         <translation>Configuración TCP</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="44"/>
         <source>Enter robot IP-address here</source>
         <translation>Introduzca aquí la dirección IP del robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="57"/>
         <source>Camera Settings</source>
         <translation>Configuración de la cámara</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="72"/>
         <source>Camera:</source>
         <translation>Cámara:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="85"/>
         <source>Use real camera</source>
         <translation>Usar cámara real</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="101"/>
         <source>Use images from project</source>
         <translation>Usar imágenes empaquetadas en el proyecto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="108"/>
         <source>Images:</source>
         <translation>Imágenes:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="114"/>
         <source>Browse...</source>
         <translation>Examinar...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="124"/>
         <source>Pack images to project</source>
         <translation>Empaquetar imágenes en el proyecto</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="140"/>
         <source>Network Settings</source>
         <translation>Configuración de red</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="146"/>
         <source>Enable Mailbox</source>
         <translation>Activar buzón (Mailbox)</translation>
     </message>
@@ -80,7 +66,6 @@
 <context>
     <name>TrikDisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikDisplayWidget.ui" line="14"/>
         <source>Trik Display</source>
         <translation>Pantalla TRIK</translation>
     </message>
@@ -88,14 +73,12 @@
 <context>
     <name>TwoDExecutionControl</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp" line="28"/>
         <source>&apos;%1&apos; is disabled
 </source>
         <translation>&apos;%1&apos; está desactivado
 </translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp" line="46"/>
         <source>No cofigured random device</source>
         <translation>No hay generador de números aleatorios configurado</translation>
     </message>
@@ -103,22 +86,18 @@
 <context>
     <name>trik::TrikAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="33"/>
         <source>2D robot image:</source>
         <translation>Imagen del robot en 2D:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="51"/>
         <source>Select Directory</source>
         <translation>Seleccionar directorio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="76"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="76"/>
         <source>You should restart the program to apply changes</source>
         <translation>Debe reiniciar el programa para aplicar los cambios</translation>
     </message>
@@ -126,84 +105,66 @@
 <context>
     <name>trik::TrikBrick</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="84"/>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="160"/>
         <source>2d model shell part was not found</source>
         <translation>No se encontró la consola del modelo 2D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="130"/>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="413"/>
         <source>Trying to read from file %1 failed</source>
         <translation>Falló al intentar leer del archivo %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="190"/>
         <source>No configured motor on port: %1</source>
         <translation>No hay motor configurado en el puerto: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="221"/>
         <source>No configured scalar sensor on port: %1</source>
         <translation>No hay sensor escalar configurado en el puerto: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="236"/>
         <source>No configured lidar on port: %1</source>
         <translation>No hay lidar configurado en el puerto: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="269"/>
         <source>No configured accelerometer</source>
         <translation>No hay acelerómetro configurado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="285"/>
         <source>No configured gyroscope</source>
         <translation>No hay giroscopio configurado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="305"/>
         <source>No configured LineSensor on port: %1</source>
         <translation>No hay sensor de línea configurado en el puerto: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="324"/>
         <source>No configured ColorSensor on port: %1</source>
         <translation>No hay sensor de color configurado en el puerto: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="334"/>
         <source>Sensor not implemented in simulation mode. Used port: %1</source>
         <translation>Sensor no implementado en modo simulación. Puerto usado: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="344"/>
         <source>No configured encoder on port: %1</source>
         <translation>No hay codificador (encoder) configurado en el puerto: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="365"/>
         <source>No configured led</source>
         <translation>No hay LED configurado</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="384"/>
         <source>Get photo with camera started</source>
         <translation>Inicio del proceso de obtención de foto con la cámara</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="386"/>
         <source>Get photo with camera finished</source>
         <translation>Finalización del proceso de obtención de foto con la cámara</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="388"/>
         <source>Cannot get a photo from camera (possibly because of wrong camera name)</source>
         <translation>No se pudo obtener una foto de la cámara (posiblemente por nombre incorrecto de la cámara)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="395"/>
         <source>Cannot get a photo from folders/project (possibly because of wrong path/empty project)</source>
         <translation>No se pudo obtener una foto de las carpetas/proyecto (posiblemente por ruta incorrecta/proyecto vacío)</translation>
     </message>
@@ -211,32 +172,26 @@
 <context>
     <name>trik::TrikKitInterpreterPluginBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="39"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="39"/>
         <source>Stop</source>
         <translation>Detener</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="100"/>
         <source>TRIK_PYTHONPATH must be set correctly to run Python script.</source>
         <translation>TRIK_PYTHONPATH debe estar configurado correctamente para ejecutar el script de Python.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="273"/>
         <source>Run program</source>
         <translation>Ejecutar programa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="278"/>
         <source>Stop robot</source>
         <translation>Detener programa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="477"/>
         <source>Enter robot`s IP-address here...</source>
         <translation>Introduzca aquí la dirección IP del robot...</translation>
     </message>
@@ -244,8 +199,6 @@
 <context>
     <name>trik::TrikTextualInterpreter</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="92"/>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="107"/>
         <source>Unsupported script file type</source>
         <translation>Tipo de archivo de script no soportado</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/interpreters/trikV62KitInterpreter_es.ts
+++ b/qrtranslations/es/plugins/robots/interpreters/trikV62KitInterpreter_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::TrikV62KitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikV62KitInterpreter/src/trikV62KitInterpreterPlugin.cpp" line="47"/>
         <source>TRIK</source>
         <translation>TRIK</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>trik::robotModel::real::RealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikV62KitInterpreter/src/robotModel/real/trikV62RealRobotModel.cpp" line="69"/>
         <source>Interpretation (Wi-Fi)</source>
         <translation>Interpretación (Wi-Fi)</translation>
     </message>

--- a/qrtranslations/es/plugins/robots/utils_es.ts
+++ b/qrtranslations/es/plugins/robots/utils_es.ts
@@ -4,18 +4,14 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="27"/>
         <source>Current TRIK runtime version can not be received</source>
         <translation>No se puede obtener la versión actual del firmware de TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="32"/>
         <source>TRIK runtime version is too old, please update it by pressing &apos;Upload Runtime&apos; button on toolbar</source>
         <translation>La versión del software del robot es demasiado antigua, actualícela pulsando el botón &apos;Cargar software en el robot&apos; en la barra de herramientas</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="38"/>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="43"/>
         <source>From robot: </source>
         <translation>En el robot: </translation>
     </message>
@@ -23,7 +19,6 @@
 <context>
     <name>SensorsGraph</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.ui" line="25"/>
         <source>SensorsGraph</source>
         <translation>Sensores</translation>
     </message>
@@ -31,23 +26,18 @@
 <context>
     <name>trik::UploaderTool</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="131"/>
         <source>WinSCP process failed to launch, check path in settings.</source>
         <translation>No se pudo iniciar el proceso de WinSCP, verifique que la carpeta winscp esté en la carpeta de TRIK Studio y que contenga WinSCP.exe</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="134"/>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="149"/>
         <source>Uploading failed, check connection and try again.</source>
         <translation>La carga del software falló, verifique la conexión e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="146"/>
         <source>Uploaded successfully!</source>
         <translation>¡Carga completada con éxito!</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="180"/>
         <source>%1 is not installed. Please install %1 first.</source>
         <translation>%1 no está instalado. Por favor, instale %1 primero.</translation>
     </message>
@@ -55,12 +45,10 @@
 <context>
     <name>utils::robotCommunication::TcpRobotCommunicator</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicator.cpp" line="81"/>
         <source>Empty program name, can not upload</source>
         <translation>Nombre de programa vacío, no se puede cargar</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicator.cpp" line="89"/>
         <source>Can not read generated file, uploading aborted</source>
         <translation>No se puede leer el archivo generado, carga cancelada</translation>
     </message>
@@ -68,12 +56,10 @@
 <context>
     <name>utils::robotCommunication::TcpRobotCommunicatorWorker</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicatorWorker.cpp" line="232"/>
         <source>Unable to resolve host.</source>
         <translation>El nombre del robot especificado es desconocido.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicatorWorker.cpp" line="250"/>
         <source>Connection failed. IP: %1</source>
         <translation>No se pudo establecer conexión con el robot. Dirección IP: %1</translation>
     </message>
@@ -81,17 +67,14 @@
 <context>
     <name>utils::sensorsGraph::SensorViewer</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorViewer.cpp" line="109"/>
         <source>Save values history</source>
         <translation>Guardar valores</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorViewer.cpp" line="109"/>
         <source>Comma-Separated Values Files (*.csv)</source>
         <translation>Archivos de valores separados por comas (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorViewer.cpp" line="215"/>
         <source>value: </source>
         <translation>valor: </translation>
     </message>
@@ -99,32 +82,26 @@
 <context>
     <name>utils::sensorsGraph::SensorsGraph</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="141"/>
         <source>Stop tracking</source>
         <translation>Detener seguimiento</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="145"/>
         <source>Start tracking</source>
         <translation>Iniciar seguimiento</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="149"/>
         <source>Reset plot</source>
         <translation>Limpiar gráfico</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="153"/>
         <source>Zoom In</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="157"/>
         <source>Zoom Out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="161"/>
         <source>Export values...</source>
         <translation>Exportar lecturas...</translation>
     </message>

--- a/qrtranslations/es/plugins/tools/subprogramsImporterExporter_es.ts
+++ b/qrtranslations/es/plugins/tools/subprogramsImporterExporter_es.ts
@@ -4,17 +4,14 @@
 <context>
     <name>SubprogramsCollectionDialog</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="29"/>
         <source>Subprograms collection manager</source>
         <translation>Gestor de colección de subprogramas</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="41"/>
         <source>Select All</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="43"/>
         <source>Deselect All</source>
         <translation>Deseleccionar todo</translation>
     </message>
@@ -22,22 +19,18 @@
 <context>
     <name>subprogramsCollectionDialog</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Diálogo</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="20"/>
         <source>Available subprograms:</source>
         <translation>Subprogramas disponibles:</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="27"/>
         <source>Select all</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="66"/>
         <source>WARNING: existing subprograms will be overwritten!</source>
         <translation>¡ADVERTENCIA: los subprogramas existentes serán sobrescritos!</translation>
     </message>
@@ -45,83 +38,66 @@
 <context>
     <name>subprogramsImporterExporter::SubprogramsImporterExporterPlugin</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="38"/>
         <source>Subprograms</source>
         <translation>Subprogramas</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="41"/>
         <source>Import from file...</source>
         <translation>Importar desde archivo...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="42"/>
         <source>Export to file...</source>
         <translation>Exportar a archivo...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="43"/>
         <source>Save to collection...</source>
         <translation>Guardar en la colección...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="44"/>
         <source>Load from collection</source>
         <translation>Cargar desde la colección</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="45"/>
         <source>Clear collection</source>
         <translation>Limpiar colección</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="100"/>
         <source>Select subprograms file (name for new one)</source>
         <translation>Seleccionar archivo de subprogramas (nombre para uno nuevo)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="101"/>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="144"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Archivo de guardado de QReal (*.qrs)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="122"/>
         <source>There are no subprograms in your project.</source>
         <translation>No hay subprogramas en su proyecto.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="143"/>
         <source>Select subprograms file</source>
         <translation>Seleccionar archivo de subprogramas</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="200"/>
         <source>There are not subprograms in your project</source>
         <translation>No hay subprogramas en su proyecto</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="241"/>
         <source>There are no subprograms in your collection for %1 robot.</source>
         <translation>No hay subprogramas en su colección para el robot %1.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="288"/>
         <source>Clear the collection</source>
         <translation>Limpiar la colección</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="289"/>
         <source>Remove all subprograms for all kits from the collection?</source>
         <translation>¿Eliminar todos los subprogramas para todos los kits de la colección?</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="300"/>
         <source>There is no opened project</source>
         <translation>No hay ningún proyecto abierto</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="322"/>
         <source>There are different subprograms with the same name in your project. Please make them unique.</source>
         <translation>Hay diferentes subprogramas con el mismo nombre en su proyecto. Por favor, haga que sean únicos.</translation>
     </message>

--- a/qrtranslations/es/plugins/tools/updatesChecker_es.ts
+++ b/qrtranslations/es/plugins/tools/updatesChecker_es.ts
@@ -4,22 +4,18 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="23"/>
         <source>New updates are available!</source>
         <translation>¡Hay nuevas actualizaciones disponibles!</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="24"/>
         <source>Update</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="25"/>
         <source>Later</source>
         <translation>Más tarde</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="27"/>
         <source>Yeah!</source>
         <translation>¡Sí!</translation>
     </message>
@@ -27,27 +23,22 @@
 <context>
     <name>updatesChecker::UpdatesCheckerPlugin</name>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="33"/>
         <source>Check for updates</source>
         <translation>Buscar actualizaciones</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="66"/>
         <source>There is some connection problem, may be network is disabled</source>
         <translation>Hay un problema de conexión, es posible que la red esté desactivada</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="69"/>
         <source>There is some unrecognized error with updating process</source>
         <translation>Se ha producido un error desconocido durante la actualización (por favor, informe a los desarrolladores)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="80"/>
         <source>No updates available</source>
         <translation>No hay actualizaciones disponibles</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="91"/>
         <source>Check for updates on start</source>
         <translation>Buscar actualizaciones al iniciar</translation>
     </message>

--- a/qrtranslations/es/qrgui/dialogs_es.ts
+++ b/qrtranslations/es/qrgui/dialogs_es.ts
@@ -4,27 +4,22 @@
 <context>
     <name>AddNodeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="14"/>
         <source>Node properties</source>
         <translation>Propiedades del nodo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="29"/>
         <source>name: *</source>
         <translation>nombre: *</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="39"/>
         <source>Make it root element of a diagram</source>
         <translation>Hacerlo elemento raíz del diagrama</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="58"/>
         <source>* Need to be filled</source>
         <translation>* Debe rellenarse</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="80"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
@@ -32,17 +27,14 @@
 <context>
     <name>ChooseTypeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/chooseTypeDialog.ui" line="14"/>
         <source>Choose element type</source>
         <translation>Seleccione el tipo de elemento</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/chooseTypeDialog.ui" line="59"/>
         <source>Entity</source>
         <translation>Entidad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/chooseTypeDialog.ui" line="99"/>
         <source>Relationship</source>
         <translation>Relación</translation>
     </message>
@@ -50,37 +42,30 @@
 <context>
     <name>DynamicPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="35"/>
         <source>Dialog</source>
         <translation>Restaurar propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="44"/>
         <source>Subprogram name:</source>
         <translation>Nombre del subprograma:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="58"/>
         <source>Subprogram arguments:</source>
         <translation>Argumentos del subprograma:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="90"/>
         <source>Add Argument</source>
         <translation>Agregar argumento</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="97"/>
         <source>Subprogram picture:</source>
         <translation>Imagen:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="104"/>
         <source>Subprogram picture background:</source>
         <translation>Fondo:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="111"/>
         <source>Save All</source>
         <translation>Guardar todo</translation>
     </message>
@@ -88,118 +73,90 @@
 <context>
     <name>EdgePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="14"/>
         <source>Edge properties</source>
         <translation>Propiedades de la conexión</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="30"/>
         <source>name: *</source>
         <translation>nombre: *</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="40"/>
         <source>Text</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="52"/>
         <source>labelText:</source>
         <translation>Etiqueta de texto:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="68"/>
         <source>labelType:</source>
         <translation>Tipo de etiqueta:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="76"/>
         <source>Dynamic text</source>
         <translation>Etiqueta dinámica</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="81"/>
         <source>Static text</source>
         <translation>Etiqueta estática</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="97"/>
         <source>* Need to be filled</source>
         <translation>* Debe rellenarse</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="111"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="123"/>
         <source>lineType:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="131"/>
         <source>solidLine</source>
         <translation>Sólida</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="136"/>
         <source>dashLine</source>
         <translation>Discontinua</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="141"/>
         <source>dotLine</source>
         <translation>Punteada</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="155"/>
         <source>beginType:</source>
         <translation>Forma del inicio de la línea:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="172"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="252"/>
         <source>no_arrow</source>
         <translation>sin_flecha</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="181"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="261"/>
         <source>open_arrow</source>
         <translation>flecha_abierta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="190"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="270"/>
         <source>empty_arrow</source>
         <translation>flecha_vacía</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="199"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="279"/>
         <source>filled_arrow</source>
         <translation>flecha_llena</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="208"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="288"/>
         <source>empty_rhomb</source>
         <translation>rombo_vacío</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="217"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="297"/>
         <source>filled_rhomb</source>
         <translation>rombo_lleno</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="235"/>
         <source>endType:</source>
         <translation>Forma del extremo de la línea:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="327"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
@@ -207,32 +164,26 @@
 <context>
     <name>EditPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Restaurar propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="28"/>
         <source>name: *</source>
         <translation>nombre: *</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="44"/>
         <source>attributeType: *</source>
         <translation>Tipo: *</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="60"/>
         <source>defaultValue: </source>
         <translation>Valor:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="84"/>
         <source>* Need to be filled</source>
         <translation>* Debe rellenarse</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="91"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
@@ -240,67 +191,54 @@
 <context>
     <name>FindReplaceDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Restaurar propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="28"/>
         <source>Find what:</source>
         <translation>Buscar:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="35"/>
         <source>Replace with:</source>
         <translation>Reemplazar con:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="56"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="63"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="74"/>
         <source>by name</source>
         <translation>por nombre</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="81"/>
         <source>by type</source>
         <translation>por tipo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="88"/>
         <source>by property</source>
         <translation>por propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="95"/>
         <source>by property content</source>
         <translation>por contenido de propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="109"/>
         <source>by regular expression</source>
         <translation>usando expresiones regulares</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="116"/>
         <source>case sensitivity</source>
         <translation>sensible a mayúsculas y minúsculas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.cpp" line="43"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.cpp" line="118"/>
         <source> / </source>
         <translation> / </translation>
     </message>
@@ -308,27 +246,22 @@
 <context>
     <name>PropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Restaurar propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="23"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="30"/>
         <source>Add</source>
         <translation>Agregar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="37"/>
         <source>Change</source>
         <translation>Modificar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="44"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -336,9 +269,6 @@
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="123"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="47"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="47"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
@@ -346,22 +276,18 @@
 <context>
     <name>RestoreElementDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Restaurar propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="20"/>
         <source>In earlier language versions already used the elements with the same name:</source>
         <translation>En versiones anteriores del lenguaje ya se usaban elementos de este tipo con el mismo nombre:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="30"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="37"/>
         <source>Create New</source>
         <translation>Crear nuevo</translation>
     </message>
@@ -369,22 +295,18 @@
 <context>
     <name>RestorePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Restaurar propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="20"/>
         <source>In earlier language versions already used the properties with the same name:</source>
         <translation>En versiones anteriores del lenguaje ya se usaban propiedades con el mismo nombre:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="34"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="41"/>
         <source>Create New</source>
         <translation>Crear nuevo</translation>
     </message>
@@ -392,47 +314,38 @@
 <context>
     <name>qReal::EditPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="103"/>
         <source>Warning:</source>
         <translation>Advertencia:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="104"/>
         <source>You changed the type of property. In case of incorrect conversion it may result in resetting of the existing property value.</source>
         <translation>Ha cambiado el tipo de propiedad. En caso de una conversión incorrecta, podría provocar la pérdida del valor actual de la propiedad.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="107"/>
         <source>Proceed anyway</source>
         <translation>Continuar de todos modos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="108"/>
         <source>Cancel the type conversion</source>
         <translation>Cancelar la conversión del tipo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="122"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="122"/>
         <source>All required properties should be filled</source>
         <translation>Todas las propiedades obligatorias deben rellenarse</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="132"/>
         <source>Restore properties</source>
         <translation>Restaurar propiedades</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="158"/>
         <source>Add new property</source>
         <translation>Agregar nueva propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="161"/>
         <source>Properties editor: </source>
         <translation>Editor de propiedades: </translation>
     </message>
@@ -440,7 +353,6 @@
 <context>
     <name>qReal::ProgressDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/progressDialog/progressDialog.cpp" line="26"/>
         <source>Please wait...</source>
         <translation>Espere por favor...</translation>
     </message>
@@ -448,27 +360,22 @@
 <context>
     <name>qReal::RestoreElementDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="48"/>
         <source>Existed</source>
         <translation>Existente</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="50"/>
         <source>Deleted</source>
         <translation>Eliminado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="74"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="74"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="74"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
@@ -476,32 +383,26 @@
 <context>
     <name>qReal::RestorePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="29"/>
         <source>Property name</source>
         <translation>Nombre de la propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="31"/>
         <source>State</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="33"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="35"/>
         <source>Default value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="68"/>
         <source>Deleted</source>
         <translation>Eliminado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="71"/>
         <source>Existed</source>
         <translation>Existente</translation>
     </message>
@@ -509,7 +410,6 @@
 <context>
     <name>qReal::SuggestToCreateDiagramDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramDialog.cpp" line="32"/>
         <source>Create diagram</source>
         <translation>Crear diagrama</translation>
     </message>
@@ -517,12 +417,10 @@
 <context>
     <name>qReal::SuggestToCreateDiagramWidget</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramWidget.cpp" line="47"/>
         <source>editor: </source>
         <translation>editor: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramWidget.cpp" line="47"/>
         <source>, diagram: </source>
         <translation>, diagrama: </translation>
     </message>
@@ -530,7 +428,6 @@
 <context>
     <name>qReal::SuggestToCreateProjectDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateProjectDialog.cpp" line="33"/>
         <source>Create project</source>
         <translation>Crear proyecto</translation>
     </message>
@@ -538,12 +435,10 @@
 <context>
     <name>qReal::gui::AddNodeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="46"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="46"/>
         <source>All required properties should be filled</source>
         <translation>Todas las propiedades obligatorias deben rellenarse</translation>
     </message>
@@ -551,64 +446,50 @@
 <context>
     <name>qReal::gui::DynamicPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="49"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="51"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="51"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="51"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="118"/>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="395"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="155"/>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="170"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="170"/>
         <source>There is already a subprogram with that name</source>
         <translation>Ya existe un subprograma con ese nombre</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="357"/>
         <source>Name is not filled in row %1</source>
         <translation>El nombre del parámetro %1 no está rellenado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="361"/>
         <source>Name should start with a letter(row %1)</source>
         <translation>El nombre del argumento debe comenzar con una letra (fila %1)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="372"/>
         <source>Value in row %1 is not integer</source>
         <translation>El valor del parámetro %1 no es un número entero</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="377"/>
         <source>Value in row %1 is not float</source>
         <translation>El valor del parámetro %1 no es un número</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="387"/>
         <source>Duplicate names</source>
         <translation>Nombres duplicados</translation>
     </message>
@@ -616,12 +497,10 @@
 <context>
     <name>qReal::gui::EdgePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="46"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="46"/>
         <source>All required properties should be filled</source>
         <translation>Todas las propiedades obligatorias deben rellenarse</translation>
     </message>
@@ -629,7 +508,6 @@
 <context>
     <name>qReal::gui::PropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.cpp" line="41"/>
         <source>Properties: </source>
         <translation>Propiedades: </translation>
     </message>

--- a/qrtranslations/es/qrgui/editor_es.ts
+++ b/qrtranslations/es/qrgui/editor_es.ts
@@ -4,32 +4,26 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="23"/>
         <source>Add connection</source>
         <translation>Agregar conexión</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="24"/>
         <source>Connect to other</source>
         <translation>Conectar a otro</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="25"/>
         <source>Disconnect</source>
         <translation>Desconectar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="26"/>
         <source>Go to connected element</source>
         <translation>Ir al elemento conectado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="28"/>
         <source>Expand explosion</source>
         <translation>Expandir explosión</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="29"/>
         <source>Collapse explosion</source>
         <translation>Contraer explosión</translation>
     </message>
@@ -37,17 +31,14 @@
 <context>
     <name>qReal::gui::editor::BrokenLine</name>
     <message>
-        <location filename="../../../qrgui/editor/private/brokenLine.cpp" line="24"/>
         <source>Delete point</source>
         <translation>Eliminar punto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/brokenLine.cpp" line="25"/>
         <source>Delete segment</source>
         <translation>Eliminar segmento</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/brokenLine.cpp" line="26"/>
         <source>Remove all points</source>
         <translation>Eliminar todos los puntos</translation>
     </message>
@@ -55,12 +46,10 @@
 <context>
     <name>qReal::gui::editor::EdgeElement</name>
     <message>
-        <location filename="../../../qrgui/editor/edgeElement.cpp" line="62"/>
         <source>Reverse</source>
         <translation>Invertir</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/edgeElement.cpp" line="63"/>
         <source>Change shape type</source>
         <translation>Cambiar tipo de forma</translation>
     </message>
@@ -68,28 +57,22 @@
 <context>
     <name>qReal::gui::editor::EditorViewScene</name>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="294"/>
         <source>Create new element</source>
         <translation>Crear nuevo elemento</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="358"/>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="367"/>
         <source>Connect with the current item</source>
         <translation>Conectar con el elemento actual</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="695"/>
         <source>Replace by...</source>
         <translation>Reemplazar por...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="927"/>
         <source>Add child</source>
         <translation>Agregar elemento secundario</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="1419"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -97,17 +80,14 @@
 <context>
     <name>qReal::gui::editor::LineFactory</name>
     <message>
-        <location filename="../../../qrgui/editor/private/lineFactory.cpp" line="49"/>
         <source>Broken</source>
         <translation>Quebrada</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/lineFactory.cpp" line="52"/>
         <source>Square</source>
         <translation>Rectangular</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/lineFactory.cpp" line="55"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
@@ -115,7 +95,6 @@
 <context>
     <name>qReal::gui::editor::NodeElement</name>
     <message>
-        <location filename="../../../qrgui/editor/nodeElement.cpp" line="53"/>
         <source>Switch on grid</source>
         <translation>Activar cuadrícula</translation>
     </message>
@@ -123,12 +102,10 @@
 <context>
     <name>qReal::gui::editor::PropertyEditorView</name>
     <message>
-        <location filename="../../../qrgui/editor/propertyEditorView.cpp" line="305"/>
         <source>Specify directory:</source>
         <translation>Especifique el directorio:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/propertyEditorView.cpp" line="312"/>
         <source>Select file:</source>
         <translation>Seleccione el archivo:</translation>
     </message>
@@ -136,7 +113,6 @@
 <context>
     <name>qReal::gui::editor::PushButtonPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/editor/private/pushButtonProperty.cpp" line="38"/>
         <source>Click to choose</source>
         <translation>Haga clic para seleccionar</translation>
     </message>
@@ -144,7 +120,6 @@
 <context>
     <name>qReal::gui::editor::SquareLine</name>
     <message>
-        <location filename="../../../qrgui/editor/private/squareLine.cpp" line="27"/>
         <source>Lay out</source>
         <translation>Reorganizar</translation>
     </message>
@@ -152,24 +127,18 @@
 <context>
     <name>qReal::gui::editor::view::details::ExploserView</name>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="80"/>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="191"/>
         <source>New </source>
         <translation>Nuevo </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="130"/>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="144"/>
         <source>Change Properties</source>
         <translation>Cambiar propiedades</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="133"/>
         <source>Change Appearance</source>
         <translation>Cambiar apariencia</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="137"/>
         <source>Add element to palette</source>
         <translation>Agregar elemento a la paleta</translation>
     </message>

--- a/qrtranslations/es/qrgui/hotKeyManager_es.ts
+++ b/qrtranslations/es/qrgui/hotKeyManager_es.ts
@@ -4,12 +4,10 @@
 <context>
     <name>PreferencesHotKeyManagerPage</name>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.cpp" line="98"/>
         <source>Question</source>
         <translation>Pregunta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.cpp" line="98"/>
         <source>This will clear all current shortcuts. Are you sure?</source>
         <translation>Esto eliminará todos los atajos actuales. ¿Está seguro?</translation>
     </message>
@@ -17,67 +15,54 @@
 <context>
     <name>hotKeyManagerPage</name>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="14"/>
         <source>Form</source>
         <translation>Formulario</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="20"/>
         <source>Keyboard Shortcuts</source>
         <translation>Atajos de teclado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="39"/>
         <source>Import...</source>
         <translation>Importar...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="46"/>
         <source>Export...</source>
         <translation>Exportar...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="108"/>
         <source>Command</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="113"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="118"/>
         <source>Shortcut 1</source>
         <translation>Atajo 1</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="123"/>
         <source>Shortcut 2</source>
         <translation>Atajo 2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="128"/>
         <source>Shortcut 3</source>
         <translation>Atajo 3</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="136"/>
         <source>Reset All</source>
         <translation>Restablecer todo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="146"/>
         <source>Shortcut</source>
         <translation>Atajo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="152"/>
         <source>Reset</source>
         <translation>Restablecer</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="175"/>
         <source>Key sequence</source>
         <translation>Introduzca la combinación de teclas...</translation>
     </message>

--- a/qrtranslations/es/qrgui/mainWindow_es.ts
+++ b/qrtranslations/es/qrgui/mainWindow_es.ts
@@ -4,12 +4,10 @@
 <context>
     <name>ErrorListWidget</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorListWidget.cpp" line="60"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorListWidget.cpp" line="61"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
@@ -17,52 +15,34 @@
 <context>
     <name>FindManager</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="39"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="81"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="82"/>
         <source>by name</source>
         <translation>por nombre</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="41"/>
         <source>by type</source>
         <translation>por tipo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="43"/>
         <source>by property</source>
         <translation>por propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="45"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="90"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="91"/>
         <source>by property content</source>
         <translation>por contenido de propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="55"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="59"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="83"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="92"/>
         <source>case sensitivity</source>
         <translation>sensibilidad a mayúsculas y minúsculas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="56"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="59"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="84"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="93"/>
         <source>by regular expression</source>
         <translation>usando expresiones regulares</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="64"/>
         <source>, </source>
         <translation>, </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="67"/>
         <source>   :: </source>
         <translation>   ::    </translation>
     </message>
@@ -70,445 +50,354 @@
 <context>
     <name>MainWindowUi</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="14"/>
         <source>QReal</source>
         <translation>QReal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="49"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="66"/>
         <source>&amp;View</source>
         <translation>&amp;Ver</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="70"/>
         <source>Panels</source>
         <translation>Paneles</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="83"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="93"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuración</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="106"/>
         <source>&amp;Tools</source>
         <translation>&amp;Herramientas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="112"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="134"/>
         <source>File Toolbar</source>
         <translation>Barra de herramientas de Archivo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="164"/>
         <source>Mini Map</source>
         <translation>Mini mapa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="213"/>
         <source>Palette</source>
         <translation>Paleta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="250"/>
         <source>Edit Toolbar</source>
         <translation>Barra de herramientas de Edición</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="263"/>
         <source>View Toolbar</source>
         <translation>Barra de herramientas de Vista</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="281"/>
         <source>Logical Model Explorer</source>
         <translation>Explorador del modelo lógico</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="333"/>
         <source>Errors</source>
         <translation>Errores</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="355"/>
         <source>Graphical Model Explorer</source>
         <translation>Explorador del modelo gráfico</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="389"/>
         <source>Property Editor</source>
         <translation>Editor de propiedades</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="426"/>
         <source>Interpreter Toolbar</source>
         <translation>Barra de herramientas del intérprete</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="437"/>
         <source>Generators Toolbar</source>
         <translation>Barra de herramientas de generadores</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="451"/>
         <source>&amp;Quit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="460"/>
         <source>Zoom In</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="463"/>
         <source>Ctrl++</source>
         <translation>Ctrl++</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="472"/>
         <source>Zoom Out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="475"/>
         <source>Ctrl+-</source>
         <translation>Ctrl+-</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="486"/>
         <source>Antialiasing</source>
         <translation>Suavizado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="494"/>
         <source>OpenGL Renderer</source>
         <translation>Renderizador OpenGL</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="503"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="508"/>
         <source>Export to SVG</source>
         <translation>Exportar a SVG</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="513"/>
         <source>Open in new tab</source>
         <translation>Abrir en nueva pestaña</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="518"/>
         <source>Small Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="521"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="526"/>
         <source>Open Logs</source>
         <translation>Abrir archivos de registro</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="531"/>
         <source>About </source>
         <translation>Acerca de </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="536"/>
         <source>About Qt...</source>
         <translation>Acerca de Qt...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="545"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="548"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="553"/>
         <source>Save as...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="556"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="565"/>
         <source>Open...</source>
         <translation>Abrir...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="568"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="571"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="582"/>
         <source>Show grid</source>
         <translation>Mostrar cuadrícula</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="590"/>
         <source>Switch on grid</source>
         <translation>Activar cuadrícula</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="595"/>
         <source>Mouse gestures</source>
         <translation>Gestos del ratón</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="600"/>
         <source>Preferences...</source>
         <translation>Preferencias...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="611"/>
         <source>Switch on alignment</source>
         <translation>Activar alineación</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="622"/>
         <source>Show alignment</source>
         <translation>Mostrar alineación</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="627"/>
         <source>Debug</source>
         <translation>Depurar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="630"/>
         <source>F9</source>
         <translation>F9</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="639"/>
         <source>Generate and build</source>
         <translation>Generar y compilar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="642"/>
         <source>Ctrl+F9</source>
         <translation>Ctrl+F9</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="647"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="650"/>
         <source>Set breakpoints</source>
         <translation>Establecer puntos de interrupción</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="653"/>
         <source>Ctrl+F3</source>
         <translation>Ctrl+F3</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="658"/>
         <source>Cont</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="661"/>
         <source>Ctrl+F6</source>
         <translation>Ctrl+F6</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="666"/>
         <source>Configure</source>
         <translation>Configurar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="669"/>
         <source>Ctrl+F2</source>
         <translation>Ctrl+F2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="678"/>
         <source>New Diagram</source>
         <translation>Nuevo diagrama</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="681"/>
         <source>Create new diagram in a current model</source>
         <translation>Crear un nuevo diagrama en el modelo actual</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="690"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="693"/>
         <source>Fullscreen Mode</source>
         <translation>Modo pantalla completa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="696"/>
         <source>Ctrl+Shift+F</source>
         <translation>Ctrl+Shift+F</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="705"/>
         <source>New Project</source>
         <translation>Nuevo proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="708"/>
         <source>Ctrl+Shift+N</source>
         <translation>Ctrl+Shift+N</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="713"/>
         <source>Import...</source>
         <translation>Importar...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="716"/>
         <source>Import QReal project into current.</source>
         <translation>Importar proyecto QReal al actual</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="721"/>
         <source>Save diagram as a picture...</source>
         <translation>Guardar diagrama como imagen...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="726"/>
         <source>Close project</source>
         <translation>Cerrar proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="731"/>
         <source>Find...</source>
         <translation>Buscar...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="736"/>
         <source>Find and replace</source>
         <translation>Buscar y reemplazar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="741"/>
         <source>Replace by...</source>
         <translation>Reemplazar por...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="750"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="753"/>
         <source>Ctrl+Z</source>
         <translation>Ctrl+Z</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="762"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="765"/>
         <source>Ctrl+Shift+Z</source>
         <translation>Ctrl+Shift+Z</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="770"/>
         <source>Export to XML</source>
         <translation>Exportar a XML</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="778"/>
         <source>Show all text</source>
         <translation>Mostrar todo el texto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="781"/>
         <source>Ctrl+Shift+T</source>
         <translation>Ctrl+Shift+T</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="786"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="789"/>
         <source>Hide bottom docks</source>
         <translation>Ocultar paneles inferiores</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="792"/>
         <source>Esc</source>
         <translation>Esc</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="801"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="804"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="813"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="816"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="825"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="828"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="833"/>
         <source>Restore default settings and Quit</source>
         <translation>Restaurar configuración predeterminada y salir</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="842"/>
         <source>Open Examples...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="845"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
@@ -516,7 +405,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="160"/>
         <source>Can`t open project file</source>
         <translation>No se puede abrir el archivo del proyecto</translation>
     </message>
@@ -524,7 +412,6 @@
 <context>
     <name>ReferenceList</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/referenceList.ui" line="14"/>
         <source>Choose a reference value</source>
         <translation>Elija un valor de referencia</translation>
     </message>
@@ -532,165 +419,130 @@
 <context>
     <name>ShapeEdit</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="14"/>
         <source>Form</source>
         <translation>Editor de forma de figuras</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="23"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="30"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="43"/>
         <source>Draw ellipse</source>
         <translation>Dibujar elipse</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="84"/>
         <source>Add static text</source>
         <translation>Añadir texto estático</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="125"/>
         <source>Add dynamic text</source>
         <translation>Añadir texto dinámico</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="160"/>
         <source>Save as picture</source>
         <translation>Guardar como imagen</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="176"/>
         <source>Draw curve</source>
         <translation>Dibujar curva</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="211"/>
         <source>Save to Xml</source>
         <translation>Guardar en XML</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="245"/>
         <source>Font</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="272"/>
         <source>Family</source>
         <translation>Familia</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="321"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="363"/>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="796"/>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="935"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="384"/>
         <source>Text format</source>
         <translation>Formato de texto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="396"/>
         <source>Italic</source>
         <translation>Cursiva</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="409"/>
         <source> Bold</source>
         <translation> Negrita</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="422"/>
         <source>Underline</source>
         <translation>Subrayado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="444"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="470"/>
         <source>Stylus</source>
         <translation>Estilo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="511"/>
         <source>Add line port</source>
         <translation>Añadir puerto lineal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="558"/>
         <source>Add point port</source>
         <translation>Añadir puerto puntual</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="599"/>
         <source>Add picture text</source>
         <translation>Añadir texto-imagen</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="637"/>
         <source>Draw rectangle</source>
         <translation>Dibujar rectángulo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="708"/>
         <source>Pen</source>
         <translation>Pluma</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="748"/>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="893"/>
         <source>Style</source>
         <translation>Estilo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="838"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="856"/>
         <source>Brush</source>
         <translation>Pincel</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="957"/>
         <source>Image</source>
         <translation>Imagen</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="976"/>
         <source>Draw line</source>
         <translation>Dibujar línea</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="1011"/>
         <source>VisibilityConditions</source>
         <translation>Condiciones de visibilidad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="1024"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="1053"/>
         <source>Delete Item</source>
         <translation>Eliminar elemento</translation>
     </message>
@@ -698,7 +550,6 @@
 <context>
     <name>VisibilityConditionsDialog</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/visibilityConditionsDialog.ui" line="14"/>
         <source>Specify conditions in which choosen element must be shown</source>
         <translation>Especifique las condiciones bajo las cuales debe mostrarse el elemento seleccionado</translation>
     </message>
@@ -706,12 +557,10 @@
 <context>
     <name>qReal::MainWindow</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="198"/>
         <source>Restore default settings</source>
         <translation>Restaurar configuración predeterminada</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="199"/>
         <source>Do you realy want to restore default settings?
 WARNING: Settings restoring cannot be undone
 WARNING: The settings will be restored after application restart</source>
@@ -720,165 +569,130 @@ ADVERTENCIA: La restauración de la configuración no se puede deshacer
 ADVERTENCIA: La configuración se restablecerá tras reiniciar la aplicación</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="676"/>
         <source>Could not save file, try to save it to another place</source>
         <translation>No se pudo guardar el archivo, intente guardarlo en otra ubicación</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="974"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="985"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="974"/>
         <source>Plugin unloading failed: </source>
         <translation>Error al descargar el complemento: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="985"/>
         <source>Plugin loading failed: </source>
         <translation>Error al cargar el complemento: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1095"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1111"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1134"/>
         <source>Shape Editor</source>
         <translation>Editor de forma de figuras</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1127"/>
         <source>Text Editor</source>
         <translation>Editor de texto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1347"/>
         <source>New diagram</source>
         <translation>Crear diagrama</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1351"/>
         <source>Open project</source>
         <translation>Abrir proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1352"/>
         <source>Open examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1353"/>
         <source>Save project</source>
         <translation>Guardar proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1354"/>
         <source>Save project as</source>
         <translation>Guardar proyecto como</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1355"/>
         <source>New project</source>
         <translation>Crear proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1356"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1357"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1358"/>
         <source>Zoom In</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1359"/>
         <source>Zoom Out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1360"/>
         <source>Close current tab</source>
         <translation>Cerrar pestaña actual</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1361"/>
         <source>Close all tabs</source>
         <translation>Cerrar todas las pestañas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1362"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1363"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1364"/>
         <source>Find and replace</source>
         <translation>Buscar y reemplazar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1365"/>
         <source>Show all text</source>
         <translation>Mostrar todo el texto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1366"/>
         <source>Toggle errors panel</source>
         <translation>Alternar panel de errores</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1568"/>
         <source>Gestures Show</source>
         <translation>Gestos del ratón</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1908"/>
         <source>Shortcuts</source>
         <translation>Atajos de teclado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1978"/>
         <source>External tools</source>
         <translation>Herramientas externas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2028"/>
         <source>Failed to open %1</source>
         <translation>No se pudo abrir %1</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2223"/>
         <source>Recent projects</source>
         <translation>Proyectos recientes</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2227"/>
         <source>Recent files</source>
         <translation>Archivos recientes</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2258"/>
         <source>Save File</source>
         <translation>Guardar archivo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2258"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Imágenes (*.png *.jpg)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2419"/>
         <source>Getting Started</source>
         <translation>Bienvenido!</translation>
     </message>
@@ -886,57 +700,46 @@ ADVERTENCIA: La configuración se restablecerá tras reiniciar la aplicación</t
 <context>
     <name>qReal::ProjectManagerWrapper</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="71"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="72"/>
         <source>&amp;Save</source>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="73"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="74"/>
         <source>&amp;Discard</source>
         <translation>&amp;Descartar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="75"/>
         <source>Do you want to save current project?</source>
         <translation>¿Desea guardar el proyecto actual?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="205"/>
         <source>Unsaved project</source>
         <translation>Proyecto sin guardar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="214"/>
         <source> [modified]</source>
         <translation> [modificado]</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="304"/>
         <source>Select file to save current metamodel to</source>
         <translation>Seleccione el archivo para guardar el metamodelo actual</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="321"/>
         <source>QReal Save File (*.qrs)</source>
         <translation>Archivo de guardado QReal (*.qrs)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="324"/>
         <source>All files (*.*)</source>
         <translation>Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="360"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Archivo de guardado QReal (*.qrs)</translation>
     </message>
@@ -944,7 +747,6 @@ ADVERTENCIA: La configuración se restablecerá tras reiniciar la aplicación</t
 <context>
     <name>qReal::ShapeEdit</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.cpp" line="352"/>
         <source>Saving</source>
         <translation>Guardando</translation>
     </message>
@@ -952,47 +754,38 @@ ADVERTENCIA: La configuración se restablecerá tras reiniciar la aplicación</t
 <context>
     <name>qReal::StartWidget</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="124"/>
         <source>Open project</source>
         <translation>Abrir proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="135"/>
         <source>New project</source>
         <translation>Crear proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="182"/>
         <source>Recent projects</source>
         <translation>Proyectos recientes</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="271"/>
         <source>Create </source>
         <translation>Crear </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="275"/>
         <source>Editor: </source>
         <translation>Editor: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="275"/>
         <source>; Diagram: </source>
         <translation>; Diagrama: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="287"/>
         <source>Select file with metamodel to open</source>
         <translation>Seleccione el archivo de metamodelo para abrir</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="336"/>
         <source>Enter the diagram name:</source>
         <translation>Introduzca el nombre del diagrama:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="336"/>
         <source>diagram name:</source>
         <translation>nombre del diagrama:</translation>
     </message>
@@ -1000,79 +793,58 @@ ADVERTENCIA: La configuración se restablecerá tras reiniciar la aplicación</t
 <context>
     <name>qReal::gui::DraggableElement</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="89"/>
         <source>Mouse gesture</source>
         <translation>Gesto del ratón</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="182"/>
         <source>Deleting an element: </source>
         <translation>Eliminando un elemento: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="183"/>
         <source>Do you really want to delete this item and all its graphicalrepresentation from the scene and from the palette?</source>
         <translation>¿Realmente desea eliminar este elemento y todas sus representaciones gráficas de la escena y de la paleta?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="191"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="231"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="269"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="192"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="232"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="270"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="222"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="255"/>
         <source>Warning</source>
         <translation>Advertencia</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="223"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="256"/>
         <source>The deleted element </source>
         <translation>El elemento eliminado </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="224"/>
         <source> is the element of root digram. Continue to delete?</source>
         <translation> es un elemento del diagrama raíz. ¿Continuar con la eliminación?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="258"/>
         <source> has inheritors:</source>
         <translation> tiene herederos:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="261"/>
         <source>If you delete it, its properties will be removed fromthe elements-inheritors. Continue to delete?</source>
         <translation>Si lo elimina, sus propiedades serán eliminadas de los elementos herederos. ¿Continuar con la eliminación?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="336"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="365"/>
         <source>Change Properties</source>
         <translation>Cambiar propiedades</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="341"/>
         <source>Change Appearance</source>
         <translation>Cambiar apariencia</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="346"/>
         <source>Delete Element</source>
         <translation>Eliminar elemento</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="370"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -1080,22 +852,18 @@ ADVERTENCIA: La configuración se restablecerá tras reiniciar la aplicación</t
 <context>
     <name>qReal::gui::ErrorReporter</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="215"/>
         <source>INFORMATION:</source>
         <translation>INFORMACIÓN:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="217"/>
         <source>WARNING:</source>
         <translation>ADVERTENCIA:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="219"/>
         <source>ERROR:</source>
         <translation>ERROR:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="221"/>
         <source>CRITICAL:</source>
         <translation>CRÍTICO:</translation>
     </message>
@@ -1103,7 +871,6 @@ ADVERTENCIA: La configuración se restablecerá tras reiniciar la aplicación</t
 <context>
     <name>qReal::gui::ModelExplorer</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/modelExplorer.cpp" line="35"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -1111,12 +878,10 @@ ADVERTENCIA: La configuración se restablecerá tras reiniciar la aplicación</t
 <context>
     <name>qReal::gui::PaletteTreeWidget</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="157"/>
         <source>Add Entity</source>
         <translation>Añadir entidad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="158"/>
         <source>Add Relastionship</source>
         <translation>Añadir relación</translation>
     </message>

--- a/qrtranslations/es/qrgui/models_es.ts
+++ b/qrtranslations/es/qrgui/models_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>qReal::gui::RenameDialog</name>
     <message>
-        <location filename="../../../qrgui/models/details/renameDialog.cpp" line="26"/>
         <source>Enter new name</source>
         <translation>Ingrese un nuevo nombre</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>qReal::models::details::modelsImplementation::AbstractModel</name>
     <message>
-        <location filename="../../../qrgui/models/details/modelsImplementation/abstractModel.cpp" line="45"/>
         <source>name</source>
         <translation>nombre</translation>
     </message>

--- a/qrtranslations/es/qrgui/mouseGestures_es.ts
+++ b/qrtranslations/es/qrgui/mouseGestures_es.ts
@@ -4,17 +4,14 @@
 <context>
     <name>GesturesWidget</name>
     <message>
-        <location filename="../../../qrgui/mouseGestures/gesturesWidget.ui" line="20"/>
         <source>Form</source>
         <translation>Gestos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mouseGestures/gesturesWidget.ui" line="36"/>
         <source>List of mouse gestures</source>
         <translation>Lista de gestos del ratón</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mouseGestures/gesturesWidget.ui" line="49"/>
         <source>Click to see how to draw it:</source>
         <translation>Haga clic para ver cómo dibujarlo:</translation>
     </message>

--- a/qrtranslations/es/qrgui/plugins/metaMetaModel_es.ts
+++ b/qrtranslations/es/qrgui/plugins/metaMetaModel_es.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/metaMetaModel/src/metamodel.cpp" line="74"/>
         <source>Unknown element %1</source>
         <translation>Elemento desconocido %1</translation>
     </message>

--- a/qrtranslations/es/qrgui/plugins/pluginManager_es.ts
+++ b/qrtranslations/es/qrgui/plugins/pluginManager_es.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="598"/>
         <source>Root node for diagram %1 (which is %2) does not exist!</source>
         <translation>¡El nodo raíz para el diagrama %1 (que es %2) no existe!</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="612"/>
         <source>Name should contain only latin letters, digits, spaces and underscores and should start with latin letter or underscore</source>
         <translation>El nombre debe contener solo letras latinas, dígitos, espacios y guiones bajos, y debe comenzar con una letra latina o guion bajo</translation>
     </message>
@@ -17,32 +15,26 @@
 <context>
     <name>qReal::QrsMetamodelLoader</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="174"/>
         <source>Incorrect label type</source>
         <translation>Tipo de etiqueta incorrecto</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="607"/>
         <source>Name should not be empty</source>
         <translation>El nombre no debe estar vacío</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="631"/>
         <source>Port type %1 not declared in metamodel</source>
         <translation>El tipo de puerto %1 no está declarado en el metamodelo</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="665"/>
         <source>Unknown link style type %1</source>
         <translation>Tipo de estilo de enlace desconocido %1</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="679"/>
         <source>Unknown link shape type %1</source>
         <translation>Tipo de forma de enlace desconocido %1</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="688"/>
         <source>%1 is not a valid integer number</source>
         <translation>%1 no es un número entero válido</translation>
     </message>
@@ -50,12 +42,10 @@
 <context>
     <name>qReal::QrsMetamodelSaver</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelSaver.cpp" line="389"/>
         <source>Unknown link style type %1</source>
         <translation>Tipo de estilo de enlace desconocido %1</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelSaver.cpp" line="405"/>
         <source>Unknown link shape type %1</source>
         <translation>Tipo de forma de enlace desconocido %1</translation>
     </message>

--- a/qrtranslations/es/qrgui/plugins/toolPluginInterface_es.ts
+++ b/qrtranslations/es/qrgui/plugins/toolPluginInterface_es.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/toolPluginInterface/customizer.h" line="113"/>
         <source>Existing connections</source>
         <translation>Conexiones existentes</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/toolPluginInterface/customizer.h" line="118"/>
         <source>Elements from this group exist for reusing all created connections</source>
         <translation>Los elementos de este grupo existen para reutilizar todas las conexiones creadas</translation>
     </message>

--- a/qrtranslations/es/qrgui/preferencesDialog_es.ts
+++ b/qrtranslations/es/qrgui/preferencesDialog_es.ts
@@ -4,72 +4,58 @@
 <context>
     <name>PreferencesBehaviourPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="23"/>
         <source>User Interface</source>
         <translation>Interfaz de usuario</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="39"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="52"/>
         <source>Automatics</source>
         <translation>Automatización</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="84"/>
         <source>Palette tab switching</source>
         <translation>Cambio de pestañas en la paleta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="91"/>
         <source>msec</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="98"/>
         <source>Autosave</source>
         <translation>Guardado automático</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="108"/>
         <source>sec</source>
         <translation>seg</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="131"/>
         <source>Delay after gesture</source>
         <translation>Retraso después del gesto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="138"/>
         <source>Gestures</source>
         <translation>Gestos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="148"/>
         <source>Touch</source>
         <translation>Pantalla táctil</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="164"/>
         <source>Touch Mode</source>
         <translation>Modo de trabajo en pantalla táctil</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="174"/>
         <source>Widgets</source>
         <translation>Elementos de interfaz</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="190"/>
         <source>Dockable mode</source>
         <translation>Modo de ventanas flotantes</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.cpp" line="117"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Idioma del sistema&gt;</translation>
     </message>
@@ -77,17 +63,14 @@
 <context>
     <name>PreferencesDebuggerPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/debuggerPage.ui" line="9"/>
         <source>Presentation</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/debuggerPage.ui" line="25"/>
         <source>Debug timeout (ms):</source>
         <translation>Tiempo de espera en depuración (ms):</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/debuggerPage.ui" line="35"/>
         <source>Color of highlighting:</source>
         <translation>Color del resaltado:</translation>
     </message>
@@ -95,32 +78,26 @@
 <context>
     <name>PreferencesDialog</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="32"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="42"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="49"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="56"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="143"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="150"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
@@ -128,132 +105,106 @@
 <context>
     <name>PreferencesEditorPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="24"/>
         <source>Font</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="61"/>
         <source>Use some of system fonts</source>
         <translation>Usar una de las fuentes del sistema</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="74"/>
         <source>Choose Font</source>
         <translation>Elegir fuente</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="84"/>
         <source>Grid</source>
         <translation>Cuadrícula</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="106"/>
         <source>Show grid</source>
         <translation>Mostrar cuadrícula</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="122"/>
         <source>Activate grid</source>
         <translation>Ajuste a la cuadrícula</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="138"/>
         <source>Show alignment</source>
         <translation>Mostrar guías</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="167"/>
         <source>Activate alignment</source>
         <translation>Ajuste a las guías</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="190"/>
         <source>Width</source>
         <translation>Grosor de la cuadrícula</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="222"/>
         <source>Cell size</source>
         <translation>Tamaño de la celda</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="260"/>
         <source>Node Elements</source>
         <translation>Elementos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="292"/>
         <source>Drag area</source>
         <translation>Tamaño del área de escalado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="302"/>
         <source>Edge</source>
         <translation>Conexiones</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="344"/>
         <source>broken</source>
         <translation>Líneas quebradas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="349"/>
         <source>square</source>
         <translation>Líneas rectangulares</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="354"/>
         <source>curve</source>
         <translation>Curvas de Bézier</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="362"/>
         <source>Line mode</source>
         <translation>Tipo de conexiones</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="375"/>
         <source>Loop edges indent</source>
         <translation>Sangría de conexiones en bucle</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="413"/>
         <source>Embedded Linkers</source>
         <translation>Enlazadores integrados</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="455"/>
         <source>Size</source>
         <translation>Tamaño de la barra de herramientas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="462"/>
         <source>Indent</source>
         <translation>Sangría</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="472"/>
         <source>Palette</source>
         <translation>Paleta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="488"/>
         <source>   Representation   </source>
         <translation>Representación</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="495"/>
         <source>   Count of items in a row </source>
         <translation>Cantidad de iconos por fila</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="515"/>
         <source>Icons  and names</source>
         <translation>Iconos y nombres</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="520"/>
         <source>Icons</source>
         <translation>Iconos</translation>
     </message>
@@ -261,33 +212,26 @@
 <context>
     <name>PreferencesFeaturesPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="23"/>
         <source>Element controls</source>
         <translation>Control de elementos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="39"/>
         <source>Gestures</source>
         <translation>Gestos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="46"/>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="53"/>
         <source>fast linking with mouse</source>
         <translation>Vinculación rápida con el ratón</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="60"/>
         <source>Embedded Linkers</source>
         <translation>Enlazadores integrados</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="67"/>
         <source>fast property editing</source>
         <translation>Edición rápida de propiedades</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="74"/>
         <source>Embedded Controls</source>
         <translation>Controles integrados</translation>
     </message>
@@ -295,52 +239,42 @@
 <context>
     <name>PreferencesMiscellaneousPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="24"/>
         <source>Antialiasing</source>
         <translation>Suavizado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="43"/>
         <source>Show splashscreen</source>
         <translation>Mostrar pantalla de inicio</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="64"/>
         <source>Limit recent projects list</source>
         <translation>Longitud de la lista de proyectos recientes</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="95"/>
         <source>Toolbars</source>
         <translation>Barras de herramientas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="102"/>
         <source>Images</source>
         <translation>Imágenes</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="109"/>
         <source>Graphics</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="125"/>
         <source>Browse</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="151"/>
         <source>Other</source>
         <translation>Otros</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="167"/>
         <source>Size</source>
         <translation>Tamaño de la barra de herramientas</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.cpp" line="57"/>
         <source>Open Directory</source>
         <translation>Seleccione el directorio</translation>
     </message>
@@ -348,43 +282,34 @@
 <context>
     <name>qReal::gui::PreferencesDialog</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="58"/>
         <source>Behaviour</source>
         <translation>Comportamiento</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="59"/>
         <source>Miscellaneous</source>
         <translation>Varios</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="60"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="80"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="80"/>
         <source>You should restart the program to apply changes</source>
         <translation>Reinicie el programa para aplicar los cambios</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="157"/>
         <source>Save File</source>
         <translation>Guardar archivo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="157"/>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="168"/>
         <source>*.ini</source>
         <translation>*.ini</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="168"/>
         <source>Open File</source>
         <translation>Abrir archivo</translation>
     </message>

--- a/qrtranslations/es/qrgui/systemFacade_es.ts
+++ b/qrtranslations/es/qrgui/systemFacade_es.ts
@@ -4,62 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="26"/>
         <source>Information:</source>
         <translation>Información:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="33"/>
         <source>Warning:</source>
         <translation>Advertencia:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="40"/>
         <source>Error:</source>
         <translation>Error:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="48"/>
         <source>Critical:</source>
         <translation>Crítico:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="62"/>
         <source>Bubble:</source>
         <translation>Burbuja:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="256"/>
         <source>Can`t open project file</source>
         <translation>No se puede abrir el archivo del proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="114"/>
         <source>Project was automaticly converted from version %1 to version %2. Please check its contents.</source>
         <translation>El proyecto fue convertido automáticamente de la versión %1 a la versión %2. Por favor, verifique su contenido.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="125"/>
         <source>The attempt to automaticly convert this project to the current enviroment version failed and thus save file can`t be opened. </source>
         <translation>El intento de convertir automáticamente este proyecto a la versión actual del entorno ha fallado, por lo que el archivo de guardado no se puede abrir. </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="135"/>
         <source>This project was created by version %1 of the editor.</source>
         <translation>Este proyecto fue creado con la versión %1 del editor.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="136"/>
         <source>This project was created by too old version of the editor.</source>
         <translation>Este proyecto fue creado con una versión demasiado antigua del editor.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="138"/>
         <source> It is now considered outdated and cannot be opened.</source>
         <translation> Ahora se considera obsoleto y no puede abrirse.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="145"/>
         <source>The save you are trying to open is made by version %1 of editor, whitch is newer than currently installed enviroment. Update your version before opening this save.</source>
         <translation>El archivo que intenta abrir fue creado con la versión %1 del editor, que es más reciente que la versión del entorno actualmente instalada. Actualice su versión antes de abrir este archivo.</translation>
     </message>
@@ -67,18 +55,14 @@
 <context>
     <name>qReal::Autosaver</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="145"/>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="159"/>
         <source>Question</source>
         <translation>Pregunta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="169"/>
         <source>More recent autosaved version of this file was found. Do you wish to open it instead?</source>
         <translation>Se encontró una versión más reciente autoguardada de este archivo. ¿Desea abrirla en su lugar?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="175"/>
         <source>It seems like the last application session was terminated in an unusual way. Do you wish to recover unsaved project?</source>
         <translation>Parece que la última sesión de la aplicación terminó de forma inesperada. ¿Desea recuperar el proyecto no guardado?</translation>
     </message>
@@ -86,61 +70,48 @@
 <context>
     <name>qReal::ProjectManager</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="76"/>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="90"/>
         <source>Open project</source>
         <translation>Abrir proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="150"/>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="157"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="150"/>
         <source>Cannot open file, please try with another one.</source>
         <translation>No se puede abrir el archivo, por favor intente con otro.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="185"/>
         <source>Select file with a save to import</source>
         <translation>Seleccione un archivo para importar</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="219"/>
         <source>There are missing plugins</source>
         <translation>Faltan complementos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="220"/>
         <source>These plugins are not present, but needed to load the save:
 </source>
         <translation>Estos complementos no están presentes, pero son necesarios para cargar el archivo:
 </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="271"/>
         <source>This project contains unknown element %1 and thus can`t be opened. Probably it was created by old or incorrectly working version of QReal.</source>
         <translation>Este proyecto contiene un elemento desconocido %1 y, por lo tanto, no se puede abrir. Probablemente fue creado por una versión antigua o defectuosa de QReal.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="273"/>
         <source>Can`t open project file</source>
         <translation>No se puede abrir el archivo del proyecto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="352"/>
         <source>Select file to save current model to</source>
         <translation>Seleccione el archivo donde guardar el modelo actual</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="403"/>
         <source>File not found</source>
         <translation>Archivo no encontrado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="403"/>
         <source>File %1 not found. Try again</source>
         <translation>Archivo %1 no encontrado. Inténtelo de nuevo</translation>
     </message>

--- a/qrtranslations/es/qrgui/textEditor_es.ts
+++ b/qrtranslations/es/qrgui/textEditor_es.ts
@@ -4,47 +4,38 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="91"/>
         <source>Text File</source>
         <translation>Archivo de texto</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="108"/>
         <source>C Language Source File</source>
         <translation>Archivo fuente en lenguaje C</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="125"/>
         <source>Russian Algorithmic Language Source File</source>
         <translation>Archivo fuente en lenguaje algorítmico ruso</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="143"/>
         <source>Python Source File</source>
         <translation>Archivo fuente en Python</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="160"/>
         <source>Java Script Language Source File</source>
         <translation>Archivo fuente en lenguaje JavaScript</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="177"/>
         <source>QtScript Language Source File</source>
         <translation>Archivo fuente en lenguaje QtScript</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="194"/>
         <source>F# Language Source File</source>
         <translation>Archivo fuente en lenguaje F#</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="212"/>
         <source>PascalABC Language Source File</source>
         <translation>Archivo fuente en lenguaje PascalABC</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="229"/>
         <source>Lua Language Source File</source>
         <translation>Archivo fuente en lenguaje Lua</translation>
     </message>
@@ -52,22 +43,18 @@
 <context>
     <name>qReal::text::TextManager</name>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="86"/>
         <source>Confirmation</source>
         <translation>Confirmación</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="87"/>
         <source>Save before closing?</source>
         <translation>¿Guardar antes de cerrar?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="280"/>
         <source>All files (*)</source>
         <translation>Todos los archivos (*)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="284"/>
         <source>Save generated code</source>
         <translation>Guardar código generado</translation>
     </message>

--- a/qrtranslations/es/qrgui/thirdparty_es.ts
+++ b/qrtranslations/es/qrgui/thirdparty_es.ts
@@ -4,15 +4,10 @@
 <context>
     <name>QtBoolEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="233"/>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="243"/>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="268"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="243"/>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="268"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
@@ -20,12 +15,10 @@
 <context>
     <name>QtBoolPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="1696"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="1697"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
@@ -33,7 +26,6 @@
 <context>
     <name>QtCharEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="1700"/>
         <source>Clear Char</source>
         <translation>Borrar carácter</translation>
     </message>
@@ -41,7 +33,6 @@
 <context>
     <name>QtColorEditWidget</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="2368"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -49,22 +40,18 @@
 <context>
     <name>QtColorPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6496"/>
         <source>Red</source>
         <translation>Rojo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6504"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6512"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6520"/>
         <source>Alpha</source>
         <translation>Alfa (transparencia)</translation>
     </message>
@@ -72,97 +59,78 @@
 <context>
     <name>QtCursorDatabase</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="58"/>
         <source>Arrow</source>
         <translation>Flecha</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="60"/>
         <source>Up Arrow</source>
         <translation>Flecha arriba</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="62"/>
         <source>Cross</source>
         <translation>Cruz</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="64"/>
         <source>Wait</source>
         <translation>Espera</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="66"/>
         <source>IBeam</source>
         <translation>Cursor en forma de I</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="68"/>
         <source>Size Vertical</source>
         <translation>Tamaño vertical</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="70"/>
         <source>Size Horizontal</source>
         <translation>Tamaño horizontal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="72"/>
         <source>Size Backslash</source>
         <translation>Tamaño diagonal invertida</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="74"/>
         <source>Size Slash</source>
         <translation>Tamaño diagonal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="76"/>
         <source>Size All</source>
         <translation>Tamaño en todas direcciones</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="78"/>
         <source>Blank</source>
         <translation>Vacío</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="80"/>
         <source>Split Vertical</source>
         <translation>División vertical</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="82"/>
         <source>Split Horizontal</source>
         <translation>División horizontal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="84"/>
         <source>Pointing Hand</source>
         <translation>Mano apuntando</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="86"/>
         <source>Forbidden</source>
         <translation>Prohibido</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="88"/>
         <source>Open Hand</source>
         <translation>Mano abierta</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="90"/>
         <source>Closed Hand</source>
         <translation>Mano cerrada</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="92"/>
         <source>What&apos;s This</source>
         <translation>¿Qué es esto?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="94"/>
         <source>Busy</source>
         <translation>Ocupado</translation>
     </message>
@@ -170,12 +138,10 @@
 <context>
     <name>QtFontEditWidget</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="2577"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="2597"/>
         <source>Select Font</source>
         <translation>Seleccionar fuente</translation>
     </message>
@@ -183,37 +149,30 @@
 <context>
     <name>QtFontPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6170"/>
         <source>Family</source>
         <translation>Familia</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6183"/>
         <source>Point Size</source>
         <translation>Tamaño en puntos</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6191"/>
         <source>Bold</source>
         <translation>Negrita</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6198"/>
         <source>Italic</source>
         <translation>Cursiva</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6205"/>
         <source>Underline</source>
         <translation>Subrayado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6212"/>
         <source>Strikeout</source>
         <translation>Tachado</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6219"/>
         <source>Kerning</source>
         <translation>Interletrado</translation>
     </message>
@@ -221,7 +180,6 @@
 <context>
     <name>QtKeySequenceEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="328"/>
         <source>Clear Shortcut</source>
         <translation>Borrar acceso directo</translation>
     </message>
@@ -229,17 +187,14 @@
 <context>
     <name>QtLocalePropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2611"/>
         <source>%1, %2</source>
         <translation>%1, %2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2664"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2672"/>
         <source>Country</source>
         <translation>País</translation>
     </message>
@@ -247,17 +202,14 @@
 <context>
     <name>QtPointFPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3081"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3152"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3160"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -265,17 +217,14 @@
 <context>
     <name>QtPointPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2841"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2878"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2885"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -283,12 +232,10 @@
 <context>
     <name>QtPropertyBrowserUtils</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="187"/>
         <source>[%1, %2, %3] (%4)</source>
         <translation>[%1, %2, %3] (%4)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="214"/>
         <source>[%1, %2]</source>
         <translation>[%1, %2]</translation>
     </message>
@@ -296,27 +243,22 @@
 <context>
     <name>QtRectFPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4586"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4742"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4750"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4758"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4767"/>
         <source>Height</source>
         <translation>Alto</translation>
     </message>
@@ -324,27 +266,22 @@
 <context>
     <name>QtRectPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4156"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4276"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4283"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4290"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4298"/>
         <source>Height</source>
         <translation>Alto</translation>
     </message>
@@ -352,17 +289,14 @@
 <context>
     <name>QtSizeFPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3764"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3894"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3903"/>
         <source>Height</source>
         <translation>Alto</translation>
     </message>
@@ -370,33 +304,26 @@
 <context>
     <name>QtSizePolicyPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5682"/>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5683"/>
         <source>&lt;Invalid&gt;</source>
         <translation>&lt;No válido&gt;</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5684"/>
         <source>[%1, %2, %3, %4]</source>
         <translation>[%1, %2, %3, %4]</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5729"/>
         <source>Horizontal Policy</source>
         <translation>Política horizontal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5738"/>
         <source>Vertical Policy</source>
         <translation>Política vertical</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5747"/>
         <source>Horizontal Stretch</source>
         <translation>Extensión horizontal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5755"/>
         <source>Vertical Stretch</source>
         <translation>Extensión vertical</translation>
     </message>
@@ -404,17 +331,14 @@
 <context>
     <name>QtSizePropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3400"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3496"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3504"/>
         <source>Height</source>
         <translation>Alto</translation>
     </message>
@@ -422,12 +346,10 @@
 <context>
     <name>QtTreePropertyBrowser</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="478"/>
         <source>Property</source>
         <translation>Propiedad</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="479"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>

--- a/qrtranslations/es/qrmc_es.ts
+++ b/qrtranslations/es/qrmc_es.ts
@@ -4,19 +4,16 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrmc/main.cpp" line="26"/>
         <source>QReal Metamodel Compiler. It takes .qrs file with QReal metamodel created by metaeditor and generates Qt project with editor plugin for that metamodel. Project is ready to be built with qmake, but it actively uses QReal sources and build system, so it can not be built alone. Example of command line:
 </source>
         <translation>Compilador de metamodelos QReal. Toma un archivo .qrs con el metamodelo QReal creado mediante metaeditor y genera un proyecto Qt con un complemento de editor para ese metamodelo. El proyecto está listo para ser compilado con qmake, pero utiliza activamente las fuentes y el sistema de compilación de QReal, por lo que no puede compilarse de forma independiente. Ejemplo de línea de comandos:
 </translation>
     </message>
     <message>
-        <location filename="../../qrmc/main.cpp" line="75"/>
         <source>Metamodel file to be processed.</source>
         <translation>Archivo de metamodelo que será procesado.</translation>
     </message>
     <message>
-        <location filename="../../qrmc/main.cpp" line="77"/>
         <source>Directory to which source code of the editor plugin shall be generated.</source>
         <translation>Directorio en el que se generará el código fuente del complemento del editor.</translation>
     </message>

--- a/qrtranslations/es/qrtext_es.ts
+++ b/qrtranslations/es/qrtext_es.ts
@@ -4,269 +4,206 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/lexer/lexer.h" line="60"/>
         <source>Invalid regexp: </source>
         <translation>Expresión regular no válida: </translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/lexer/lexer.h" line="171"/>
         <source>Unknown sequence of symbols: </source>
         <translation>Secuencia de símbolos desconocida: </translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/parser.h" line="54"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="57"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/concatenationParser.h" line="72"/>
         <source>Unexpected token</source>
         <translation>Token inesperado</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/tokenStream.h" line="62"/>
         <source>Expected &quot;%1&quot;, got &quot;%2&quot;</source>
         <translation>Se esperaba &quot;%1&quot;, se obtuvo &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/tokenParser.h" line="52"/>
         <source>Semantic action incorrectly discarded node in TokenParser</source>
         <translation>La acción semántica descartó incorrectamente un nodo en TokenParser</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/simpleParser.h" line="51"/>
         <source>Semantic action incorrectly discarded node in SimpleParser</source>
         <translation>La acción semántica descartó incorrectamente un nodo en SimpleParser</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="40"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/concatenationParser.h" line="43"/>
         <source>Unexpected end of input</source>
         <translation>Fin inesperado de la entrada</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="46"/>
         <source>Parser can not decide which alternative to use on </source>
         <translation>El analizador no puede decidir qué alternativa usar en </translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/expressionParser.h" line="94"/>
         <source>Binary operator in expression is of the wrong type</source>
         <translation>El operador binario en la expresión es de tipo incorrecto</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/expressionParser.h" line="102"/>
         <source>Right operand required</source>
         <translation>Se requiere operando derecho</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/types/any.h" line="28"/>
         <source>any</source>
         <translation>cualquiera</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/boolean.h" line="28"/>
         <source>boolean</source>
         <translation>booleano</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/float.h" line="28"/>
         <source>float</source>
         <translation>flotante</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/integer.h" line="28"/>
         <source>integer</source>
         <translation>entero</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/nil.h" line="28"/>
         <source>nil</source>
         <translation>nulo</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/number.h" line="28"/>
         <source>number</source>
         <translation>número</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/string.h" line="28"/>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="100"/>
         <source>string</source>
         <translation>cadena</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/table.h" line="44"/>
         <source>table[%1]</source>
         <translation>tabla[%1]</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="68"/>
         <source>Type mismatch</source>
         <translation>Incompatibilidad de tipos</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="73"/>
         <source>Can not deduce type, expression can be of following types: %1</source>
         <translation>No se puede deducir el tipo, la expresión puede ser de los siguientes tipos: %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="172"/>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="193"/>
         <source>This construction is not supported by semantic analysis</source>
         <translation>Esta construcción no es compatible con el análisis semántico</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="178"/>
         <source>Type mismatch.</source>
         <translation>Incompatibilidad de tipos.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="107"/>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="387"/>
         <source>Variable %1 is read-only</source>
         <translation>La variable %1 es de solo lectura</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="119"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="158"/>
         <source>This construction is not supported by interpreter</source>
         <translation>Esta construcción no es compatible con el intérprete</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="130"/>
         <source>Seems like accessing an uninitialized variable %1</source>
         <translation>Parece que se está accediendo a una variable no inicializada %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="263"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="273"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="286"/>
         <source>Division by zero</source>
         <translation>División por cero</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="360"/>
         <source>Currently interpreter allows only tables denoted by identifier and by integer expression index, as in &apos;a[1 + 2][3]&apos;</source>
         <translation>Actualmente el intérprete solo permite tablas indicadas por identificador y por índice de expresión entera, como en &apos;a[1 + 2][3]&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="391"/>
         <source>Tables denoted by something other than identifier (like f(x)[0]) are not allowed</source>
         <translation>No se permiten tablas indicadas por algo distinto a un identificador (por ejemplo, no se puede escribir f(x)[0])</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="417"/>
         <source>Explicit table indexes of non-integer type are not supported</source>
         <translation>No se admiten índices explícitos de tablas de tipo no entero</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="452"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="469"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="523"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="537"/>
         <source>Negative index for a table</source>
         <translation>Índice negativo para una tabla</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="30"/>
         <source>whitespace</source>
         <translation>espacio en blanco</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="31"/>
         <source>newline</source>
         <translation>nueva línea</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="34"/>
         <source>identifier</source>
         <translation>identificador</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="105"/>
         <source>integer literal</source>
         <translation>literal entero</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="119"/>
         <source>float literal</source>
         <translation>literal flotante</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="122"/>
         <source>comment</source>
         <translation>comentario</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="158"/>
         <source>node in &apos;stat&apos; semantic action is of unexpected type</source>
         <translation>el nodo en la acción semántica &apos;stat&apos; es de tipo inesperado</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="165"/>
         <source>Number of variables in assignment shall be equal to the number of assigned values</source>
         <translation>El número de variables en la asignación debe ser igual al número de valores asignados</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="177"/>
         <source>Assignment to function call is impossible</source>
         <translation>No es posible asignar a una llamada a función</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="304"/>
         <source>In &apos;args&apos; semantic action node is of incorrect type</source>
         <translation>En la acción semántica &apos;args&apos;, el nodo es de tipo incorrecto</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="321"/>
         <source>In &apos;table constructor&apos; semantic action fieldList is of incorrect type</source>
         <translation>En la acción semántica &apos;constructor de tabla&apos;, fieldList es de tipo incorrecto</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="364"/>
         <source>In &apos;field&apos; semantic action node is of incorrect type</source>
         <translation>En la acción semántica &apos;field&apos;, el nodo es de tipo incorrecto</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="113"/>
         <source>Intrinsic function used as an identifier</source>
         <translation>Función intrínseca utilizada como identificador</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="280"/>
         <source>Incorrect assignment, only variables and tables can be assigned to.</source>
         <translation>Asignación incorrecta, solo se puede asignar a variables y tablas.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="295"/>
         <source>Left and right operand have mismatched types.</source>
         <translation>Los operandos izquierdo y derecho tienen tipos incompatibles.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="301"/>
         <source>An attempt will be made to implicitly cast the right operand to the type &apos;%1&apos;</source>
         <translation>Se intentará convertir implícitamente el operando derecho al tipo &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="334"/>
         <source>Indirect function calls are not supported</source>
         <translation>No se admiten llamadas indirectas a funciones</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="342"/>
         <source>Unknown function</source>
         <translation>Función desconocida</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="354"/>
         <source>Too many parameters, %1 expected</source>
         <translation>Demasiados parámetros, se esperaban %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="357"/>
         <source>Not enough parameters, %1 expected</source>
         <translation>Faltan parámetros, se esperaban %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="377"/>
         <source>Undeclared identifier: %1</source>
         <translation>Identificador no declarado: %1</translation>
     </message>

--- a/qrtranslations/es/qrutils_es.ts
+++ b/qrtranslations/es/qrutils_es.ts
@@ -4,72 +4,58 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="642"/>
         <source>Unexpected end of stream at %1. Mb you forget &apos;;&apos;?</source>
         <translation>Final inesperado del flujo en la posición %1. ¿Quizás olvidó &apos;;&apos;?</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="647"/>
         <source>Unexpected symbol at %1 : expected %2, got %3</source>
         <translation>Símbolo inesperado en la posición %1: se esperaba %2, se obtuvo %3</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="651"/>
         <source>Types mismatch at %1: %2 = %3. Possible loss of data</source>
         <translation>Incompatibilidad de tipos en la posición %1: %2 = %3. Posible pérdida de datos</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="656"/>
         <source>Unknown identifier at %1 &apos; %2 &apos;</source>
         <translation>Identificador desconocido en la posición %1: &apos;%2&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="659"/>
         <source>Empty process is unnecessary</source>
         <translation>El proceso vacío es innecesario</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="663"/>
         <source>Condition can&apos;t be empty</source>
         <translation>La condición no puede estar vacía</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="667"/>
         <source>Using reserved variable %1</source>
         <translation>Uso de una palabra reservada como identificador (%1)</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="671"/>
         <source>No value of expression</source>
         <translation>Falta el valor de la expresión</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="674"/>
         <source>Incorrect variable declaration: use function block for it</source>
         <translation>Declaración incorrecta de variable: use el bloque &quot;Función&quot; para ello</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="679"/>
         <source>Unexpected symbol after the end of expression</source>
         <translation>Símbolo inesperado después del final de la expresión</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="683"/>
         <source>Unknown element property used</source>
         <translation>Se utilizó una propiedad desconocida del elemento</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="687"/>
         <source>Unknown element name used</source>
         <translation>Se utilizó un nombre desconocido del elemento</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="691"/>
         <source>Integer division by zero</source>
         <translation>División entera por cero</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphicsUtils/abstractItem.cpp" line="696"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
@@ -77,23 +63,18 @@
 <context>
     <name>qReal::BaseGraphTransformationUnit</name>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="48"/>
         <source>no current diagram</source>
         <translation>Abra un diagrama</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="75"/>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="123"/>
         <source>Rule &apos;</source>
         <translation>Regla &apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="76"/>
         <source>&apos; has not any appropriate nodes</source>
         <translation>&apos; no tiene nodos adecuados</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="123"/>
         <source>&apos; has unconnected link</source>
         <translation>&apos; contiene un enlace no conectado</translation>
     </message>
@@ -101,28 +82,22 @@
 <context>
     <name>qReal::interpretation::Block</name>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="60"/>
         <source>Control flow break detected, stopping</source>
         <translation>Se detectó una interrupción en el flujo de control, deteniendo la ejecución</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="65"/>
-        <location filename="../../qrutils/interpreter/block.cpp" line="158"/>
         <source>Block has disappeared!</source>
         <translation>¡El bloque ha desaparecido!</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="80"/>
         <source>Too many outgoing links</source>
         <translation>Demasiados enlaces salientes</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="85"/>
         <source>No outgoing links, please connect this block to something or use Final Node to end program</source>
         <translation>No hay enlaces salientes. Conecte este bloque a otro o use el bloque &quot;Fin&quot; para finalizar el programa</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="92"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace saliente no está conectado</translation>
     </message>
@@ -130,22 +105,18 @@
 <context>
     <name>qReal::interpretation::Interpreter</name>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="55"/>
         <source>Interpreter is already running</source>
         <translation>El intérprete ya está en ejecución</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="97"/>
         <source>Cannot create new thread with already occupied id %1</source>
         <translation>No se puede crear una nueva tarea con el identificador %1 ya ocupado</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="109"/>
         <source>Threads limit exceeded. Maximum threads count is %1</source>
         <translation>Se ha excedido el límite de tareas. El número máximo de tareas es %1</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="131"/>
         <source>Killing non-existent thread %1</source>
         <translation>Intento de finalizar una tarea inexistente %1</translation>
     </message>
@@ -153,17 +124,14 @@
 <context>
     <name>qReal::interpretation::Thread</name>
     <message>
-        <location filename="../../qrutils/interpreter/thread.cpp" line="117"/>
         <source>No entry point found, please add Initial Node to a diagram</source>
         <translation>No se encontró punto de entrada. Agregue un bloque &quot;Inicio&quot; al diagrama</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/thread.cpp" line="122"/>
         <source>Stack overflow</source>
         <translation>Desbordamiento de pila</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/thread.cpp" line="181"/>
         <source>Block has disappeared!</source>
         <translation>¡El bloque ha desaparecido!</translation>
     </message>
@@ -171,7 +139,6 @@
 <context>
     <name>qReal::interpretation::blocks::CommentBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/commentBlock.cpp" line="28"/>
         <source>The comment block with incoming links detected!</source>
         <translation>¡El bloque &quot;Comentario&quot; no puede tener enlaces entrantes!</translation>
     </message>
@@ -179,22 +146,18 @@
 <context>
     <name>qReal::interpretation::blocks::ForkBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="36"/>
         <source>There must be at least two outgoing links</source>
         <translation>Debe haber al menos dos enlaces salientes</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="43"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace saliente no está conectado</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="55"/>
         <source>Cannot create two threads with the same id %1</source>
         <translation>No se pueden crear dos tareas con el mismo identificador %1</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="69"/>
         <source>There must be a link that has its &apos;Guard&apos; property set to the current thread id %1</source>
         <translation>Debe haber un enlace cuya propiedad &apos;Guardia&apos; esté configurada con el identificador de la tarea actual %1</translation>
     </message>
@@ -202,27 +165,22 @@
 <context>
     <name>qReal::interpretation::blocks::IfBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="36"/>
         <source>There must be exactly TWO links outgoing from if block</source>
         <translation>Del bloque condicional debe salir exactamente DOS enlaces</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="43"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace saliente no está conectado</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="52"/>
         <source>Two links marked with &apos;true&apos; found</source>
         <translation>Se encontraron dos enlaces marcados con &apos;verdadero&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="59"/>
         <source>Two links marked with &apos;false&apos; found</source>
         <translation>Se encontraron dos enlaces marcados con &apos;falso&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="66"/>
         <source>There must be at least one link with &quot;true&quot; or &quot;false&quot; marker on it</source>
         <translation>Debe haber al menos un enlace marcado con &quot;verdadero&quot; o &quot;falso&quot;</translation>
     </message>
@@ -230,54 +188,42 @@
 <context>
     <name>qReal::interpretation::blocks::InputBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="27"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="36"/>
         <source>Input value for %1:</source>
         <translation>Introduzca el valor para %1:</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="56"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace saliente no está conectado</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="61"/>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="65"/>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="72"/>
         <source>cancel</source>
         <translation>cancelar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="65"/>
         <source>Only one link with &quot;%1&quot; is allowed</source>
         <translation>Solo se permite un enlace con &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="72"/>
         <source>One of the outgoing links must be marked with &quot;%1&quot;</source>
         <translation>Uno de los enlaces salientes debe estar marcado como &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="79"/>
         <source>Link to the next statement is missing</source>
         <translation>Falta el enlace al siguiente bloque</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="105"/>
         <source>You must input some value!</source>
         <translation>¡Debe introducir algún valor!</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="115"/>
         <source>No outgoing links, please connect this block to something or use Final Node to end program</source>
         <translation>No hay enlaces salientes. Conecte este bloque a otro o use el bloque &quot;Fin&quot; para finalizar el programa</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="119"/>
         <source>There should be a maximum of TWO links outgoing from input block</source>
         <translation>Del bloque de entrada deben salir como máximo DOS enlaces</translation>
     </message>
@@ -285,7 +231,6 @@
 <context>
     <name>qReal::interpretation::blocks::JoinBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/joinBlock.cpp" line="32"/>
         <source>Link outgoing from join block must have surviving thread id in its &apos;Guard&apos; property</source>
         <translation>El enlace que sale del bloque &quot;Unión de tareas&quot; debe tener el identificador de la tarea superviviente en su propiedad &apos;Guardia&apos;</translation>
     </message>
@@ -293,7 +238,6 @@
 <context>
     <name>qReal::interpretation::blocks::KillThreadBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/killThreadBlock.cpp" line="24"/>
         <source>Need to specify a thread to be stopped</source>
         <translation>Debe especificar la tarea que debe detenerse</translation>
     </message>
@@ -301,22 +245,18 @@
 <context>
     <name>qReal::interpretation::blocks::LoopBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="43"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Debe haber un enlace saliente del bloque &quot;Bucle&quot; marcado como &quot;cuerpo del bucle&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="47"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace saliente no está conectado</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="56"/>
         <source>Two links marked as &quot;body&quot; found</source>
         <translation>Se encontraron dos enlaces marcados como &quot;cuerpo del bucle&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="76"/>
         <source>There must be a non-marked outgoing link</source>
         <translation>Debe haber un enlace saliente sin marca</translation>
     </message>
@@ -324,23 +264,18 @@
 <context>
     <name>qReal::interpretation::blocks::PreconditionalLoopBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="41"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace saliente no está conectado</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="51"/>
         <source>Two links marked as &quot;body&quot; found</source>
         <translation>Se encontraron dos enlaces marcados como &quot;cuerpo del bucle&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="59"/>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="66"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Debe haber un enlace saliente del bloque &quot;Bucle&quot; marcado como &quot;cuerpo del bucle&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="71"/>
         <source>There must be a non-marked outgoing link</source>
         <translation>Debe haber un enlace saliente sin marca</translation>
     </message>
@@ -348,7 +283,6 @@
 <context>
     <name>qReal::interpretation::blocks::ReceiveThreadMessageBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/receiveThreadMessageBlock.cpp" line="25"/>
         <source>Need to specify variable which will contain received message</source>
         <translation>Debe especificar la variable que contendrá el mensaje recibido</translation>
     </message>
@@ -356,7 +290,6 @@
 <context>
     <name>qReal::interpretation::blocks::SendThreadMessageBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/sendThreadMessageBlock.cpp" line="23"/>
         <source>Need to specify a receiving thread in &apos;Thread&apos; property</source>
         <translation>Debe especificar la tarea receptora en la propiedad &apos;Tarea&apos;</translation>
     </message>
@@ -364,7 +297,6 @@
 <context>
     <name>qReal::interpretation::blocks::SubprogramBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/subprogramBlock.cpp" line="35"/>
         <source>Please enter valid c-style name for subprogram &quot;</source>
         <translation>Introduzca un nombre válido en estilo C para el subprograma &quot;</translation>
     </message>
@@ -372,27 +304,22 @@
 <context>
     <name>qReal::interpretation::blocks::SwitchBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="36"/>
         <source>There must be at list TWO links outgoing from switch block</source>
         <translation>Del bloque de selección deben salir al menos DOS enlaces</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="43"/>
         <source>Outgoing link is not connected</source>
         <translation>El enlace saliente no está conectado</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="52"/>
         <source>There must be exactly one link without marker on it (default branch)</source>
         <translation>Debe haber exactamente un enlace sin marca (rama por defecto)</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="57"/>
         <source>Duplicate case branch: &apos;%1&apos;</source>
         <translation>Rama duplicada: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="66"/>
         <source>There must be a link without marker on it (default branch)</source>
         <translation>Debe haber un enlace sin marca (rama por defecto)</translation>
     </message>
@@ -400,7 +327,6 @@
 <context>
     <name>qReal::interpretation::blocks::UnsupportedBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/unsupportedBlock.cpp" line="21"/>
         <source>Block of a type which is unsupported by an interpreter</source>
         <translation>Bloque de un tipo no soportado por el intérprete</translation>
     </message>
@@ -408,12 +334,10 @@
 <context>
     <name>qReal::ui::ColorDialog</name>
     <message>
-        <location filename="../../qrutils/widgets/colorDialog.cpp" line="34"/>
         <source>Select background color in the 2D-model editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/colorDialog.cpp" line="75"/>
         <source>Select the background color of the scene</source>
         <translation type="unfinished"></translation>
     </message>
@@ -421,7 +345,6 @@
 <context>
     <name>qReal::ui::ConsoleDock</name>
     <message>
-        <location filename="../../qrutils/widgets/consoleDock.cpp" line="50"/>
         <source>Reset shell</source>
         <translation>Limpiar consola</translation>
     </message>
@@ -429,7 +352,6 @@
 <context>
     <name>qReal::ui::DirPicker</name>
     <message>
-        <location filename="../../qrutils/widgets/dirPicker.cpp" line="33"/>
         <source>Browse...</source>
         <translation>Examinar...</translation>
     </message>
@@ -441,17 +363,14 @@
 <context>
     <name>qReal::ui::ImagePicker</name>
     <message>
-        <location filename="../../qrutils/widgets/imagePicker.cpp" line="35"/>
         <source>Browse...</source>
         <translation>Examinar...</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/imagePicker.cpp" line="70"/>
         <source>Select image</source>
         <translation>Seleccionar imagen</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/imagePicker.cpp" line="72"/>
         <source>Images (*.png *.svg *.jpg *.gif *.bmp);;All files (*.*)</source>
         <translation>Imágenes (*.png *.svg *.jpg *.gif *.bmp);;Todos los archivos (*.*)</translation>
     </message>
@@ -459,27 +378,22 @@
 <context>
     <name>qReal::ui::SearchLineEdit</name>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="31"/>
         <source>Clear text</source>
         <translation>Limpiar texto</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="32"/>
         <source>Case insensitive</source>
         <translation>No distinguir mayúsculas</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="33"/>
         <source>Case sensitive</source>
         <translation>Distinguir mayúsculas</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="34"/>
         <source>Regular expression</source>
         <translation>Expresión regular</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="43"/>
         <source>Enter search text...</source>
         <translation>Introduzca el texto de búsqueda...</translation>
     </message>
@@ -487,13 +401,10 @@
 <context>
     <name>qReal::ui::SearchLinePanel</name>
     <message>
-        <location filename="../../qrutils/widgets/searchLinePanel.cpp" line="134"/>
-        <location filename="../../qrutils/widgets/searchLinePanel.cpp" line="144"/>
         <source>Enter search text...</source>
         <translation>Introduzca el texto de búsqueda...</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLinePanel.cpp" line="155"/>
         <source>&lt;line&gt;:&lt;column&gt;</source>
         <translation>&lt;línea&gt;:&lt;columna&gt;</translation>
     </message>
@@ -501,22 +412,18 @@
 <context>
     <name>utils::MetamodelGeneratorSupport</name>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="72"/>
         <source>Please, fill compiler settings</source>
         <translation>Por favor, complete la configuración del compilador en la configuración</translation>
     </message>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="92"/>
         <source>Cannot unload plugin</source>
         <translation>No se puede descargar el complemento</translation>
     </message>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="115"/>
         <source>Cannot load new editor</source>
         <translation>No se puede cargar un nuevo editor</translation>
     </message>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="121"/>
         <source>Cannot build new editor</source>
         <translation>No se puede compilar el nuevo editor. Verifique los nombres de los elementos</translation>
     </message>
@@ -524,97 +431,78 @@
 <context>
     <name>utils::QRealMessageBox</name>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="30"/>
         <source>Ok</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="31"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="32"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="33"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="34"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="35"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="36"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="37"/>
         <source>Reset</source>
         <translation>Restablecer</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="38"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="39"/>
         <source>Save All</source>
         <translation>Guardar todo</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="40"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="41"/>
         <source>Yes To All</source>
         <translation>Sí para todo</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="42"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="43"/>
         <source>No To All</source>
         <translation>No para todo</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="44"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="45"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="46"/>
         <source>Ignore</source>
         <translation>Ignorar</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="47"/>
         <source>NoButton</source>
         <translation>Sin botón</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="49"/>
         <source>Restore Defaults</source>
         <translation>Restaurar valores predeterminados</translation>
     </message>
@@ -622,17 +510,14 @@
 <context>
     <name>watchListWindow</name>
     <message>
-        <location filename="../../qrutils/watchListWindow.ui" line="41"/>
         <source>Watch List</source>
         <translation>Variables</translation>
     </message>
     <message>
-        <location filename="../../qrutils/watchListWindow.ui" line="100"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../qrutils/watchListWindow.ui" line="105"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/checker/patcher_fr.ts
+++ b/qrtranslations/fr/plugins/robots/checker/patcher_fr.ts
@@ -4,37 +4,30 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="25"/>
         <source>Patcher for save files, replaces world model with contents of a given XML world model</source>
         <translation>Correctif pour les fichiers sauvegardés, remplace le modèle de monde par le contenu d&apos;un modèle de monde XML donné</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="38"/>
         <source>TRIK Studio save file to be patched.</source>
         <translation>Fichier de sauvegarde TRIK Studio à corriger.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="40"/>
         <source>XML file with prepared 2D model field. Both world and robot configurations (position + ports) will be patched.</source>
         <translation>Fichier XML avec champ de modèle 2D préparé. Les configurations du monde et du robot (position + ports) seront corrigées.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="43"/>
         <source>Script file to be patched into save file.</source>
         <translation>Fichier de script à intégrer dans le fichier de sauvegarde.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="45"/>
         <source>XML file with prepared 2D model field. Only world configurations will be patched.</source>
         <translation>Fichier XML avec champ de modèle 2D préparé. Seules les configurations du monde seront corrigées.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="49"/>
         <source>XML file with prepared 2D model field. Only world configurations and robot position will be patched.</source>
         <translation>Fichier XML avec champ de modèle 2D préparé. Seules les configurations du monde et la position du robot seront corrigées.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="53"/>
         <source>Reset robot position to start position</source>
         <translation>Réinitialiser la position du robot à la position initiale</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/checker/twoDModelRunner_fr.ts
+++ b/qrtranslations/fr/plugins/robots/checker/twoDModelRunner_fr.ts
@@ -4,69 +4,56 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="+30"/>
         <source>Emulates robot`s behaviour on TRIK Studio 2D model separately from programming environment. Passed .qrs will be interpreted just like when &apos;Run&apos; button was pressed in TRIK Studio. 
 In background mode the session will be terminated just after the execution ended and return code will then contain binary information about program correctness.Example: 
 </source>
         <translation>Émule le comportement du robot sur le modèle 2D TRIK Studio séparément de l&apos;environnement de programmation. Le fichier .qrs sera interprété comme si le bouton &apos;Executer&apos; était appuyé dans TRIK Studio.</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Save file to be interpreted.</source>
         <translation>Le fichier de sauvegarde à interpréter.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Run emulation in background.</source>
         <translation>Executer l&apos;émulation en tache de fond.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>A path to file where checker results will be written (JSON).</source>
         <translation>Chemin du fichier où les résultats du vérificateur seront écrits (JSON).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Inputs for JavaScript solution.</source>
         <translation>Entrées pour la solution en JavaScript.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set to &quot;script&quot; for execution of js/py from the project or set to &quot;diagram&quot; for block diagram.</source>
         <translation>Définir sur &quot;script&quot; pour exécuter un script js/py depuis le projet ou sur &quot;diagram&quot; pour un diagramme en blocs.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Speed factor, try from 5 to 20, or even 1000 (at your own risk!).</source>
         <translation>Facteur de vitesse, essayez entre 5 et 20, voire même 1000 (à vos risques et périls !).</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Shows robot&apos;s display.</source>
         <translation>Affiche l&apos;écran du robot.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The complete file path, including the filename, to save the generated JavaScript or Python code.</source>
         <translation>Chemin complet du fichier, nom inclus, pour enregistrer le code JavaScript ou Python généré.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The path to the Python or JavaScript file that will be used for interpretation.</source>
         <translation>Chemin vers le fichier Python ou JavaScript qui sera utilisé pour l&apos;interprétation.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do not run the interpretation in any mode, this is a parameter that is only used to generate a file.</source>
         <translation>Ne pas exécuter l&apos;interprétation dans aucun mode, ce paramètre sert uniquement à générer un fichier.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add a delay in milliseconds after executing the script before closing the window</source>
         <translation>Ajouter un délai en millisecondes après l&apos;exécution du script avant de fermer la fenêtre</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select &quot;python&quot; or &quot;javascript&quot;.</source>
         <translation>Sélectionnez &quot;python&quot; ou &quot;javascript&quot;.</translation>
     </message>
@@ -79,22 +66,18 @@ In background mode the session will be terminated just after the execution ended
         <translation type="vanished">Le chemin au fichier de sauvegarde des resultats (JSON)</translation>
     </message>
     <message>
-        <location line="-24"/>
         <source>A path to file where robot`s trajectory will be written. The writing will not be performed not immediately, each trajectory point will be written just when obtained by checker, so FIFOs are recommended to be targets for this option.</source>
         <translation>Le chemin au ficher ou la trajectoire du robot sera enregistrée. L&apos;enregistrement ne sera pas fait immediatement, chaque point de trajectoire sera écrit dès lors qu&apos;il est obteneur par le checker, donc FIFO sont récommandés pour cette option.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Close the window and exit if the diagram/script finishes without errors.</source>
         <translation>Fermer la fenêtre et quitter si le diagramme/le script se termine sans erreur.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Close the window and exit after diagram/script finishes.</source>
         <translation>Fermer la fenêtre et quitter après la fin du diagramme/du script.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Shows robot&apos;s console.</source>
         <translation>Affiche la console du robot.</translation>
     </message>
@@ -102,7 +85,6 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+241"/>
         <source>Robot console</source>
         <translation>Console du robot</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/common/ev3Kit_fr.ts
+++ b/qrtranslations/fr/plugins/robots/common/ev3Kit_fr.ts
@@ -4,17 +4,14 @@
 <context>
     <name>ev3::blocks::details::Ev3ReadRGBBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/blocks/details/ev3ReadRGBBlock.cpp" line="+43"/>
         <source>Sensor reading should consist of three components</source>
         <translation>La lecture du capteur doit comporter trois composants</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Sensor reading failed</source>
         <translation>Échec de la lecture du capteur</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Color raw sensor is not configured on port %2</source>
         <translation>Le capteur de couleur brut n&apos;est pas configuré sur le port %2</translation>
     </message>
@@ -22,7 +19,6 @@
 <context>
     <name>ev3::communication::BluetoothRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/bluetoothRobotCommunicationThread.cpp" line="+82"/>
         <source>Cannot open port </source>
         <translation>Impossible d&apos;ouvrir le port </translation>
     </message>
@@ -30,7 +26,6 @@
 <context>
     <name>ev3::communication::Ev3RobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/ev3RobotCommunicationThread.cpp" line="+55"/>
         <source>EV3 limits filename length to %1 characters, but you have %2, please, rename your project.</source>
         <translation>EV3 limite la longueur du nom de fichier à %1 caractères, mais vous en avez %2. Veuillez renommer votre projet.</translation>
     </message>
@@ -38,7 +33,6 @@
 <context>
     <name>ev3::communication::UsbRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/usbRobotCommunicationThread.cpp" line="+99"/>
         <source>Cannot find EV3 device. Check robot connected and turned on and try again.</source>
         <translation>Impossible de trouver l&apos;appareil EV3. Vérifiez que le robot est connecté et allumé, puis réessayez.</translation>
     </message>
@@ -46,7 +40,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3ACIRSeeker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3ACIRSeeker.h" line="+27"/>
         <source>NXT IRSeeker V2 (AC)</source>
         <translation>NXT IRSeeker V2 (AC)</translation>
     </message>
@@ -54,7 +47,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Compass</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Compass.h" line="+27"/>
         <source>Compass</source>
         <translation>Boussole</translation>
     </message>
@@ -62,7 +54,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3DCIRSeeker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3DCIRSeeker.h" line="+27"/>
         <source>NXT IRSeeker V2 (DC)</source>
         <translation>NXT IRSeeker V2 (DC)</translation>
     </message>
@@ -70,7 +61,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Led</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Led.h" line="+53"/>
         <source>LED</source>
         <translation>Diode</translation>
     </message>
@@ -78,7 +68,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Motor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Motor.h" line="+27"/>
         <source>Motor</source>
         <translation>Moteur</translation>
     </message>
@@ -86,7 +75,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Color</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Color.h" line="+27"/>
         <source>NXT color sensor V2 (color)</source>
         <translation>Capteur de couleur NXT V2 (couleur)</translation>
     </message>
@@ -94,7 +82,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Passive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Passive.h" line="+27"/>
         <source>NXT color sensor V2 (passive)</source>
         <translation>Capteur de couleur NXT V2 (passif)</translation>
     </message>
@@ -102,7 +89,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2RGB</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2RGB.h" line="+27"/>
         <source>NXT color sensor V2 (RGB)</source>
         <translation>Capteur de couleur NXT V2 (RGB)</translation>
     </message>
@@ -110,7 +96,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Raw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Raw.h" line="+27"/>
         <source>NXT color sensor V2 (raw)</source>
         <translation>Capteur de couleur NXT V2 (brut)</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/common/kitBase_fr.ts
+++ b/qrtranslations/fr/plugins/robots/common/kitBase_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/blocksBase/common/deviceBlock.h" line="+47"/>
         <source>%1 is not configured.</source>
         <translation>%1 n&apos;est pas configuré.</translation>
     </message>
@@ -12,17 +11,14 @@
 <context>
     <name>kitBase::DevicesConfigurationWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/devicesConfigurationWidget.cpp" line="+103"/>
         <source>%1:</source>
         <translation>%1 :</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Port %1:</source>
         <translation>Port %1 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unused</source>
         <translation>Pas utilisé</translation>
     </message>
@@ -30,7 +26,6 @@
 <context>
     <name>kitBase::blocksBase::common::WaitForButtonBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/blocksBase/common/waitForButtonBlock.cpp" line="+37"/>
         <source>Incorrect button port %1</source>
         <translation>Le port de bouton %1 n&apos;est pas correct</translation>
     </message>
@@ -65,7 +60,6 @@
 <context>
     <name>kitBase::blocksBase::common::WaitForSensorBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/blocksBase/common/waitForSensorBlock.cpp" line="+46"/>
         <source>%1 is not configured on port %2</source>
         <translation>%1 n&apos;est pas configuré sur le port %2</translation>
     </message>
@@ -73,7 +67,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::AccelerometerSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/accelerometerSensor.h" line="+29"/>
         <source>Accelerometer</source>
         <translation>Accéléromètre</translation>
     </message>
@@ -81,7 +74,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Button</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/button.h" line="+29"/>
         <source>Button</source>
         <translation>Bouton</translation>
     </message>
@@ -89,7 +81,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensor.h" line="+32"/>
         <source>Color sensor</source>
         <translation>Capteur de couleur</translation>
     </message>
@@ -97,7 +88,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorAmbient</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorAmbient.h" line="+29"/>
         <source>EV3 color sensor (ambient)</source>
         <translation>Capteur de couleur EV3 (ambiant)</translation>
     </message>
@@ -105,7 +95,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorBlue</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorBlue.h" line="+30"/>
         <source>NXT color sensor (blue)</source>
         <translation>NXT capteur de couleur (bleu)</translation>
     </message>
@@ -113,7 +102,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorFull</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorFull.h" line="+33"/>
         <source>NXT / EV3 color sensor (full)</source>
         <translation>NXT / EV3 capteur de couleur (reconnaissance de couleurs)</translation>
     </message>
@@ -121,7 +109,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorGreen</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorGreen.h" line="+30"/>
         <source>NXT color sensor (green)</source>
         <translation>NXT capteur de couleur (vert)</translation>
     </message>
@@ -129,7 +116,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorPassive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorPassive.h" line="+33"/>
         <source>NXT color sensor (passive)</source>
         <translation>NXT capteur de couleur (passif)</translation>
     </message>
@@ -137,7 +123,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorRaw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorRaw.h" line="+29"/>
         <source>EV3 color sensor (raw)</source>
         <translation>Capteur de couleur EV3 (brut)</translation>
     </message>
@@ -145,7 +130,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorRed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorRed.h" line="+30"/>
         <source>NXT color sensor (red)</source>
         <translation>NXT capteur de couleur (rouge)</translation>
     </message>
@@ -153,7 +137,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorReflected</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorReflected.h" line="+29"/>
         <source>EV3 color sensor (reflected)</source>
         <translation>Capteur de couleur EV3 (réfléchi)</translation>
     </message>
@@ -161,7 +144,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Communicator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h" line="+29"/>
         <source>Communicator</source>
         <translation>Communicateur</translation>
     </message>
@@ -169,7 +151,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Display</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/display.h" line="+29"/>
         <source>Display</source>
         <translation>Écran</translation>
     </message>
@@ -177,7 +158,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::EncoderSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/encoderSensor.h" line="+29"/>
         <source>Encoder</source>
         <translation>Encodeur</translation>
     </message>
@@ -185,7 +165,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::GyroscopeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/gyroscopeSensor.h" line="+29"/>
         <source>Gyroscope</source>
         <translation>Gyroscope</translation>
     </message>
@@ -193,7 +172,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::LidarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lidarSensor.h" line="+29"/>
         <source>Lidar</source>
         <translation>Lidar</translation>
     </message>
@@ -201,7 +179,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::LightSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lightSensor.h" line="+29"/>
         <source>Light sensor</source>
         <translation>Capteur de lumière</translation>
     </message>
@@ -209,7 +186,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Motor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/motor.h" line="+29"/>
         <source>Motor</source>
         <translation>Moteur</translation>
     </message>
@@ -217,7 +193,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::MotorsAggregator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/motorsAggregator.h" line="+29"/>
         <source>Motors aggregator</source>
         <translation>Agrégateur de moteurs</translation>
     </message>
@@ -225,7 +200,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Random</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/random.h" line="+30"/>
         <source>Random</source>
         <translation>Nombre aléatoire</translation>
     </message>
@@ -233,7 +207,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::RangeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/rangeSensor.h" line="+30"/>
         <source>Range sensor</source>
         <translation>Capteur de distance</translation>
     </message>
@@ -241,7 +214,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Shell</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/shell.h" line="+28"/>
         <source>Shell</source>
         <translation>Console</translation>
     </message>
@@ -249,7 +221,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::SoundSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/soundSensor.h" line="+30"/>
         <source>Sound sensor</source>
         <translation>Capteur de son</translation>
     </message>
@@ -257,7 +228,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Speaker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/speaker.h" line="+29"/>
         <source>Speaker</source>
         <translation>Haut-parleur</translation>
     </message>
@@ -265,7 +235,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::TouchSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/touchSensor.h" line="+30"/>
         <source>Touch sensor</source>
         <translation>Capteur tactile</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/common/nxtKit_fr.ts
+++ b/qrtranslations/fr/plugins/robots/common/nxtKit_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>nxt::communication::BluetoothRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/bluetoothRobotCommunicationThread.cpp" line="+86"/>
         <source>Cannot open port </source>
         <translation>Impossible d&apos;ouvrir le port </translation>
     </message>
@@ -12,32 +11,26 @@
 <context>
     <name>nxt::communication::NxtUsbDriverInstaller</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="+54"/>
         <source>Driver for NXT is not installed. An attempt to attach TRIK Studio driver also failed (probably NXT tools package was not installer). No panic! Driver can still be installed manually, see documentation, chapter &quot;Installing NXT driver manually.&quot;. Also TRIK Studio supports &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>Le pilote pour Lego NXT n&apos;est pas installé sur l&apos;ordinateur. La tentative d&apos;installation du pilote TRIK Studio a également échoué (probablement parce que le package « Outils NXT » a été désactivé lors de l&apos;installation). Pas de panique ! Le pilote peut toujours être installé manuellement, voir la documentation, chapitre « Installation du pilote NXT manuellement ». TRIK Studio est également compatible avec le &lt;a href=&apos;%1&apos;&gt;pilote Lego Fantom&lt;/a&gt;, vous pouvez le télécharger et l&apos;installer.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Driver installation cancelled. Please note that TRIK Studio also supports official &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>L&apos;installation du pilote TRIK Studio a été annulée. Veuillez noter que TRIK Studio prend également en charge le pilote officiel &lt;a href=&apos;%1&apos;&gt;Lego Fantom&lt;/a&gt;, vous pouvez simplement le télécharger et l&apos;installer.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>An attempt to attach TRIK Studio driver failed. No panic! Driver can be still installed manually, see documentation, chapter &quot;Installing NXT driver manually.&quot;. Also TRIK Studio supports &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>La tentative d&apos;installation du pilote TRIK Studio a échoué. Pas de panique ! Le pilote peut toujours être installé manuellement, voir la documentation, chapitre « Installation du pilote NXT manuellement ». TRIK Studio est également compatible avec le &lt;a href=&apos;%1&apos;&gt;pilote Lego Fantom&lt;/a&gt;, vous pouvez le télécharger et l&apos;installer.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>NXT drivers not found</source>
         <translation>Pilote NXT non trouvé</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Drivers for LEGO NXT brick are not installed. TRIK Studio can install own drivers to communicate with NXT. Do you want to do it?</source>
         <translation>Le pilote pour la brique LEGO NXT n&apos;est pas installé. TRIK Studio peut installer ses propres pilotes pour communiquer avec le NXT. Voulez-vous le faire ?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>TRIK Studio drivers are not officially registered, so two red warning messages will be shown by Windows. Confirm them to proceed installation.</source>
         <translation>Le pilote TRIK Studio n&apos;est pas officiellement enregistré par Microsoft, donc Windows affichera deux messages d&apos;avertissement rouges. Confirmez-les pour continuer l&apos;installation.</translation>
     </message>
@@ -45,33 +38,26 @@
 <context>
     <name>nxt::communication::UsbRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="+169"/>
         <source>USB Device configuration problem. Try to restart TRIK Studio and re-plug NXT.</source>
         <translation>Problème de configuration du périphérique USB. Essayez de redémarrer TRIK Studio et de rebrancher le NXT.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>NXT device is already used by another software.</source>
         <translation>Le périphérique NXT est déjà utilisé par un autre logiciel. Essayez de redémarrer l&apos;environnement et de rebrancher le NXT.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>NXT handshake procedure failed. Please contact developers.</source>
         <translation>La procédure de poignée de main avec le NXT a échoué. Veuillez réessayer. Si cette erreur réapparaît, contactez les développeurs.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot find NXT device. Check robot connected and turned on and try again.</source>
         <translation>Impossible de trouver le périphérique NXT. Vérifiez que le robot est allumé et connecté à l&apos;ordinateur, puis réessayez.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+19"/>
         <source>Connection to NXT lost</source>
         <translation>Connexion au NXT perdue</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Cannot find NXT device in resetted mode. Check robot resetted, connected and ticking and try again.</source>
         <translation>Impossible de trouver le périphérique NXT en mode réinitialisation. Vérifiez que le firmware du robot est effacé, que le robot est connecté à l&apos;ordinateur et qu&apos;il émet des signaux sonores répétitifs (bip-bip), puis réessayez.</translation>
     </message>
@@ -79,7 +65,6 @@
 <context>
     <name>nxt::robotModel::parts::NxtMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/include/nxtKit/robotModel/parts/nxtMotor.h" line="+27"/>
         <source>Motor</source>
         <translation>Moteur</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/common/trikKit_fr.ts
+++ b/qrtranslations/fr/plugins/robots/common/trikKit_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::blocks::details::WaitForMessageBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="+46"/>
         <source>Device not found for port name CommunicatorPort</source>
         <translation>Périphérique non trouvé pour le nom de port CommunicatorPort</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>trik::blocks::details::WaitGamepadButtonBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/blocks/details/waitGamepadButtonBlock.cpp" line="+41"/>
         <source>Incorrect port for gamepad button %1</source>
         <translation>Port incorrect pour le bouton de manette %1</translation>
     </message>
@@ -20,13 +18,10 @@
 <context>
     <name>trik::robotModel::TrikRobotModelBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="+93"/>
-        <location line="+212"/>
         <source>Video 2</source>
         <translation>Vidéo 2</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Lidar</source>
         <translation>Lidar</translation>
     </message>
@@ -34,7 +29,6 @@
 <context>
     <name>trik::robotModel::parts::TrikColorSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikColorSensor.h" line="+29"/>
         <source>Color Sensor</source>
         <translation>Capteur couleur</translation>
     </message>
@@ -42,7 +36,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadButton</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadButton.h" line="+28"/>
         <source>Android Gamepad Button</source>
         <translation>Bouton de manette android</translation>
     </message>
@@ -50,7 +43,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadConnectionIndicator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadConnectionIndicator.h" line="+28"/>
         <source>Android Gamepad Connection Indicator</source>
         <translation>Voyant de connection de manette android</translation>
     </message>
@@ -58,7 +50,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadPad</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadPad.h" line="+29"/>
         <source>Android Gamepad Pad</source>
         <translation>Manette android</translation>
     </message>
@@ -66,7 +57,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadPadPressSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadPadPressSensor.h" line="+28"/>
         <source>Android Gamepad Pad as Button</source>
         <translation>Manette android comme un bouton</translation>
     </message>
@@ -74,7 +64,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadWheel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadWheel.h" line="+29"/>
         <source>Android Gamepad Wheel</source>
         <translation>&quot;Volant&quot; de manette android</translation>
     </message>
@@ -82,7 +71,6 @@
 <context>
     <name>trik::robotModel::parts::TrikInfraredSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikInfraredSensor.h" line="+27"/>
         <source>Infrared Sensor</source>
         <translation>Capteur infrarouge</translation>
     </message>
@@ -90,7 +78,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLed.h" line="+27"/>
         <source>Led</source>
         <translation>Led</translation>
     </message>
@@ -98,7 +85,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLightSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLightSensor.h" line="+28"/>
         <source>Light sensor</source>
         <translation>Capteur de luminosité</translation>
     </message>
@@ -106,7 +92,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLineSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLineSensor.h" line="+28"/>
         <source>Line Sensor</source>
         <translation>Capteur de ligne</translation>
     </message>
@@ -114,7 +99,6 @@
 <context>
     <name>trik::robotModel::parts::TrikMotionSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikMotionSensor.h" line="+27"/>
         <source>Motion Sensor</source>
         <translation>Capteur de mouvement</translation>
     </message>
@@ -122,7 +106,6 @@
 <context>
     <name>trik::robotModel::parts::TrikMotorsAggregator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikMotorsAggregator.h" line="+27"/>
         <source>Trik Motors Aggregator</source>
         <translation>Agrégateur de moteurs Trik</translation>
     </message>
@@ -130,7 +113,6 @@
 <context>
     <name>trik::robotModel::parts::TrikObjectSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikObjectSensor.h" line="+28"/>
         <source>Object Sensor</source>
         <translation>Capteur d&apos;objet</translation>
     </message>
@@ -138,7 +120,6 @@
 <context>
     <name>trik::robotModel::parts::TrikPowerMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikPowerMotor.h" line="+27"/>
         <source>Power Motor</source>
         <translation>Moteur électrique</translation>
     </message>
@@ -146,7 +127,6 @@
 <context>
     <name>trik::robotModel::parts::TrikServoMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikServoMotor.h" line="+27"/>
         <source>Servo Motor</source>
         <translation>Servomoteur</translation>
     </message>
@@ -154,7 +134,6 @@
 <context>
     <name>trik::robotModel::parts::TrikSonarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikSonarSensor.h" line="+27"/>
         <source>Sonic Sensor</source>
         <translation>Capteur de son</translation>
     </message>
@@ -162,7 +141,6 @@
 <context>
     <name>trik::robotModel::parts::TrikTouchSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikTouchSensor.h" line="+28"/>
         <source>Touch sensor</source>
         <translation>Capteur de toucher</translation>
     </message>
@@ -170,7 +148,6 @@
 <context>
     <name>trik::robotModel::parts::TrikVideoCamera</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikVideoCamera.h" line="+27"/>
         <source>Video Camera</source>
         <translation>Caméra vidéo</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/common/twoDModel_fr.ts
+++ b/qrtranslations/fr/plugins/robots/common/twoDModel_fr.ts
@@ -4,370 +4,290 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="+100"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="+125"/>
         <source>No such object: %1</source>
         <translation>Objet inexistant : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>No such region: %1</source>
         <translation>Région inexistante : %1</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 is not a region</source>
         <translation>%1 n&apos;est pas une région</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>%1 has incorrect type for matching it with region</source>
         <translation>%1 n&apos;est pas d&apos;un type qui permet de l&apos;associer avec une région</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+12"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="+112"/>
-        <location line="+12"/>
         <source>No such event: %1</source>
         <translation>événement inexistant : %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="+65"/>
         <source>Root element must be &quot;constraints&quot; tag</source>
         <translation>L&apos;élément racine doit être une balise &quot;constraints&quot;</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>There must be a &quot;timelimit&quot; constraint.</source>
         <translation>Il doit y exister une contrainte &quot;timelimit&quot;.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>There must be only one &quot;timelimit&quot; tag.</source>
         <translation>Il ne peut pas y avoir plus d&apos;une balise &quot;timelimit&quot;.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Event tag must have &quot;condition&quot; or &quot;conditions&quot; child tag. &quot;%1&quot; found instead.</source>
         <translation>La balise événement doit avoir &quot;condition&quot; ou &quot;conditions&quot; comme balise-enfant. &quot;%1&quot; est trouvé à la place. </translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Event tag must have &quot;trigger&quot; or &quot;triggers&quot; child tag. &quot;%1&quot; found instead.</source>
         <translation>La balise événement doit avoir &quot;trigger&quot; ou &quot;triggers&quot; comme balise-enfant. &quot;%1&quot; est trouvé à la place.</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Program worked for too long time</source>
         <translation>Le programme a tourné trop longtemps</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>&quot;Glue&quot; attribute must have value &quot;and&quot; or &quot;or&quot;.</source>
         <translation>Attribut &quot;glue&quot; doit avoir une valeur &quot;and&quot; ou &quot;or&quot;.</translation>
     </message>
     <message>
-        <location line="+59"/>
-        <location line="+212"/>
         <source>Unknown tag &quot;%1&quot;.</source>
         <translation>Balise inconnue &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>There must be only one tag &quot;return&quot; in &quot;using&quot; expression.</source>
         <translation>Il ne doit y avoir qu&apos;une seule balise &quot;return&quot; dans l&apos;expression &quot;using&quot;.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>There must be &quot;return&quot; tag in &quot;using&quot; expression.</source>
         <translation>La balise &quot;return&quot; doit être présente dans l&apos;expression &quot;using&quot;.</translation>
     </message>
     <message>
-        <location line="+334"/>
         <source>Unknown value &quot;%1&quot;.</source>
         <translation>Valeur inconnue &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Invalid integer value &quot;%1&quot;</source>
         <translation>Valeur entière invalide &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Invalid floating point value &quot;%1&quot;</source>
         <translation>Nombre avec un point flottant invalide &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Invalid boolean value &quot;%1&quot; (expected &quot;true&quot; or &quot;false&quot;)</source>
         <translation>Une valeur booléenne invalide &quot;%1&quot; (&quot;true&quot; ou &quot;false&quot; sont attendues)</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Duplicate id: &quot;%1&quot;</source>
         <translation>Un id non unique : &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>When using the extended form for the %1 tag, the number of arguments starting with _ must be %2, %3 was provided</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>%1 tag must have exactly %2 child tag(s)</source>
         <translation>Balise %1 doit avoir exactement %2 balise(s) enfant(s) </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 tag must have at least %2 child tag(s)</source>
         <translation>Balise %1 doit avoir au moins %2 balise(s) enfant(s)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&quot;%1&quot; tag must have &quot;%2&quot; attribute.</source>
         <translation>Balise %1 doit avoir un attribut %2.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Expected &quot;%1&quot; tag, got &quot;%2&quot;.</source>
         <translation>Une balise &quot;%1&quot; est attendue et non pas &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Attribute &quot;%1&quot; of the tag &quot;%2&quot; must not be empty.</source>
         <translation>L&apos;attribut &quot;%1&quot; de la balise &quot;%2&quot; ne doit pas être vide.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="-61"/>
         <source>Using special syntax with an empty variable name</source>
         <translation>Utilisation d&apos;une syntaxe spéciale avec un nom de variable vide</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The name %1 is not a valid variable name or property chain for an object</source>
         <translation>Le nom %1 n&apos;est pas un nom de variable valide ni une chaîne de propriétés pour un objet</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Requesting variable value with empty name</source>
         <translation>Demande de la valeur d&apos;une variable ayant un nom vide</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Object path is empty!</source>
         <translation>Le chemin de l&apos;objet est vide !</translation>
     </message>
     <message>
-        <location line="+131"/>
         <source>Unknown type of object &quot;%1&quot;</source>
         <translation>Type d&apos;objet &quot;%1&quot; inconnu</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Object &quot;%1&quot; has no property &quot;%2&quot;</source>
         <translation>L&apos;objet &quot;%1&quot; n&apos;a pas de propriété &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/speedPopup.cpp" line="+25"/>
         <source>Speed:&amp;nbsp;&amp;nbsp;&lt;b&gt;%1%&lt;/b&gt;</source>
         <translation>Vitesse :&amp;nbsp;&amp;nbsp;&lt;b&gt;%1%&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="-30"/>
         <source>Invalid &lt;setState&gt; object type %1</source>
         <translation>Type d&apos;objet %1 invalide dans l&apos;élément &lt;setState&gt;</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Object %1 has no property %2</source>
         <translation>L&apos;objet %1 n&apos;a pas la propriété %2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/colorFieldItem.cpp" line="+52"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="+181"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp" line="+261"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Convert to region</source>
         <translation>Convertir en région</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bind to region</source>
         <translation>Lier à la région</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="+1"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Edit</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="+119"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Pixels</source>
         <translation>Pixels</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Centimeters</source>
         <translation>Centimètres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Meters</source>
         <translation>Mètres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimètres</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="+35"/>
         <source>The &amp;lt;template&amp;gt; tag was provided, but the required &quot;name&quot; attribute was missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Redefinition a template %1 that already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>the &amp;lt;templates&amp;gt; tag can only contain the &amp;lt;template&amp;gt; tag as a child tag, actual %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="+31"/>
         <source>The &amp;lt;use&amp;gt; tag must contain a &quot;template&quot; attribute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Recursive template expansion detected: %1 -&gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The &amp;lt;use&amp;gt; tag contains a template=%1 attribute that is not the name of a declared template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>After substituting the parameters for the template %1, it did not become a valid xml node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="+78"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="+100"/>
         <source>line %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>template %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="+3"/>
         <source>relative the beginning of the &amp;lt;constraints&amp;gt; tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>relative to the beginning of the %1 template body</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Substitution chain: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="+29"/>
         <source>Currently, this method of setting &amp;lt;content&amp;gt; tag for the template %1 is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>When defining the template %1, the syntax %2 was used to substitute an offset %3 for an undeclared parameter %4.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>the &amp;lt;params&amp;gt; tag can only contain the &amp;lt;param&amp;gt; tag as a child tag for template %1, actual tag is &amp;lt;%2&amp;gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The &amp;lt;param&amp;gt; tag of template %1 was provided, but the required &quot;name&quot; attribute was missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>The &amp;lt;template&amp;gt; of template %1 tag was provided, but the required child tag &amp;lt;content&amp;gt; was missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The using an undeclared parameter %1 for template %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>The &amp;lt;use&amp;gt; tag can only contain a child tag &amp;lt;with&amp;gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>The parameter %1 of template %2 has no default value and was not explicitly specified by the user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/templateParserApi.cpp" line="+101"/>
         <source>Error while template substitution: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Error while parsing template: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp" line="+1"/>
         <source>Change visibility</source>
         <translation>Modifier la visibilité</translation>
     </message>
@@ -375,7 +295,6 @@
 <context>
     <name>TwoDModelWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="+14"/>
         <source>2D Robot Model</source>
         <translation>Un modèle 2D</translation>
     </message>
@@ -388,80 +307,62 @@
         <translation type="vanished">Arrêter le programme (Esc)</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Run program</source>
         <translation>Executer le programme</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Stop program</source>
         <translation>Arrêter le programme</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>Grid size:</source>
         <translation>Taille de la grille:</translation>
     </message>
     <message>
-        <location line="+230"/>
-        <location line="+7"/>
-        <location line="+7"/>
-        <location line="+14"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>kg</source>
         <translation>kg</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Decrease speed</source>
         <translation>Diminuer la vitesse</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Time in 2D model</source>
         <translation>Le temps dans le modèle 2D</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source> sec.</source>
         <translation> sec.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Increase speed</source>
         <translation>Augmenter la vitesse</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location line="-555"/>
         <source>Left wheel:</source>
         <translation>Roue gauche :</translation>
     </message>
     <message>
-        <location line="-194"/>
         <source>Edit Regions</source>
         <translation>Modifier les régions</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Reset World</source>
         <translation>Réinitialiser le monde</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Right wheel:</source>
         <translation>Roue droite :</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Metric system units:</source>
         <translation>Unités du système métrique :</translation>
     </message>
@@ -470,42 +371,34 @@
         <translation type="vanished">Nombre de pixels par cm :</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Realistic physics</source>
         <translation>Physique réaliste</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Realistic sensors</source>
         <translation>Capteurs réalistes</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Realistic engines</source>
         <translation>Moteurs réalistes</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Wheel diameter:</source>
         <translation>Diamètre de la roue :</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Robot height:</source>
         <translation>Hauteur du robot :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Robot mass:</source>
         <translation>Masse du robot :</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Robot track:</source>
         <translation>Empattement du robot :</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Robot width:</source>
         <translation>Largeur du robot :</translation>
     </message>
@@ -513,17 +406,14 @@
 <context>
     <name>twoDModel::constraints::ConstraintsChecker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+127"/>
         <source>Error while parsing constraints: %1</source>
         <translation>Une erreur lors de l&apos;analyse des contraints est survenue : %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Warning while parsing constraints: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+232"/>
         <source>Program has finished, but the task is not accomplished.</source>
         <translation>Le programme est terminé, mais la tache n&apos;est pas accomplie.</translation>
     </message>
@@ -531,7 +421,6 @@
 <context>
     <name>twoDModel::engine::TwoDModelEngineFacade</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+207"/>
         <source>Realistic physics&apos; must be turned on to enjoy skittles, cubes and balls</source>
         <translation>La physique réaliste doit être activée pour interagir avec les quilles, les cubes et les balles</translation>
     </message>
@@ -539,7 +428,6 @@
 <context>
     <name>twoDModel::items::BallItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/ballItem.cpp" line="+54"/>
         <source>Ball (B)</source>
         <translation>Balle (B)</translation>
     </message>
@@ -547,7 +435,6 @@
 <context>
     <name>twoDModel::items::CommentItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="-141"/>
         <source>Text (T)</source>
         <translation>Texte (T)</translation>
     </message>
@@ -555,7 +442,6 @@
 <context>
     <name>twoDModel::items::CubeItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="+62"/>
         <source>Cube (X)</source>
         <translation>Cube (X)</translation>
     </message>
@@ -563,7 +449,6 @@
 <context>
     <name>twoDModel::items::CurveItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/curveItem.cpp" line="+64"/>
         <source>Bezier Curve (Z)</source>
         <translation>Courbe de Bézier (Z)</translation>
     </message>
@@ -571,7 +456,6 @@
 <context>
     <name>twoDModel::items::EllipseItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/ellipseItem.cpp" line="+44"/>
         <source>Ellipse (E)</source>
         <translation>Ellipse (E)</translation>
     </message>
@@ -579,7 +463,6 @@
 <context>
     <name>twoDModel::items::ImageItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/imageItem.cpp" line="+80"/>
         <source>Image (I)</source>
         <translation>Image (I)</translation>
     </message>
@@ -587,7 +470,6 @@
 <context>
     <name>twoDModel::items::LineItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/lineItem.cpp" line="+49"/>
         <source>Line (L)</source>
         <translation>Ligne (L)</translation>
     </message>
@@ -595,7 +477,6 @@
 <context>
     <name>twoDModel::items::RectangleItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/rectangleItem.cpp" line="+44"/>
         <source>Rectangle (R)</source>
         <translation>Rectangle (R)</translation>
     </message>
@@ -603,7 +484,6 @@
 <context>
     <name>twoDModel::items::SkittleItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/skittleItem.cpp" line="+54"/>
         <source>Can (C)</source>
         <translation>Boîte (C)</translation>
     </message>
@@ -611,7 +491,6 @@
 <context>
     <name>twoDModel::items::StylusItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/stylusItem.cpp" line="+62"/>
         <source>Stylus (S)</source>
         <translation>Stylo (S)</translation>
     </message>
@@ -619,7 +498,6 @@
 <context>
     <name>twoDModel::items::WallItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+69"/>
         <source>Wall (W)</source>
         <translation>Mur (W)</translation>
     </message>
@@ -627,27 +505,22 @@
 <context>
     <name>twoDModel::model::Model</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="+74"/>
         <source>The task was accomplished in %1 sec!</source>
         <translation>La tâche a été accomplie en %1 secondes!</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Error in checker: %1</source>
         <translation>Erreur dans le vérificateur : %1</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>The &quot;version&quot; field of the &quot;root&quot; tag must not be empty.</source>
         <translation>Le champ &quot;version&quot; de la balise &quot;root&quot; ne doit pas être vide.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The world model has version %1. The current version is %2. Please check that the world model behaves as expected.</source>
         <translation>Le modèle de monde a la version %1. La version actuelle est %2. Veuillez vérifier que le modèle de monde se comporte comme prévu.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>This robot model already exists</source>
         <translation>Ce modèle de robot existe déjà</translation>
     </message>
@@ -690,24 +563,14 @@
 <context>
     <name>twoDModel::model::WorldModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="+195"/>
-        <location line="+20"/>
-        <location line="+19"/>
-        <location line="+19"/>
-        <location line="+19"/>
-        <location line="+19"/>
-        <location line="+44"/>
-        <location line="+20"/>
         <source>Trying to add an item with a duplicate id: %1</source>
         <translation>Tentative d&apos;ajout d&apos;un élément avec un identifiant dupliqué : %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Incorrect image, please try anouther one</source>
         <translation>Image incorrecte, veuillez en essayer une autre</translation>
     </message>
     <message>
-        <location line="+543"/>
         <source>Unknown image with imageId %1</source>
         <translation>Image inconnue avec imageId %1</translation>
     </message>
@@ -715,8 +578,6 @@
 <context>
     <name>twoDModel::robotModel::TwoDRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/robotModel/twoDRobotModel.cpp" line="+74"/>
-        <location line="+3"/>
         <source>2D Model</source>
         <translation>Modèle 2D</translation>
     </message>
@@ -724,7 +585,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorAmbient</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorAmbient.h" line="+33"/>
         <source>EV3 color sensor (ambient)</source>
         <translation>Capteur de couleur EV3 (lumière ambiante)</translation>
     </message>
@@ -732,7 +592,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorBlue</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorBlue.h" line="+36"/>
         <source>Color sensor (blue)</source>
         <translation>Capteur de couleur (bleu)</translation>
     </message>
@@ -740,7 +599,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorFull</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorFull.h" line="+37"/>
         <source>Color sensor (full)</source>
         <translation>Capteur de couleurs (reconnaissance de couleurs)</translation>
     </message>
@@ -748,7 +606,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorGreen</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorGreen.h" line="+36"/>
         <source>Color sensor (green)</source>
         <translation>Capteur de couleurs (vert)</translation>
     </message>
@@ -756,7 +613,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorPassive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorPassive.h" line="+37"/>
         <source>Color sensor (passive)</source>
         <translation>Capteur de couleurs (passif)</translation>
     </message>
@@ -764,7 +620,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorRaw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorRaw.h" line="+35"/>
         <source>Color sensor (raw)</source>
         <translation>Capteur de couleur (brut)</translation>
     </message>
@@ -772,7 +627,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorRed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorRed.h" line="+36"/>
         <source>Color sensor (red)</source>
         <translation>Capteur de couleurs (rouge)</translation>
     </message>
@@ -780,7 +634,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorReflected</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorReflected.h" line="+33"/>
         <source>EV3 color sensor (reflected)</source>
         <translation>Capteur de couleur EV3 (lumière réfléchie)</translation>
     </message>
@@ -788,7 +641,6 @@
 <context>
     <name>twoDModel::robotModel::parts::Marker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/marker.h" line="+37"/>
         <source>Marker</source>
         <translation>Marqueur</translation>
     </message>
@@ -796,42 +648,34 @@
 <context>
     <name>twoDModel::view::ActionsBox</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="+26"/>
         <source>Hand dragging mode</source>
         <translation>Le mode de glissement manuel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Multiselection mode</source>
         <translation>Mode multisélection</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Save world model...</source>
         <translation>Enregister le modèle du monde...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Load world model...</source>
         <translation>Charger le modèle du monde...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Load templates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Load world model without robot configuration...</source>
         <translation>Charger le modèle de monde sans configuration de robot...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear items</source>
         <translation>Tout effacer</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Clear floor</source>
         <translation>Effacer le sol des traces du robot</translation>
     </message>
@@ -839,22 +683,18 @@
 <context>
     <name>twoDModel::view::ColorItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="+104"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Disable filling</source>
         <translation>Désactiver le remplissage</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enable filling</source>
         <translation>Activer le remplissage</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Thickness</source>
         <translation>Épaisseur</translation>
     </message>
@@ -862,32 +702,26 @@
 <context>
     <name>twoDModel::view::DetailsTab</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="+38"/>
         <source>Display</source>
         <translation>Écran</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ports configuration</source>
         <translation>Configuration des ports</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Motors</source>
         <translation>Moteurs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Physics</source>
         <translation>Physique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Model parameters</source>
         <translation>Paramètres du modèle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Metric system</source>
         <translation>Système métrique</translation>
     </message>
@@ -895,7 +729,6 @@
 <context>
     <name>twoDModel::view::GridParameters</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/gridParameters.cpp" line="+34"/>
         <source>Grid</source>
         <translation>Grille</translation>
     </message>
@@ -903,37 +736,30 @@
 <context>
     <name>twoDModel::view::ImageItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="+58"/>
         <source>Image will be packed into save file. Warning: this will increase save file size.</source>
         <translation>L&apos;image sera intégrée au fichier de sauvegarde. Attention : cela augmentera considérablement la taille du fichier.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Image will not be packed into a save file. Warning: if will use save file on other machine or rename file this image will disappear from 2D model.</source>
         <translation>L&apos;image ne sera pas incluse dans le fichier de sauvegarde. Attention : si vous utilisez ce fichier sur une autre machine ou que vous renommez le fichier image, celle-ci disparaîtra du modèle 2D.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The image will be in the background. Warning: the robot does not see this image.</source>
         <translation>L&apos;image sera en arrière-plan. Attention : le robot ne voit pas cette image.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The image will be in the foreground. Warning: robot sees this image with sensors.</source>
         <translation>L&apos;image sera en premier plan. Attention : le robot voit cette image grâce à ses capteurs.</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Change image...</source>
         <translation>Changer l&apos;image...</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select image</source>
         <translation>Sélectionner une image</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Graphics (*.*)</source>
         <translation>Graphiques (*.*)</translation>
     </message>
@@ -941,7 +767,6 @@
 <context>
     <name>twoDModel::view::Palette</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/palette.cpp" line="+25"/>
         <source>Cursor (N)</source>
         <translation>Curseur (N)</translation>
     </message>
@@ -949,32 +774,26 @@
 <context>
     <name>twoDModel::view::RobotItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="+78"/>
         <source>Camera folowing robot: %1</source>
         <translation>Suivre le robot : %1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>enabled</source>
         <translation>actionné</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>disabled</source>
         <translation>éteint</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Return robot to the initial position</source>
         <translation>Retourner le robot à la position initiale</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Move start position here</source>
         <translation>Déplacer la position de départ ici</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Marker thickness</source>
         <translation>Épaisseur du marqueur</translation>
     </message>
@@ -982,7 +801,6 @@
 <context>
     <name>twoDModel::view::SpeedPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/speedPopup.cpp" line="+5"/>
         <source>Reset to default</source>
         <translation>Réinitialiser</translation>
     </message>
@@ -990,32 +808,26 @@
 <context>
     <name>twoDModel::view::TwoDModelScene</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+897"/>
         <source>Select images</source>
         <translation>Sélectionner des images</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Graphics (*.*)</source>
         <translation>Graphiques (*.*)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You are trying to load to big image, it may freeze execution for some time. Continue?</source>
         <translation>Vous essayez de charger une image trop volumineuse, cela pourrait bloquer l&apos;exécution pendant un certain temps. Continuer ?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot load %1. Try another file.</source>
         <translation>Impossible de charger %1. Essayez un autre fichier.</translation>
     </message>
@@ -1023,12 +835,10 @@
 <context>
     <name>twoDModel::view::TwoDModelWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+385"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to clear scene?</source>
         <translation>Est-ce que vous voulez vraiment effacer la scène ?</translation>
     </message>
@@ -1045,60 +855,46 @@
         <translation type="vanished">cm</translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>kg</source>
         <translation>kg</translation>
     </message>
     <message>
-        <location line="+303"/>
         <source>Training mode: solution will not be checked</source>
         <translation>Mode entraînement : la solution ne sera pas vérifiée</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Checking mode: solution will be checked, errors will be reported</source>
         <translation>Mode vérification : la solution sera vérifiée, les erreurs seront signalées</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Saving world and robot model</source>
         <translation>Enregistrement des modèles du monde et du robot</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+20"/>
-        <location line="+25"/>
         <source>2D model saves (*.xml)</source>
         <translation>Fichiers de sauvegarde du modèle 2D (*.xml) </translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Loading world and robot model</source>
         <translation>Chargement des modèles du monde et du robot</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Loading world without robot model</source>
         <translation>Chargement du monde sans modèle de robot</translation>
     </message>
     <message>
-        <location line="+336"/>
         <source>Hide details</source>
         <translation>Masquer les détails</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Show details</source>
         <translation>Afficher les détails</translation>
     </message>
     <message>
-        <location line="+211"/>
-        <location line="+1"/>
         <source>No wheel</source>
         <translation>Pas de roue</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 (port %2)</source>
         <translation>%1 (port %2)</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/editor/common_fr.ts
+++ b/qrtranslations/fr/plugins/robots/editor/common_fr.ts
@@ -8,12 +8,10 @@
         <translation type="vanished">Attendez la fin :</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="+884"/>
         <source>X:</source>
         <translation>X :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y:</source>
         <translation>Y :</translation>
     </message>
@@ -78,7 +76,6 @@
         <translation type="vanished">Durée</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
@@ -91,7 +88,6 @@
         <translation type="vanished">Port :</translation>
     </message>
     <message>
-        <location line="-557"/>
         <source>Color:</source>
         <translation>Couleur :</translation>
     </message>
@@ -116,33 +112,22 @@
         <translation type="vanished">Corps :</translation>
     </message>
     <message>
-        <location line="-328"/>
-        <location line="+141"/>
-        <location line="+374"/>
-        <location line="+62"/>
-        <location line="+361"/>
         <source>Variable:</source>
         <translation>Variable :</translation>
     </message>
     <message>
-        <location line="-885"/>
-        <location line="+354"/>
         <source>Condition:</source>
         <translation>Condition :</translation>
     </message>
     <message>
-        <location line="-273"/>
         <source>Reads a value into variable from an input dialog.</source>
         <translation>Lit une valeur dans une variable à partir d&apos;une boîte de dialogue de saisie.</translation>
     </message>
     <message>
-        <location line="+104"/>
-        <location line="+450"/>
         <source>Thread:</source>
         <translation>Fil :</translation>
     </message>
     <message>
-        <location line="-406"/>
         <source>Iterations:</source>
         <translation>Itérations :</translation>
     </message>
@@ -155,44 +140,34 @@
         <translation type="vanished">Limite de compte tours :</translation>
     </message>
     <message>
-        <location line="-125"/>
-        <location line="+310"/>
         <source>Text:</source>
         <translation>Texte :</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>From:</source>
         <translation>De :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>To:</source>
         <translation>À :</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Synchronized:</source>
         <translation>Synchronisé :</translation>
     </message>
     <message>
-        <location line="+111"/>
         <source>Message:</source>
         <translation>Message :</translation>
     </message>
     <message>
-        <location line="-741"/>
-        <location line="+885"/>
         <source>Expression:</source>
         <translation>Expression :</translation>
     </message>
     <message>
-        <location line="-440"/>
         <source>This block executes a sequence of blocks while condition in &apos;Condition&apos; is true. This block must have two outgoing links. One of them must be marked with the &apos;body&apos; guard (that means that the property &apos;Guard&apos; of the link must be set to &apos;body&apos; value). Another outgoing link must be unmarked: the program execution will be proceeded through this link when condition becomes false.</source>
         <translation>Ce bloc exécute une séquence de blocs tant que la condition dans &apos;Condition&apos; est vraie. Ce bloc doit avoir deux liens sortants. L&apos;un d&apos;eux doit être marqué avec la garde &apos;body&apos; (cela signifie que la propriété &apos;Guard&apos; du lien doit être définie à la valeur &apos;body&apos;). L&apos;autre lien sortant doit rester non marqué : l&apos;exécution du programme se poursuivra par ce lien lorsque la condition deviendra fausse.</translation>
     </message>
     <message>
-        <location line="+484"/>
         <source>Delay:</source>
         <translation>Délai :</translation>
     </message>
@@ -285,69 +260,54 @@
         <translation type="vanished">Manette :</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Value:</source>
         <translation>Valeur :</translation>
     </message>
     <message>
-        <location line="-1353"/>
         <source>AbstractNode</source>
         <translation>AbstractNode</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Clear Screen</source>
         <translation>Effacer l&apos;écran</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Clears everything drawn on the robot`s screen.</source>
         <translation>Efface l&apos;écran du robot.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+840"/>
         <source>Redraw</source>
         <translation>Redessiner</translation>
     </message>
     <message>
-        <location line="-829"/>
-        <location line="+37"/>
         <source>Comment</source>
         <translation>Commentaire</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>This block can hold text notes that are ignored by generators and interpreters. Use it for improving the diagram readability.</source>
         <translation>Ce bloc peut contenir des notes textuelles ignorées par les générateurs et interpréteurs. Utilisez-le pour améliorer la lisibilité du diagramme.</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Enter some text here...</source>
         <translation>Entrez du texte ici...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Link</source>
         <translation>Lien</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>For creating a link between two elements A and B you can just hover a mouse above A, press the right mouse button and (without releasing it) draw a line to the element B. Alternatively you can just &apos;pull&apos; a link from a small blue circle next to the element.</source>
         <translation>Pour créer un lien entre deux éléments A et B, vous pouvez placer le curseur au-dessus de A, cliquer avec le bouton droit de la souris et (sans relâcher) tracer une ligne jusqu&apos;à l&apos;élément B. Sinon, vous pouvez simplement &apos;tirer&apos; un lien à partir du petit cercle bleu situé à côté de l&apos;élément.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Guard</source>
         <translation>Garde</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>EngineCommand</source>
         <translation>EngineCommand</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>EngineMovementCommand</source>
         <translation>EngineMovementCommand</translation>
     </message>
@@ -392,12 +352,10 @@
         <translation type="vanished">Rempli</translation>
     </message>
     <message>
-        <location line="+688"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -450,7 +408,6 @@
         <translation type="vanished">Mode</translation>
     </message>
     <message>
-        <location line="-665"/>
         <source>Power (%)</source>
         <translation>Puissance (%)</translation>
     </message>
@@ -459,7 +416,6 @@
         <translation type="vanished">B, C</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>100</source>
         <translation>100</translation>
     </message>
@@ -480,7 +436,6 @@
         <translation type="vanished">LED</translation>
     </message>
     <message>
-        <location line="+522"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
@@ -493,7 +448,6 @@
         <translation type="vanished">Frequence</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
@@ -530,8 +484,6 @@
         <translation type="vanished">Signe</translation>
     </message>
     <message>
-        <location line="-363"/>
-        <location line="+415"/>
         <source>0</source>
         <translation>0</translation>
     </message>
@@ -568,32 +520,26 @@
         <translation type="vanished">Attendre un capteur tactile</translation>
     </message>
     <message>
-        <location line="-1129"/>
         <source>End if</source>
         <translation>Fin Si</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Unites control flow from different condition branches.</source>
         <translation>Réunit les flux de contrôle provenant de différentes branches conditionnelles.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Final Node</source>
         <translation>Nœud terminal</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The final node of the program. If the program consists of some parallel execution lines the reachment of this block terminates the corresponding execution line. This block can`t have outgoing links.</source>
         <translation>Le nœud final du programme. Si le programme comprend plusieurs lignes d&apos;exécution parallèles, l&apos;atteinte de ce bloc termine la ligne d&apos;exécution correspondante. Ce bloc ne peut pas avoir de liens sortants.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Fork</source>
         <translation>Fork</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Separates program execution into a number of threads that will be executed concurrently from the programmers`s point of view. For example in such way signal from sensor and some time interval can be waited synchroniously. This block must have at least two outgoing links. &apos;Guard&apos; property of every link must contain unique thread identifiers, and one of those identifiers must be the same as the identifier of a thread where fork is placed (it must be &apos;main&apos; if it is the first fork in a program.</source>
         <translation>Sépare l&apos;exécution du programme en plusieurs threads qui seront exécutés simultanément du point de vue du programmeur. Par exemple, on peut ainsi attendre de façon synchrone un signal provenant d&apos;un capteur et un intervalle de temps donné. Ce bloc doit avoir au moins deux liens sortants. La propriété &apos;Guard&apos; de chaque lien doit contenir des identifiants de thread uniques, et l&apos;un de ces identifiants doit être identique à celui du thread dans lequel le fork est placé (il doit être &apos;main&apos; s&apos;il s&apos;agit du premier fork du programme).</translation>
     </message>
@@ -602,7 +548,6 @@
         <translation type="vanished">Fonction</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Evaluates a value of the given expression. Also new variables can be defined in this block. See the &apos;Expressions Syntax&apos; chapter in help for more information about &apos;Function&apos; block syntax.</source>
         <translation>Évalue la valeur de l&apos;expression donnée. De nouvelles variables peuvent également être définies dans ce bloc. Consultez le chapitre &apos;Syntaxe des expressions&apos; dans l&apos;aide pour plus d&apos;informations sur la syntaxe du bloc &apos;Fonction&apos;.</translation>
     </message>
@@ -611,157 +556,114 @@
         <translation type="vanished">Corps</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Get Button Code</source>
         <translation>Obtenir le code de bouton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Assigns a given variable a value of pressed button. If no button is pressed at the moment and &apos;Wait&apos; property is false when variable is set to -1.</source>
         <translation>Attribue à une variable donnée la valeur du bouton pressé. Si aucun bouton n&apos;est enfoncé au moment où la propriété &apos;Wait&apos; est fausse, la variable prend la valeur -1.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wait:</source>
         <translation>Attendre :</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+151"/>
-        <location line="+374"/>
-        <location line="+414"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location line="-938"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="+137"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Wait</source>
         <translation>Attendre</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+151"/>
-        <location line="+374"/>
-        <location line="+307"/>
-        <location line="+107"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+34"/>
-        <location line="+353"/>
         <source>Condition</source>
         <translation>Condition</translation>
     </message>
     <message>
-        <location line="-385"/>
         <source>Separates program execution in correspondece with the given condition. The &apos;Condition&apos; parameter value must be some boolean expression that will determine subsequent program execution line. This block must have two outgoing links, at least one of them must have &apos;Guard&apos; parameter set to &apos;true&apos; or &apos;false&apos;. The execution will be proceed trough the link marked with the guard corresponding to &apos;Condition&apos; parameter of the block.</source>
         <translation>Sépare l&apos;exécution du programme selon la condition donnée. La valeur du paramètre &apos;Condition&apos; doit être une expression booléenne qui déterminera le prochain chemin d&apos;exécution. Ce bloc doit avoir deux liens sortants, dont au moins un doit avoir le paramètre &apos;Guard&apos; défini à &apos;true&apos; ou &apos;false&apos;. L&apos;exécution se poursuivra par le lien marqué avec la garde correspondant à la valeur du paramètre &apos;Condition&apos; du bloc.</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location line="+353"/>
         <source>x &gt; 0</source>
         <translation>x &gt; 0</translation>
     </message>
     <message>
-        <location line="-342"/>
         <source>Initial Node</source>
         <translation>Nœud initial</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The entry point of the program execution. Each diagram should have only one such block, it must not have incomming links and it must have only one outgoing link. The interpretation process starts from exactly this block.</source>
         <translation>Le point d&apos;entrée de l&apos;exécution du programme. Chaque diagramme ne doit contenir qu&apos;un seul bloc de ce type, il ne doit pas avoir de liens entrants et doit avoir exactement un lien sortant. Le processus d&apos;interprétation commence précisément à ce bloc.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>User Input</source>
         <translation>Saisie utilisateur</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Default:</source>
         <translation>Par défaut :</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Join</source>
         <translation>Jonction</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Joins a number of threads into one. &apos;Guard&apos; property of the single outgoing link must contain an identifier of one of threads being joined. The specified thread would wait until the rest of them finish execution, and then proceed in a normal way.</source>
         <translation>Fusionne plusieurs threads en un seul. La propriété &apos;Guard&apos; du lien sortant unique doit contenir l&apos;identifiant d&apos;un des threads fusionnés. Le thread spécifié attendra que les autres aient terminé leur exécution, puis poursuivra normalement.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Kill Thread</source>
         <translation>Tuer un fil</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Terminates execution of a specified thread.</source>
         <translation>Termine l&apos;exécution d&apos;un thread spécifié.</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Thread</source>
         <translation>Fil</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>main</source>
         <translation>main</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loop</source>
         <translation>Boucle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This block executes a sequence of blocks for a given number of times. The number of repetitions is specified by the &apos;Iterations&apos; parameter. This block must have two outgoing links. One of them must be marked with the &apos;body&apos; guard (that means that the property &apos;Guard&apos; of the link must be set to &apos;body&apos; value). Another outgoing link must be unmarked: the program execution will be proceeded through this link when it will go through our &apos;Loop&apos; block for the given number of times.</source>
         <translation>Ce bloc exécute une séquence de blocs un nombre donné de fois. Le nombre de répétitions est défini par le paramètre &apos;Itérations&apos;. Ce bloc doit avoir deux liens sortants. L&apos;un d&apos;eux doit être marqué avec la garde &apos;body&apos; (cela signifie que la propriété &apos;Guard&apos; du lien doit être définie à la valeur &apos;body&apos;). L&apos;autre lien sortant doit rester non marqué : l&apos;exécution du programme se poursuivra par ce lien une fois que le bloc &apos;Loop&apos; aura été exécuté le nombre de fois indiqué.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Iterations</source>
         <translation>Itérations</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+248"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Marker Down</source>
         <translation>Descendre le marqueur </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Moves the marker of the 2D model robot down to the floor: the robot will draw its trace on the floor after that. If the marker of another color is already drawing at the moment it will be replaced.</source>
         <translation>Abaisse le marqueur du robot du modèle 2D jusqu&apos;au sol : le robot commencera à tracer sa trajectoire sur le sol. Si un marqueur d&apos;une autre couleur est déjà en cours d&apos;utilisation, il sera remplacé.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Marker Up</source>
         <translation>Remonter le marqueur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Lifts the marker of the 2D model robot up: the robot stops drawing its trace on the floor after that.</source>
         <translation>Relève le marqueur du robot du modèle 2D : le robot cesse alors de tracer sa trajectoire sur le sol.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Pre-conditional Loop</source>
         <translation>Boucle avec condition préalable</translation>
     </message>
@@ -790,79 +692,62 @@
         <translation type="vanished">Attendre une distance de sonar</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Print Text</source>
         <translation>Imprimer le texte</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Prints a given line in the specified coordinates on the robot`s screen. The value of &apos;Text&apos; property is interpreted as a plain text unless &apos;Evaluate&apos; property is set to true, then it will be interpreted as an expression (that may be useful for example when debugging variables values).</source>
         <translation>Affiche une ligne donnée aux coordonnées spécifiées sur l&apos;écran du robot. La valeur de la propriété &apos;Text&apos; est interprétée comme un texte brut, sauf si la propriété &apos;Evaluate&apos; est définie à vrai, auquel cas elle sera interprétée comme une expression (ce qui peut être utile, par exemple, lors du débogage des valeurs des variables).</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Evaluate</source>
         <translation>Évaluer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enter some text here</source>
         <translation>Saisissez du texte ici</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+1"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Random Initialization</source>
         <translation>Initialisation aléatoire</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets a variable value to a random value inside given interval.</source>
         <translation>Attribue à une variable une valeur aléatoire comprise dans l&apos;intervalle donné.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>To</source>
         <translation>À</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Receive Message From Thread</source>
         <translation>Recevoir un message de fil</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Receive a message sent to a thread from which this block is called.</source>
         <translation>Reçoit un message envoyé à un thread depuis lequel ce bloc est appelé.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Synchronized</source>
         <translation>Synchronisé</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>RobotsDiagramGroup</source>
         <translation>RobotsDiagramGroup</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="-29"/>
         <source>Robot`s Behaviour Diagram</source>
         <translation>Le diagramme de comportement du robot</translation>
     </message>
@@ -871,12 +756,10 @@
         <translation type="vanished">Paramétrage des périfériques</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Send Message To Thread</source>
         <translation>Envoyer un message à un fil</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sends a message to a specified thread.</source>
         <translation>Envoie un message à un fil spécifié.</translation>
     </message>
@@ -885,53 +768,42 @@
         <translation type="vanished">Message</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Subprogram</source>
         <translation>Sousprogramme</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Subprogram call. Subprograms are used for splitting repetitive program parts into a separate diagram and then calling it from main diagram or other subprograms. When this block is added into a diagram it will be suggested to enter subprogram name. The double click on subprogram call block may open the corresponding subprogram diagram. Moreover user palette will appear containing existing subrpograms, they can be dragged into a diagram like the usual blocks.</source>
         <translation>Appel de sous-programme. Les sous-programmes permettent de séparer les parties répétitives d&apos;un programme dans un diagramme distinct, puis de les appeler depuis le diagramme principal ou d&apos;autres sous-programmes. Lorsque ce bloc est ajouté à un diagramme, il est demandé de saisir le nom du sous-programme. Un double-clic sur le bloc d&apos;appel du sous-programme peut ouvrir le diagramme correspondant. En outre, une palette utilisateur apparaît, contenant les sous-programmes existants, qui peuvent être glissés dans un diagramme comme des blocs ordinaires.</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Subprogram Diagram</source>
         <translation>Diagramme de sousprogramme</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>SubprogramDiagramGroup</source>
         <translation>SubprogramDiagramGroup</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Switch</source>
         <translation>Choix multifonction</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Selects the program execution branch in correspondence with some expression value. The value of the expression written in &apos;Expression&apos; property is compared to the values on the outgoing links. If equal value is found then execution will be proceeded by that branch. Else branch without a marker will be selected.</source>
         <translation>Sélectionne la branche d&apos;exécution du programme en fonction de la valeur d&apos;une expression. La valeur de l&apos;expression indiquée dans la propriété &apos;Expression&apos; est comparée aux valeurs des liens sortants. Si une valeur égale est trouvée, l&apos;exécution se poursuit par cette branche. Sinon, la branche sans marqueur est sélectionnée.</translation>
     </message>
     <message>
-        <location line="-887"/>
-        <location line="+918"/>
         <source>Expression</source>
         <translation>Expression</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Timer</source>
         <translation>Minuteur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for a given time in milliseconds.</source>
         <translation>Attends un temps donné en ms.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Delay (ms)</source>
         <translation>Délai (ms)</translation>
     </message>
@@ -1156,53 +1028,26 @@
         <translation type="vanished">Enregister dans un fichier</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Variable Initialization</source>
         <translation>Initialisation de variable</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Assigns a given value to a given variable.</source>
         <translation>Affecter une valeur à une variable.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Algorithms</source>
         <translation>Algorithmes</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Actions</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Drawing</source>
         <translation>Dessin</translation>
     </message>
@@ -1214,37 +1059,30 @@
         <translation type="obsolete">Corps</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="-990"/>
         <source>Expression</source>
         <translation>Expression</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Devices configuration</source>
         <translation>Configuration des dispositifs</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thread</source>
         <translation>Tâche</translation>
     </message>
@@ -1984,12 +1822,10 @@
         <translation type="vanished">4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="+22"/>
         <source>black</source>
         <translation>noire</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>blue</source>
         <translation>bleu</translation>
     </message>
@@ -2030,7 +1866,6 @@
         <translation type="vanished">girs</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>green</source>
         <translation>vert</translation>
     </message>
@@ -2043,7 +1878,6 @@
         <translation type="vanished">pourpre</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red</source>
         <translation>rouge</translation>
     </message>
@@ -2060,32 +1894,26 @@
         <translation type="vanished">E4</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>white</source>
         <translation>blanc</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yellow</source>
         <translation>jaune</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>greater</source>
         <translation>supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>inférieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>pas supérieur à</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>pas inférieur à</translation>
     </message>
@@ -2102,67 +1930,54 @@
         <translation type="vanished">interrompre</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>float</source>
         <translation>float</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>Composite</source>
         <translation>Composite</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Partagé</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>brake</source>
         <translation>interrompre</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Package</source>
         <translation>Paquet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Privé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Protegé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Publique</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>In</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Entrée/sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Retour</translation>
     </message>
@@ -2199,17 +2014,14 @@
         <translation type="vanished">Vrai</translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>Concurrent</source>
         <translation>Concurrent</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Gardé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Séquentiel</translation>
     </message>
@@ -2222,39 +2034,30 @@
         <translation type="vanished">Echapper</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+6"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>body</source>
         <translation>corps</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+6"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>norm</source>
         <translation>norme</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>axe x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>axe y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>axe z</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/editor/ev3_fr.ts
+++ b/qrtranslations/fr/plugins/robots/editor/ev3_fr.ts
@@ -4,297 +4,234 @@
 <context>
     <name>Ev3MetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="+204"/>
         <source>In</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Entrée-sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Valeur de retour</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>black</source>
         <translation>noir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>blue</source>
         <translation>bleu</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+6"/>
         <source>green</source>
         <translation>vert</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
         <source>red</source>
         <translation>rouge</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>white</source>
         <translation>blanc</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yellow</source>
         <translation>jaune</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>bool</source>
         <translation>Valeur booléenne</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>int</source>
         <translation>Nombre entier</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>string</source>
         <translation>Chaîne de caractères</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>norm</source>
         <translation>normale</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>axe des x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>axe des y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>axe des z</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>brake</source>
         <translation>interrompre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Concurrent</source>
         <translation>Concurrent</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Avec garde</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Séquentiel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>greater</source>
         <translation>supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>inférieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>non supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>non inférieur</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Package</source>
         <translation>Paquet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Privé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Protégé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Public</translation>
     </message>
     <message>
-        <location line="-22"/>
-        <location line="+14"/>
         <source>float</source>
         <translation>Nombre à virgule flottante</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Back</source>
         <translation>Arrière</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Down</source>
         <translation>Bas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enter</source>
         <translation>Avancer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Right</source>
         <translation>Droite</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Up</source>
         <translation>Haut</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>green flash</source>
         <translation>vert clignotant</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>green pulse</source>
         <translation>vert pulsé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>off</source>
         <translation>éteint</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>orange</source>
         <translation>orange</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>orange flash</source>
         <translation>orange clignotant</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>orange pulse</source>
         <translation>orange pulsé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red flash</source>
         <translation>rouge clignotant</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red pulse</source>
         <translation>rouge pulsé</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+6"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>body</source>
         <translation>corps de la boucle</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+6"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Composite</source>
         <translation>Composition</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Agrégation</translation>
     </message>
@@ -302,1017 +239,706 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="+26"/>
         <source>Beep</source>
         <translation>Bip</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.</source>
         <translation>Émet un son à fréquence fixe sur le robot. Deux paramètres sont disponibles : le premier correspond au volume du son, le second indique si le programme doit attendre la fin du son avant de passer au bloc suivant.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+876"/>
-        <location line="+1061"/>
         <source>Volume:</source>
         <translation>Volume :</translation>
     </message>
     <message>
-        <location line="-1929"/>
-        <location line="+886"/>
         <source>Wait for Completion:</source>
         <translation>Attendre la fin :</translation>
     </message>
     <message>
-        <location line="-853"/>
-        <location line="+880"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location line="-880"/>
-        <location line="+880"/>
-        <location line="+1051"/>
         <source>Volume</source>
         <translation>Volume</translation>
     </message>
     <message>
-        <location line="-1930"/>
-        <location line="+880"/>
         <source>Wait for Completion</source>
         <translation>Attendre la fin</translation>
     </message>
     <message>
-        <location line="-869"/>
         <source>Calibrate Black</source>
         <translation>Calibrer le noir</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Calibrates the black threshold for each sensor in the array. Place the array over the black surface with all sensors on the black area.</source>
         <translation>Calibre le seuil du noir pour chaque capteur du réseau. Placez l&apos;ensemble sur une surface noire, tous les capteurs devant être au-dessus de la zone noire.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Calibrate gyroscope</source>
         <translation>Calibrer le gyroscope</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets gyroscope&apos;s angle to zero in current position.</source>
         <translation>Réinitialise l&apos;angle du gyroscope à zéro dans la position actuelle.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Calibrate PID</source>
         <translation>Calibrer le régulateur PID</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets set point, P, I, D value of PID control and P factor, I factor, D factor for P, I, D value of PID control.</source>
         <translation>Définit la consigne du capteur (milieu du capteur au-dessus de la ligne), P/(facteur P), I/(facteur I), D/(facteur D).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Set point:</source>
         <translation>Consigne du capteur :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>P:</source>
         <translation>P :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>P factor:</source>
         <translation>Facteur P :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>I:</source>
         <translation>I :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>I factor:</source>
         <translation>Facteur I :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>D:</source>
         <translation>D :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>D factor:</source>
         <translation>Facteur D :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>D factor</source>
         <translation>Facteur D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I factor</source>
         <translation>Facteur I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P factor</source>
         <translation>Facteur P</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set point</source>
         <translation>Milieu du capteur</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Calibrate White</source>
         <translation>Calibrer le blanc</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Calibrates the white threshold for each sensor in the array. Place the array over the white surface with all sensors on the white area.</source>
         <translation>Calibre le seuil du blanc pour chaque capteur du réseau. Placez l&apos;ensemble sur une surface blanche, tous les capteurs devant être au-dessus de la zone blanche.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Clear Encoder</source>
         <translation>Réinitialiser les encodeurs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Remet à zéro le compteur de tours des moteurs sur les ports indiqués.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+360"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>Ports:</source>
         <translation>Ports :</translation>
     </message>
     <message>
-        <location line="-443"/>
-        <location line="+476"/>
         <source>A, B, C, D</source>
         <translation>A, B, C, D</translation>
     </message>
     <message>
-        <location line="-476"/>
-        <location line="+314"/>
-        <location line="+54"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>Ports</source>
         <translation>Ports</translation>
     </message>
     <message>
-        <location line="-465"/>
         <source>Draw Circle</source>
         <translation>Dessiner un cercle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws on the robot screen a circle with the given center and radius.</source>
         <translation>Dessine un cercle sur l&apos;écran du robot avec le centre et le rayon indiqués.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+144"/>
-        <location line="+54"/>
         <source>X:</source>
         <translation>X :</translation>
     </message>
     <message>
-        <location line="-190"/>
-        <location line="+144"/>
-        <location line="+54"/>
         <source>Y:</source>
         <translation>Y :</translation>
     </message>
     <message>
-        <location line="-190"/>
         <source>Radius:</source>
         <translation>Rayon :</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+206"/>
         <source>Filled:</source>
         <translation>Rempli :</translation>
     </message>
     <message>
-        <location line="-182"/>
         <source>Radius</source>
         <translation>Rayon</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+205"/>
         <source>Filled</source>
         <translation>Rempli</translation>
     </message>
     <message>
-        <location line="-204"/>
-        <location line="+70"/>
-        <location line="+56"/>
-        <location line="+80"/>
         <source>Redraw</source>
         <translation>Rafraîchir l&apos;image</translation>
     </message>
     <message>
-        <location line="-205"/>
-        <location line="+126"/>
-        <location line="+81"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="-206"/>
-        <location line="+126"/>
-        <location line="+81"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Draw Line</source>
         <translation>Dessiner une ligne</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Dessine un segment sur l&apos;écran du robot. Les paramètres indiquent les extrémités du segment.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>X1:</source>
         <translation>X1 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y1:</source>
         <translation>Y1 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>X2:</source>
         <translation>X2 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y2:</source>
         <translation>Y2 :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Draw Pixel</source>
         <translation>Dessiner un pixel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Dessine un pixel aux coordonnées indiquées sur l&apos;écran du robot.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Draw Rectangle</source>
         <translation>Dessiner un rectangle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Dessine un rectangle sur l&apos;écran du robot. Les paramètres indiquent les coordonnées du coin supérieur gauche, la largeur et la hauteur du rectangle.</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Width:</source>
         <translation>Largeur :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Height:</source>
         <translation>Hauteur :</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Ev3EngineMovementCommand</source>
         <translation>Bloc de base des moteurs EV3</translation>
     </message>
     <message>
-        <location line="+185"/>
         <source>Mode</source>
         <translation>Mode</translation>
     </message>
     <message>
-        <location line="-161"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>B, C</source>
         <translation>B, C</translation>
     </message>
     <message>
-        <location line="-107"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location line="-108"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>Power (%)</source>
         <translation>Puissance (%)</translation>
     </message>
     <message>
-        <location line="-97"/>
         <source>Motors Backward</source>
         <translation>Moteurs arrière</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Active les moteurs sur les ports indiqués en mode inverse avec la puissance donnée. Les ports sont spécifiés par les lettres A, B ou C, séparées par des virgules. La puissance est indiquée en pourcentage, avec un nombre allant de -100 à 100 ; si une valeur négative est indiquée, le moteur est activé en mode normal.</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+54"/>
         <source>Power:</source>
         <translation>Puissance :</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Motors Forward</source>
         <translation>Moteurs avant</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Active les moteurs sur les ports indiqués avec la puissance donnée. Les ports sont spécifiés par les lettres A, B ou C, séparées par des virgules. La puissance est indiquée en pourcentage, avec un nombre allant de -100 à 100 ; si une valeur négative est indiquée, le moteur est activé en mode inverse.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Stop Motors</source>
         <translation>Arrêter les moteurs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Disables motors on the given ports.</source>
         <translation>Désactive les moteurs sur les ports indiqués.</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Led</source>
         <translation>LED</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the color of the LED on the robot`s front panel.</source>
         <translation>Définit la couleur de la LED sur le panneau avant du robot.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+649"/>
         <source>Color:</source>
         <translation>Couleur :</translation>
     </message>
     <message>
-        <location line="-624"/>
-        <location line="+649"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location line="-638"/>
         <source>Play Tone</source>
         <translation>Jouer un son</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Plays on the robot a sound with the given frequency and duration. This block is similar to the &apos;Beep&apos; block wuth the only difference that here you can specify sound parameters.</source>
         <translation>Joue sur le robot un son avec la fréquence et la durée indiquées. Ce bloc est similaire au bloc &apos;Bip&apos;, à la différence près que vous pouvez ici spécifier les paramètres du son.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Frequency:</source>
         <translation>Fréquence :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+34"/>
         <source>Duration</source>
         <translation>Durée</translation>
     </message>
     <message>
-        <location line="-33"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+1"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Frequency</source>
         <translation>Fréquence</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Read Sensor to Array</source>
         <translation>Lire le capteur dans un tableau</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Read the values from the Line Leader.  Amount of light or dark each sensor sees.  Typically between 0-20.  0=black, 100=white.</source>
         <translation>Lit les valeurs du capteur Line Leader. Quantité de lumière ou d&apos;obscurité détectée par chaque capteur. Généralement entre 0 et 100. 0 = noir, 100 = blanc.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Array:</source>
         <translation>Tableau :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>a</source>
         <translation>a</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Array Variable</source>
         <translation>Variable tableau</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Read Average to Variable</source>
         <translation>Valeur moyenne dans la variable</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+124"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location line="-124"/>
-        <location line="+124"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Read RGB into Variables</source>
         <translation>Lire les composantes RVB dans des variables</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reads R, G, B channels values into given variables</source>
         <translation>Lit les valeurs des canaux R, V, B dans les variables indiquées</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>R Variable:</source>
         <translation>Variable R :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>G Variable:</source>
         <translation>Variable V :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>B Variable:</source>
         <translation>Variable B :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>b</source>
         <translation>b</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B Variable</source>
         <translation>Variable B</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>g</source>
         <translation>v</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G Variable</source>
         <translation>Variable V</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>r</source>
         <translation>r</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R Variable</source>
         <translation>Variable R</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Read Steering to Variable</source>
         <translation>Valeur de direction dans la variable</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Read the Steering value from the sensor.  This value is calculated internally and can directly be used to set turning values for the robot&apos;s motors. EXPECTED VALUES: -100 to 100 (-101=ERROR)</source>
         <translation>Lit la valeur de direction depuis le capteur. Cette valeur est calculée en interne et peut être directement utilisée pour régler les moteurs du robot. VALEURS ATTENDUES : -100 à 100 (-101 = ERREUR)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Send Mail</source>
         <translation>Envoyer un message au robot</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sends mail (message) to another robot. If Receiver name left empty, message will be sent to all connected robots</source>
         <translation>Envoie un message à un autre robot. Si le nom du destinataire est laissé vide, le message sera envoyé à tous les robots connectés</translation>
     </message>
     <message>
-        <location line="+863"/>
         <source>Wake Up Line Leader</source>
         <translation>Réveiller le capteur de ligne</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wakes the line leader to prepare for use.</source>
         <translation>Active le capteur de ligne pour le préparer à l&apos;utilisation.</translation>
     </message>
     <message>
-        <location line="-858"/>
-        <location line="+621"/>
         <source>Message type:</source>
         <translation>Type de message :</translation>
     </message>
     <message>
-        <location line="-613"/>
         <source>Message:</source>
         <translation>Message :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Receiver name:</source>
         <translation>Nom du destinataire :</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+605"/>
         <source>Mailbox name:</source>
         <translation>Nom de la boîte aux lettres :</translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>42</source>
         <translation>42</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+621"/>
         <source>Message type</source>
         <translation>Type de message</translation>
     </message>
     <message>
-        <location line="-620"/>
-        <location line="+619"/>
         <source>EV3MailBox</source>
         <translation>Boîte mail EV3</translation>
     </message>
     <message>
-        <location line="-619"/>
-        <location line="+619"/>
         <source>Mailbox name</source>
         <translation>Nom de la boîte mail</translation>
     </message>
     <message>
-        <location line="-607"/>
         <source>Ev3SensorBlock</source>
         <translation>Bloc capteur EV3</translation>
     </message>
     <message>
-        <location line="-1148"/>
-        <location line="+44"/>
-        <location line="+106"/>
-        <location line="+45"/>
-        <location line="+693"/>
-        <location line="+53"/>
-        <location line="+71"/>
-        <location line="+53"/>
-        <location line="+107"/>
-        <location line="+44"/>
-        <location line="+44"/>
-        <location line="+52"/>
-        <location line="+99"/>
-        <location line="+78"/>
-        <location line="+62"/>
-        <location line="+64"/>
-        <location line="+71"/>
-        <location line="+136"/>
-        <location line="+62"/>
-        <location line="+47"/>
-        <location line="+44"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>Wait for button</source>
         <translation>Attendre l&apos;appui sur un bouton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Attend que l&apos;on appuie sur un bouton du brick.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Button:</source>
         <translation>Bouton :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Button</source>
         <translation>Bouton</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Wait for Color</source>
         <translation>Attendre la couleur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the color sensor on the given port will recognize the given color.</source>
         <translation>Attend que le capteur de couleur sur le port indiqué détecte la couleur spécifiée.</translation>
     </message>
     <message>
-        <location line="-1394"/>
-        <location line="+44"/>
-        <location line="+44"/>
-        <location line="+107"/>
-        <location line="+685"/>
-        <location line="+53"/>
-        <location line="+53"/>
-        <location line="+71"/>
-        <location line="+159"/>
-        <location line="+44"/>
-        <location line="+44"/>
-        <location line="+97"/>
-        <location line="+54"/>
-        <location line="+79"/>
-        <location line="+63"/>
-        <location line="+63"/>
-        <location line="+142"/>
-        <location line="+65"/>
-        <location line="+63"/>
-        <location line="+45"/>
         <source>Port:</source>
         <translation>Port :</translation>
     </message>
     <message>
-        <location line="-1049"/>
         <source>Read the Weighted Average value from the sensor.  This value is calculated internally by the sensor where each of the eight sensors is either triggered or not and multiplied by a factor to help determine if the line is left, right or on center of the line (according to the set point). EXPECTED VALUES: 0-80 (-1=ERROR)</source>
         <translation>Lit la valeur de la moyenne pondérée du capteur. Cette valeur est calculée en interne par le capteur, où chacun des huit capteurs est activé ou non et multiplié par un facteur afin de déterminer si la ligne est à gauche, à droite ou au centre (selon le point de consigne). VALEURS ATTENDUES : 0-80 (-1=ERREUR)</translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Sleep Line Leader</source>
         <translation>Mettre le capteur de ligne en veille</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Puts the line leader to sleep conserve power</source>
         <translation>Met le capteur de ligne en veille pour économiser l&apos;énergie</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Start Compass Calibration</source>
         <translation>Démarrer l&apos;étalonnage du compas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Starts compass calibration under program control. To calibrate, robot needs to spin &gt;=540 clockwise and counterclockwise with minimum 20 seconds duration for each direction. Atfer robot rotation add Stop Compass Сalibration block.</source>
         <translation>Démarre l&apos;étalonnage du compas par programme. Pour étalonner, le robot doit effectuer une rotation d&apos;au moins 540 degrés dans le sens horaire puis antihoraire, pendant au moins 20 secondes dans chaque sens. Après la rotation, ajouter un bloc &apos;Arrêter l&apos;étalonnage du compas&apos;.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Stop Compass Calibration</source>
         <translation>Arrêter l&apos;étalonnage du compas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Ends compass calibration process. Stores result of calibration into the given variable. Not zero means success.</source>
         <translation>Termine le processus d&apos;étalonnage du compas. Stocke le résultat dans la variable indiquée. Une valeur non nulle signifie que l&apos;étalonnage a réussi.</translation>
     </message>
     <message>
-        <location line="+149"/>
         <source>Wait for Color Intensity</source>
         <translation>Attendre l&apos;intensité de couleur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the color sensor on the given port will be greater or less than the given in the &apos;Intensity&apos; parameter value (the intensity is specified in percents, 0 to 100).</source>
         <translation>Attend que la valeur renvoyée par le capteur de couleur sur le port indiqué soit supérieure ou inférieure à celle du paramètre &apos;Intensité&apos; (l&apos;intensité est exprimée en pourcentage, de 0 à 100).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Intensity:</source>
         <translation>Intensité :</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+79"/>
-        <location line="+63"/>
-        <location line="+63"/>
-        <location line="+143"/>
-        <location line="+64"/>
         <source>Sign:</source>
         <translation>Signe :</translation>
     </message>
     <message>
-        <location line="-371"/>
-        <location line="+197"/>
-        <location line="+136"/>
-        <location line="+65"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location line="-398"/>
         <source>Intensity</source>
         <translation>Intensité</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+62"/>
-        <location line="+64"/>
-        <location line="+71"/>
-        <location line="+136"/>
-        <location line="+62"/>
         <source>Sign</source>
         <translation>Signe</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Wait for Encoder</source>
         <translation>Attendre l&apos;encodeur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Attend que la limite du tachymètre du moteur sur le port indiqué atteigne la valeur du paramètre &apos;Limite tachymètre&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tacho Limit:</source>
         <translation>Limite tachymètre :</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Wait for Gyroscope</source>
         <translation>Attendre le gyroscope</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given.</source>
         <translation>Attend que la valeur renvoyée par le gyroscope sur le port indiqué soit supérieure ou inférieure à la valeur donnée.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Value:</source>
         <translation>Valeur :</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Light</source>
         <translation>Attendre la lumière</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Attend que la valeur renvoyée par le capteur de lumière sur le port indiqué soit supérieure ou inférieure à celle du paramètre &apos;Pourcentage&apos; (0 à 100).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Percents:</source>
         <translation>Pourcentage :</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Percents</source>
         <translation>Pourcentage</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Mail Receiving</source>
         <translation>Attendre la réception d&apos;un message</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Stores a message from another robot (fom mailbox) into a given variable. When no incoming messages are present at the moment, a robot will wait for incoming message if &apos;Synchronized&apos; property is true, and doing nothing otherwise.</source>
         <translation>Stocke un message provenant d&apos;un autre robot (de la boîte mail) dans une variable donnée. S&apos;il n&apos;y a pas de message entrant au moment présent, le robot attendra un message si la propriété &apos;Synchronisé&apos; est vraie, sinon il ne fait rien.</translation>
     </message>
     <message>
-        <location line="-783"/>
-        <location line="+124"/>
-        <location line="+247"/>
-        <location line="+435"/>
         <source>Variable:</source>
         <translation>Variable :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Synchronized:</source>
         <translation>Synchronisé :</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Synchronized</source>
         <translation>Synchronisé</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Range Sensor</source>
         <translation>Attendre le capteur de distance</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the ultrasonic or infrared range sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, 0 to 255).</source>
         <translation>Attend que la valeur renvoyée par le capteur de distance ultrasonique ou infrarouge sur le port indiqué soit supérieure ou inférieure à celle du paramètre &apos;Distance&apos; (la distance est exprimée en centimètres, de 0 à 255).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Distance:</source>
         <translation>Distance :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Sound Sensor</source>
         <translation>Attendre le capteur de son</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the loudness obtained by the sound sensor on the given port will be greater or less than the given value.</source>
         <translation>Attend que le niveau sonore mesuré par le capteur de son sur le port indiqué soit supérieur ou inférieur à la valeur donnée.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Wait for Touch Sensor</source>
         <translation>Attendre le capteur tactile</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Attend que le capteur tactile soit enfoncé. Le seul paramètre est le numéro du port du capteur (1, 2, 3 ou 4).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="-60"/>
         <source>RobotsDiagram</source>
         <translation>Diagramme de comportement du robot</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Actions</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Line Leader</source>
         <translation>Capteur de ligne</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Wait</source>
         <translation>Attendre</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Drawing</source>
         <translation>Dessin</translation>
     </message>
@@ -1320,18 +946,14 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="-762"/>
         <source>Receiver name</source>
         <translation>Nom du destinataire</translation>
     </message>
     <message>
-        <location line="+416"/>
         <source>Tacho Limit</source>
         <translation>Limite tachymètre</translation>
     </message>
     <message>
-        <location line="-240"/>
-        <location line="+445"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/editor/nxt_fr.ts
+++ b/qrtranslations/fr/plugins/robots/editor/nxt_fr.ts
@@ -4,209 +4,166 @@
 <context>
     <name>NxtMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="+138"/>
         <source>In</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Entrée-sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Valeur de retour</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+10"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>body</source>
         <translation>corps de la boucle</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+10"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>Enter</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Escape</source>
         <translation>Échap</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Right</source>
         <translation>Droite</translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>Concurrent</source>
         <translation>En parallèle</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Avec garde</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Séquentiel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>black</source>
         <translation>noir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>blue</source>
         <translation>bleu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>green</source>
         <translation>vert</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red</source>
         <translation>rouge</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>white</source>
         <translation>blanc</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yellow</source>
         <translation>jaune</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Composite</source>
         <translation>Composition</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Agrégation</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>brake</source>
         <translation>interrompre</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>greater</source>
         <translation>supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>inférieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>non supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>non inférieur</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Package</source>
         <translation>Par paquet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Privé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Protégé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Public</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>float</source>
         <translation>flottant</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>norm</source>
         <translation>norme</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>axe des x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>axe des y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>axe des z</translation>
     </message>
@@ -214,578 +171,398 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="+26"/>
         <source>Beep</source>
         <translation>Bip</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.</source>
         <translation>Émet un son à fréquence fixe sur le robot. Deux paramètres sont disponibles : le premier correspond au volume du son, le second indique si le programme doit attendre la fin du son avant de passer au bloc suivant ou non.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+578"/>
-        <location line="+485"/>
         <source>Volume:</source>
         <translation>Volume :</translation>
     </message>
     <message>
-        <location line="-1055"/>
-        <location line="+588"/>
         <source>Wait for Completion:</source>
         <translation>Attendre la fin :</translation>
     </message>
     <message>
-        <location line="-555"/>
-        <location line="+582"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location line="-582"/>
-        <location line="+582"/>
-        <location line="+475"/>
         <source>Volume</source>
         <translation>Volume</translation>
     </message>
     <message>
-        <location line="-1056"/>
-        <location line="+582"/>
         <source>Wait for Completion</source>
         <translation>Attendre la fin</translation>
     </message>
     <message>
-        <location line="-571"/>
         <source>Clear Encoder</source>
         <translation>Réinitialiser l&apos;encodeur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Remet à zéro la valeur du compteur de tours des moteurs sur les ports indiqués.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+343"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>Ports:</source>
         <translation>Ports :</translation>
     </message>
     <message>
-        <location line="-430"/>
-        <location line="+462"/>
         <source>A, B, C</source>
         <translation>A, B, C</translation>
     </message>
     <message>
-        <location line="-462"/>
-        <location line="+297"/>
-        <location line="+56"/>
-        <location line="+56"/>
-        <location line="+53"/>
         <source>Ports</source>
         <translation>Ports</translation>
     </message>
     <message>
-        <location line="-451"/>
         <source>Draw Circle</source>
         <translation>Dessiner un cercle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws on the robot screen a circle with the given center and radius.</source>
         <translation>Dessine un cercle sur l&apos;écran du robot avec le centre et le rayon indiqués.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+135"/>
-        <location line="+54"/>
         <source>X:</source>
         <translation>X :</translation>
     </message>
     <message>
-        <location line="-181"/>
-        <location line="+135"/>
-        <location line="+54"/>
         <source>Y:</source>
         <translation>Y :</translation>
     </message>
     <message>
-        <location line="-181"/>
         <source>Radius:</source>
         <translation>Rayon :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Radius</source>
         <translation>Rayon</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+70"/>
-        <location line="+56"/>
-        <location line="+71"/>
         <source>Redraw</source>
         <translation>Redessiner</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+126"/>
-        <location line="+72"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+126"/>
-        <location line="+72"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="-187"/>
         <source>Draw Line</source>
         <translation>Dessiner une ligne</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Dessine un segment sur l&apos;écran du robot. Les paramètres indiquent les extrémités du segment.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>X1:</source>
         <translation>X1 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y1:</source>
         <translation>Y1 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>X2:</source>
         <translation>X2 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y2:</source>
         <translation>Y2 :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Draw Pixel</source>
         <translation>Dessiner un pixel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Dessine un pixel aux coordonnées spécifiées sur l&apos;écran du robot.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Draw Rectangle</source>
         <translation>Dessiner un rectangle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Dessine un rectangle sur l&apos;écran du robot. Les paramètres indiquent les coordonnées du coin supérieur gauche, la largeur et la hauteur du rectangle.</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Width:</source>
         <translation>Largeur :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Height:</source>
         <translation>Hauteur :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>NxtEngineMovementCommand</source>
         <translation>Bloc moteur de base NXT</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>Mode</source>
         <translation>Mode</translation>
     </message>
     <message>
-        <location line="-111"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>B, C</source>
         <translation>B, C</translation>
     </message>
     <message>
-        <location line="-111"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location line="-112"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>Power (%)</source>
         <translation>Puissance (%)</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Motors Backward</source>
         <translation>Moteurs arrière</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Active les moteurs sur les ports indiqués en mode inverse avec la puissance donnée. Les ports sont spécifiés par les lettres A, B ou C, séparées par des virgules. La puissance est indiquée en pourcentage, avec une valeur de -100 à 100 ; si une valeur négative est indiquée, le moteur est activé en mode normal.</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+56"/>
         <source>Power:</source>
         <translation>Puissance :</translation>
     </message>
     <message>
-        <location line="-55"/>
-        <location line="+56"/>
-        <location line="+109"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location line="-127"/>
         <source>Motors Forward</source>
         <translation>Moteurs avant</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Active les moteurs sur les ports indiqués avec la puissance donnée. Les ports sont spécifiés par les lettres A, B ou C, séparées par des virgules. La puissance est indiquée en pourcentage, avec une valeur de -100 à 100 ; si une valeur négative est indiquée, le moteur est activé en mode inverse.</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Stop Motors</source>
         <translation>Arrêter les moteurs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Disables motors on the given ports.</source>
         <translation>Désactive les moteurs sur les ports indiqués.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Play Tone</source>
         <translation>Jouer un ton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Plays on the robot a sound with the given frequency and duration. This block is similar to the &apos;Beep&apos; block wuth the only difference that here you can specify sound parameters.</source>
         <translation>Joue sur le robot un son avec la fréquence et la durée indiquées. Ce bloc est similaire au bloc &apos;Bip&apos;, à la différence près que vous pouvez ici spécifier les paramètres du son.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Frequency:</source>
         <translation>Fréquence :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+34"/>
         <source>Duration</source>
         <translation>Durée</translation>
     </message>
     <message>
-        <location line="-33"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+1"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Frequency</source>
         <translation>Fréquence</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>NxtSensorBlock</source>
         <translation>Bloc capteur de base NXT</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+98"/>
-        <location line="+78"/>
-        <location line="+62"/>
-        <location line="+72"/>
-        <location line="+65"/>
-        <location line="+62"/>
-        <location line="+47"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Wait for Button</source>
         <translation>Attendre l&apos;appui sur un bouton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Attend l&apos;appui sur un bouton du bloc.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Button:</source>
         <translation>Bouton :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Button</source>
         <translation>Bouton</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Wait for Color</source>
         <translation>Attendre la couleur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the color sensor on the given port will recognize the given color.</source>
         <translation>Attend que le capteur de couleur sur le port indiqué reconnaisse la couleur spécifiée.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+54"/>
-        <location line="+79"/>
-        <location line="+63"/>
-        <location line="+71"/>
-        <location line="+65"/>
-        <location line="+63"/>
         <source>Port:</source>
         <translation>Port :</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Color:</source>
         <translation>Couleur :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Color Intensity</source>
         <translation>Attendre l&apos;intensité de couleur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the color sensor on the given port will be greater or less than the given in the &apos;Intensity&apos; parameter value (the intensity is specified in percents, 0 to 100).</source>
         <translation>Attend que la valeur retournée par le capteur de couleur sur le port indiqué soit supérieure ou inférieure à celle du paramètre &apos;Intensité&apos; (l&apos;intensité est indiquée en pourcentage, de 0 à 100).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Intensity:</source>
         <translation>Intensité :</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+79"/>
-        <location line="+63"/>
-        <location line="+72"/>
-        <location line="+64"/>
         <source>Sign:</source>
         <translation>Valeur lue :</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+134"/>
-        <location line="+65"/>
-        <location line="+65"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location line="-264"/>
         <source>Intensity</source>
         <translation>Intensité</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+62"/>
-        <location line="+72"/>
-        <location line="+65"/>
-        <location line="+62"/>
         <source>Sign</source>
         <translation>Valeur lue</translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Wait for Encoder</source>
         <translation>Attendre l&apos;encodeur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Attend que la limite du tachymètre du moteur sur le port indiqué atteigne la valeur du paramètre &apos;Limite du tachymètre&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tacho Limit:</source>
         <translation>Limite du tachymètre :</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Light</source>
         <translation>Attendre la lumière</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Attend que la valeur retournée par le capteur de lumière sur le port indiqué soit supérieure ou inférieure à celle du paramètre &apos;Pourcentages&apos; (0 à 100).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Percents:</source>
         <translation>Pourcentages :</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Percents</source>
         <translation>Pourcentages</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Sonar Distance</source>
         <translation>Attendre la distance du sonar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the ultrasonic sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, 0 to 255).</source>
         <translation>Attend que la valeur retournée par le capteur ultrasonore sur le port indiqué soit supérieure ou inférieure à celle du paramètre &apos;Distance&apos; (la distance est indiquée en centimètres, de 0 à 255).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Distance:</source>
         <translation>Distance :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Sound Sensor</source>
         <translation>Attendre le capteur de son</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the loudness obtained by the sound sensor on the given port will be greater or less than the given value.</source>
         <translation>Attend que le niveau sonore mesuré par le capteur de son sur le port indiqué soit supérieur ou inférieur à la valeur donnée.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Wait for Touch Sensor</source>
         <translation>Attendre le capteur de contact</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Attend que le capteur de contact soit enfoncé. Le seul paramètre est le numéro du port du capteur (1, 2, 3 ou 4).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="-41"/>
         <source>RobotsDiagram</source>
         <translation>Diagramme de comportement du robot</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Actions</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Wait</source>
         <translation>Attendre</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Drawing</source>
         <translation>Dessin</translation>
     </message>
@@ -793,7 +570,6 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="-212"/>
         <source>Tacho Limit</source>
         <translation>Limite du tachymètre</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/editor/pioneer_fr.ts
+++ b/qrtranslations/fr/plugins/robots/editor/pioneer_fr.ts
@@ -4,209 +4,166 @@
 <context>
     <name>PioneerMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="+132"/>
         <source>Concurrent</source>
         <translation>Concurrent</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Protégé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Séquentiel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>black</source>
         <translation>noir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>blue</source>
         <translation>bleu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>green</source>
         <translation>vert</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red</source>
         <translation>rouge</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>white</source>
         <translation>blanc</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yellow</source>
         <translation>jaune</translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>norm</source>
         <translation>normal</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>selon l&apos;axe x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>selon l&apos;axe y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>selon l&apos;axe z</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>brake</source>
         <translation>interrompre</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Altfu</source>
         <translation>Altfu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Input</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Output</source>
         <translation>Sortie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Package</source>
         <translation>Paquet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Privé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Protégé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Public</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>greater</source>
         <translation>supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>inférieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>non supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>non inférieur</translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>Composite</source>
         <translation>Composition</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Agrégation</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>In</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Entrée-sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Retour</translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+6"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>body</source>
         <translation>corps de la boucle</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+6"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>float</source>
         <translation>flottant</translation>
     </message>
@@ -214,616 +171,446 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="+26"/>
         <source>Landing</source>
         <translation>Atterrissage</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Orders quadcopter to land.</source>
         <translation>Ordonne au quadricoptère d&apos;atterrir.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Takeoff</source>
         <translation>Décollage</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Orders quadcopter to takeoff.</source>
         <translation>Ordonne au quadricoptère de décoller.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Go to point</source>
         <translation>Aller au point</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Orders quadcopter to fly to given coordinates.</source>
         <translation>Ordonne au quadricoptère de voler vers les coordonnées indiquées.</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Latitude:</source>
         <translation>Latitude&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Longitude:</source>
         <translation>Longitude&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Altitude:</source>
         <translation>Altitude&#xa0;:</translation>
     </message>
     <message>
-        <location line="+96"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+496"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location line="-570"/>
         <source>Altitude</source>
         <translation>Altitude</translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>Orders quadcopter to fly to given GPS coordinates.</source>
         <translation>Ordonne au quadricoptère de voler vers les coordonnées GPS indiquées.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Latitude</source>
         <translation>Latitude</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>600859810</source>
         <translation>600859810</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Longitude</source>
         <translation>Longitude</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>304206500</source>
         <translation>304206500</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Go to local point</source>
         <translation>Aller au point (CSL)</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+143"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>X:</source>
         <translation>X&#xa0;:</translation>
     </message>
     <message>
-        <location line="-321"/>
-        <location line="+143"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>Y:</source>
         <translation>Y&#xa0;:</translation>
     </message>
     <message>
-        <location line="-321"/>
-        <location line="+143"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>Z:</source>
         <translation>Z&#xa0;:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Time:</source>
         <translation>Temps&#xa0;:</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+133"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+133"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+133"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location line="-308"/>
         <source>GPIO Initialization</source>
         <translation>Initialisation GPIO</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+578"/>
-        <location line="+99"/>
         <source>Pin name:</source>
         <translation>Nom&#xa0;:</translation>
     </message>
     <message>
-        <location line="-669"/>
         <source>Port:</source>
         <translation>Port&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Pin:</source>
         <translation>Broche&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mode:</source>
         <translation>Mode&#xa0;:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Mode</source>
         <translation>Mode</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pin</source>
         <translation>Numéro de la broche</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+560"/>
-        <location line="+91"/>
         <source>pin_name</source>
         <translation>nom_broche</translation>
     </message>
     <message>
-        <location line="-651"/>
-        <location line="+560"/>
-        <location line="+91"/>
         <source>Pin name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location line="-650"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get Accelerometer</source>
         <translation>Lire l&apos;accéléromètre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns accelerometer.</source>
         <translation>Retourne les données de l&apos;accéléromètre du quadricoptère selon les trois axes.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>aX</source>
         <translation>aX</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>aY</source>
         <translation>aY</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>aZ</source>
         <translation>aZ</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get Gyroscope</source>
         <translation>Lire le gyroscope</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns gyroscope.</source>
         <translation>Retourne les données du gyroscope du quadricoptère selon les trois axes.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>gX</source>
         <translation>gX</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>gY</source>
         <translation>gY</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>gZ</source>
         <translation>gZ</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get LPS Position</source>
         <translation>Obtenir la position (CSL)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns position (local positioning system).</source>
         <translation>Retourne la position actuelle dans le système de coordonnées local.</translation>
     </message>
     <message>
-        <location line="+47"/>
-        <location line="+376"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location line="-375"/>
         <source>y</source>
         <translation>y</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>z</source>
         <translation>z</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get LPS Velocity</source>
         <translation>Lire le vecteur vitesse (CSL)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns velocity (local position system).</source>
         <translation>Retourne les valeurs actuelles de vitesse dans le système de coordonnées local.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>velX</source>
         <translation>velX</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>velY</source>
         <translation>velY</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>velZ</source>
         <translation>velZ</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get LPS Yaw</source>
         <translation>Lire l&apos;angle de lacet (CSL)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns yaw (local position system).</source>
         <translation>Retourne l&apos;angle de lacet actuel dans le système de coordonnées local.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Yaw:</source>
         <translation>Lacet&#xa0;:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>yaw</source>
         <translation>lacet</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get Orientation</source>
         <translation>Lire les données d&apos;orientation</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns orientation.</source>
         <translation>Retourne les données d&apos;orientation du quadricoptère dans l&apos;espace - roulis, tangage, lacet.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Roll:</source>
         <translation>Roulis&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Pitch:</source>
         <translation>Tangage&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Azimuth:</source>
         <translation>Lacet&#xa0;:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>azimuth</source>
         <translation>lacet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Azimuth</source>
         <translation>Lacet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pitch</source>
         <translation>tangage</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Pitch</source>
         <translation>Tangage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>roll</source>
         <translation>roulis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Roll</source>
         <translation>Roulis</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Sets the color of the specified LED on a quadcopter.</source>
         <translation>Définit la couleur de la LED spécifiée sur un quadricoptère.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Number:</source>
         <translation>Numéro&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Red:</source>
         <translation>Rouge&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Green:</source>
         <translation>Vert&#xa0;:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Blue:</source>
         <translation>Bleu&#xa0;:</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1"/>
-        <location line="+2"/>
-        <location line="+314"/>
         <source>0.0</source>
         <translation>0,0</translation>
     </message>
     <message>
-        <location line="-317"/>
         <source>Blue</source>
         <translation>Bleu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Number</source>
         <translation>Numéro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Read GPIO</source>
         <translation>Lire la valeur GPIO</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns GPIO value.</source>
         <translation>Retourne la valeur d&apos;état GPIO.</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Read Range Sensor</source>
         <translation>Lire le télémètre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reads distance from rangefinder.</source>
         <translation>Lit les informations du télémètre.</translation>
     </message>
     <message>
-        <location line="-38"/>
-        <location line="+45"/>
         <source>Variable:</source>
         <translation>Variable&#xa0;:</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Angle (degrees)</source>
         <translation>Angle (degrés)</translation>
     </message>
     <message>
-        <location line="-180"/>
-        <location line="+46"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dist</source>
         <translation>dist</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Set GPIO state</source>
         <translation>Définir l&apos;état GPIO</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set GPIO value in &quot;true/false&quot;.</source>
         <translation>Définit l&apos;état GPIO à &quot;vrai/faux&quot;.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>System</source>
         <translation>Commande</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Executes given Lua script.</source>
         <translation>Exécute la chaîne donnée en langage Lua sur le quadricoptère.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Command:</source>
         <translation>Commande&#xa0;:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>print(&apos;Hello&apos;)</source>
         <translation>print(&apos;Bonjour&apos;)</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Command</source>
         <translation>Commande</translation>
     </message>
     <message>
-        <location line="-403"/>
-        <location line="+415"/>
         <source>Yaw</source>
         <translation>Lacet</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets yaw for quadcopter</source>
         <translation>Définit le lacet du quadricoptère. Le paramètre &quot;angle&quot; est donné en degrés</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Angle:</source>
         <translation>Angle&#xa0;:</translation>
     </message>
     <message>
-        <location line="-210"/>
-        <location line="+190"/>
         <source>Evaluate</source>
         <translation>Calculer</translation>
     </message>
     <message>
-        <location line="-754"/>
         <source>Create GPIO in settings port.</source>
         <translation>Crée un GPIO sur le port avec les paramètres indiqués.</translation>
     </message>
     <message>
-        <location line="+495"/>
         <source>Magnet</source>
         <translation>Aimant</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Controls magnet on a quadcopter.</source>
         <translation>Contrôle l&apos;aimant sur un quadricoptère.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+189"/>
         <source>State on</source>
         <translation>Activé</translation>
     </message>
     <message>
-        <location line="-178"/>
         <source>Print</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Prints given string on a console.</source>
         <translation>Affiche la chaîne fournie dans la console.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Text:</source>
         <translation>Texte&#xa0;:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Enter some text here</source>
         <translation>Saisissez un texte ici</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location line="-142"/>
         <source>Led</source>
         <translation>LED</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="-42"/>
         <source>RobotsDiagram</source>
         <translation>Diagramme</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Actions</translation>
     </message>
@@ -831,7 +618,6 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="-439"/>
         <source>Time</source>
         <translation>Temps</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/editor/trik_fr.ts
+++ b/qrtranslations/fr/plugins/robots/editor/trik_fr.ts
@@ -4,1259 +4,846 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="+26"/>
         <source>TrikAnalogSensorBlock</source>
         <translation>Capteur analogique TRIK</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+226"/>
-        <location line="+512"/>
-        <location line="+944"/>
-        <location line="+413"/>
-        <location line="+119"/>
-        <location line="+71"/>
-        <location line="+158"/>
-        <location line="+46"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
-        <location line="-2478"/>
-        <location line="+1522"/>
         <source>Angular Servo</source>
         <translation>Servomoteur angulaire</translation>
     </message>
     <message>
-        <location line="-1520"/>
-        <location line="+1522"/>
         <source>Manages angular servomotor. Sets up rotation angle on the given port in degrees. Values from 0 to 90 are correspond to a clockwise rotation and values from -90 to 0 correspond to counterclockwise rotation.</source>
         <translation>Gère le servomoteur angulaire. Définit l&apos;angle de rotation sur le port donné en degrés. Les valeurs de 0 à 90 correspondent à une rotation dans le sens horaire, les valeurs de -90 à 0 correspondent à une rotation dans le sens antihoraire.</translation>
     </message>
     <message>
-        <location line="-1515"/>
-        <location line="+1522"/>
-        <location line="+54"/>
-        <location line="+108"/>
-        <location line="+81"/>
-        <location line="+55"/>
-        <location line="+55"/>
         <source>Ports:</source>
         <translation>Ports :</translation>
     </message>
     <message>
-        <location line="-1867"/>
-        <location line="+1522"/>
-        <location line="+1101"/>
         <source>Angle:</source>
         <translation>Angle :</translation>
     </message>
     <message>
-        <location line="-2622"/>
-        <location line="+1522"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location line="-1498"/>
         <source>E1</source>
         <translation>E1</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+1522"/>
-        <location line="+46"/>
-        <location line="+108"/>
-        <location line="+35"/>
-        <location line="+55"/>
-        <location line="+55"/>
-        <location line="+54"/>
         <source>Ports</source>
         <translation>Ports</translation>
     </message>
     <message>
-        <location line="-1874"/>
-        <location line="+261"/>
-        <location line="+1"/>
-        <location line="+72"/>
-        <location line="+1"/>
-        <location line="+69"/>
-        <location line="+2"/>
-        <location line="+127"/>
-        <location line="+1"/>
-        <location line="+988"/>
-        <location line="+412"/>
-        <location line="+162"/>
-        <location line="+63"/>
-        <location line="+71"/>
-        <location line="+158"/>
-        <location line="+241"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location line="-2629"/>
-        <location line="+1522"/>
         <source>Angle (degrees)</source>
         <translation>Angle (degrés)</translation>
     </message>
     <message>
-        <location line="-1476"/>
-        <location line="+11"/>
         <source>Detect by Videocamera</source>
         <translation>Détecter par caméra vidéo</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Initializes videocamera line or object detector with the color of the object in the middle of the camera`s sight.</source>
         <translation>Initialise le détecteur de ligne ou d&apos;objet par caméra vidéo avec la couleur de l&apos;objet situé au centre du champ de vision de la caméra.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+499"/>
-        <location line="+795"/>
         <source>Mode:</source>
         <translation>Mode :</translation>
     </message>
     <message>
-        <location line="-1263"/>
-        <location line="+500"/>
-        <location line="+794"/>
-        <location line="+493"/>
         <source>Mode</source>
         <translation>Mode</translation>
     </message>
     <message>
-        <location line="-1776"/>
-        <location line="+3"/>
         <source>Line Detector into Variable</source>
         <translation>Détecteur de ligne dans une variable</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Stores videocamera line detector`s value into a given variable.</source>
         <translation>Stocke la valeur du détecteur de ligne par caméra vidéo dans une variable donnée.</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+809"/>
-        <location line="+1330"/>
         <source>Variable:</source>
         <translation>Variable :</translation>
     </message>
     <message>
-        <location line="-2115"/>
         <source>err</source>
         <translation>err</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+809"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location line="-798"/>
         <source>TrikDigitalSensorBlock</source>
         <translation>Bloc de base des capteurs numériques TRIK</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Draw Arc</source>
         <translation>Dessiner un arc</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws the arc defined by the rectangle beginning at (x, y) with the specified width and height, and the given startAngle and spanAngle.</source>
         <translation>Dessine sur l&apos;écran un arc délimité par un rectangle dont le coin supérieur gauche est situé aux coordonnées (x, y), avec une largeur et une hauteur spécifiées, ainsi qu&apos;un angle de départ et un angle d&apos;ouverture donnés.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+90"/>
-        <location line="+145"/>
-        <location line="+54"/>
-        <location line="+368"/>
         <source>X:</source>
         <translation>X :</translation>
     </message>
     <message>
-        <location line="-649"/>
-        <location line="+90"/>
-        <location line="+145"/>
-        <location line="+54"/>
-        <location line="+368"/>
         <source>Y:</source>
         <translation>Y :</translation>
     </message>
     <message>
-        <location line="-649"/>
-        <location line="+90"/>
-        <location line="+199"/>
-        <location line="+771"/>
         <source>Width:</source>
         <translation>Largeur :</translation>
     </message>
     <message>
-        <location line="-1052"/>
-        <location line="+90"/>
-        <location line="+199"/>
         <source>Height:</source>
         <translation>Hauteur :</translation>
     </message>
     <message>
-        <location line="-281"/>
         <source>Start Angle:</source>
         <translation>Angle de départ :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Span Angle:</source>
         <translation>Angle d&apos;ouverture :</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+4"/>
-        <location line="+71"/>
-        <location line="+2"/>
-        <location line="+127"/>
-        <location line="+1"/>
-        <location line="+69"/>
-        <location line="+2"/>
         <source>5</source>
         <translation>5</translation>
     </message>
     <message>
-        <location line="-276"/>
-        <location line="+75"/>
-        <location line="+199"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
     <message>
-        <location line="-273"/>
-        <location line="+75"/>
-        <location line="+71"/>
-        <location line="+56"/>
-        <location line="+72"/>
-        <location line="+369"/>
-        <location line="+304"/>
         <source>Redraw</source>
         <translation>Redessiner</translation>
     </message>
     <message>
-        <location line="-946"/>
         <source>SpanAngle</source>
         <translation>Angle d&apos;ouverture</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>StartAngle</source>
         <translation>Angle de départ</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+73"/>
-        <location line="+199"/>
-        <location line="+760"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="-1031"/>
-        <location line="+73"/>
-        <location line="+126"/>
-        <location line="+73"/>
-        <location line="+368"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="-639"/>
-        <location line="+73"/>
-        <location line="+126"/>
-        <location line="+73"/>
-        <location line="+368"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="-629"/>
         <source>Draw Ellipse</source>
         <translation>Dessiner une ellipse</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws the ellipse defined by the rectangle beginning at (x, y) with the given width and height.</source>
         <translation>Dessine sur l&apos;écran une ellipse délimitée par un rectangle dont le coin supérieur gauche est situé aux coordonnées (x, y), avec une largeur et une hauteur données.</translation>
     </message>
     <message>
-        <location line="+55"/>
-        <location line="+199"/>
         <source>Filled</source>
         <translation>Rempli</translation>
     </message>
     <message>
-        <location line="-183"/>
         <source>Draw Line</source>
         <translation>Dessiner une ligne</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Dessine un segment sur l&apos;écran du robot. Les paramètres indiquent les extrémités du segment.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>X1:</source>
         <translation>X1 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y1:</source>
         <translation>Y1 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>X2:</source>
         <translation>X2 :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y2:</source>
         <translation>Y2 :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+2"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Draw Pixel</source>
         <translation>Dessiner un pixel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Dessine un pixel aux coordonnées spécifiées sur l&apos;écran du robot.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Draw Rectangle</source>
         <translation>Dessiner un rectangle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Dessine un rectangle sur l&apos;écran du robot. Les paramètres indiquent les coordonnées du coin supérieur gauche, la largeur et la hauteur du rectangle.</translation>
     </message>
     <message>
-        <location line="+71"/>
-        <location line="+11"/>
         <source>Initialize Videocamera</source>
         <translation>Initialiser la caméra vidéo</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Enables line or object or color detector by videocamera and draws videostream on the robot`s screen.</source>
         <translation>Active le détecteur de ligne, d&apos;objet ou de couleur par caméra vidéo et affiche le flux vidéo sur l&apos;écran du robot.</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
         <source>Enable Video Streaming</source>
         <translation>Activer le flux vidéo</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Enables video stream on robot. Video then can be watched on TRIK gamepad or in browser using URL http://ROBOT.IP.ADDRESS:8080/?action=stream</source>
         <translation>Active le flux vidéo sur le robot. La vidéo peut ensuite être visualisée sur la manette TRIK ou dans un navigateur via l&apos;URL http://ADRESSE.IP.ROBOT:8080/?action=stream</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Grayscaled</source>
         <translation>Niveaux de gris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quality</source>
         <translation>Qualité</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Sets the hull number and connects with a peer by a (host)name or an IP-address. Target IP-port can be changed too if required.</source>
         <translation>Définit le numéro de coque et établit une connexion avec un appareil distant via un nom (hôte) ou une adresse IP. Le port IP cible peut également être modifié si nécessaire.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Led</source>
         <translation>LED</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the color of the LED on the robot`s front panel.</source>
         <translation>Définit la couleur de la LED située sur le panneau avant du robot.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+475"/>
-        <location line="+45"/>
         <source>Color:</source>
         <translation>Couleur :</translation>
     </message>
     <message>
-        <location line="-495"/>
-        <location line="+474"/>
-        <location line="+45"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location line="-463"/>
         <source>Play Tone</source>
         <translation>Jouer un ton</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Plays on the robot a sound file (.wav or .mp3) previously uploaded to it.</source>
         <translation>Lecture sur le robot d&apos;un fichier sonore (.wav ou .mp3) préalablement chargé.</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>Play Sound</source>
         <translation>Jouer un son</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File name:</source>
         <translation>Nom du fichier :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>media/beep.wav</source>
         <translation>media/beep.wav</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>File Name</source>
         <translation>Nom du fichier</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Plays on the robot a sound with the given frequency and duration.</source>
         <translation>Émet un son sur le robot avec une fréquence et une durée données.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Frequency:</source>
         <translation>Fréquence :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Duration</source>
         <translation>Durée</translation>
     </message>
     <message>
-        <location line="-24"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location line="-793"/>
         <source>Calibrate gyroscope</source>
         <translation>Calibrer le gyroscope</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets gyroscope&apos;s angle to zero in current position.</source>
         <translation>Réinitialise l&apos;angle du gyroscope à zéro dans la position actuelle.</translation>
     </message>
     <message>
-        <location line="+572"/>
         <source>Draw stream</source>
         <translation>Afficher le flux</translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Duration:</source>
         <translation>Durée :</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Frequency</source>
         <translation>Fréquence</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Remove File</source>
         <translation>Supprimer le fichier</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Removes a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
         <translation>Supprime un fichier. Le chemin du fichier peut être absolu ou relatif au répertoire contenant l&apos;exécutable de TRIK Studio.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1735"/>
         <source>File:</source>
         <translation>Fichier :</translation>
     </message>
     <message>
-        <location line="-1711"/>
-        <location line="+1743"/>
         <source>output.txt</source>
         <translation>output.txt</translation>
     </message>
     <message>
-        <location line="-1743"/>
-        <location line="+1743"/>
         <source>File</source>
         <translation>Fichier</translation>
     </message>
     <message>
-        <location line="-1732"/>
         <source>Sad Smile</source>
         <translation>Smiley triste</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a sad smile on the robot`s screen :(</source>
         <translation>Affiche un smiley triste sur l&apos;écran du robot :(</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Say</source>
         <translation>Dire</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Synthesizes the given phrase and plays it on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Text&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
         <translation>Synthétise la phrase donnée et la joue sur le robot. Si la propriété « Évaluer » est activée, la valeur de la propriété « Texte » est interprétée comme une formule, sinon elle est traitée comme une chaîne de caractères simple.</translation>
     </message>
     <message>
-        <location line="-175"/>
-        <location line="+182"/>
-        <location line="+1662"/>
         <source>Text:</source>
         <translation>Texte :</translation>
     </message>
     <message>
-        <location line="-1812"/>
-        <location line="+174"/>
-        <location line="+397"/>
         <source>Evaluate</source>
         <translation>Évaluer</translation>
     </message>
     <message>
-        <location line="-396"/>
         <source>Hi!</source>
         <translation>Bonjour !</translation>
     </message>
     <message>
-        <location line="-173"/>
-        <location line="+173"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Send message</source>
         <translation>Envoyer un message</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sends message to another robot.</source>
         <translation>Envoie un message à un autre robot.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message:</source>
         <translation>Message :</translation>
     </message>
     <message>
-        <location line="-434"/>
-        <location line="+442"/>
         <source>Hull number:</source>
         <translation>Numéro de coque :</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>TrikSensorBlock</source>
         <translation>Bloc de base des capteurs TRIK</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Background Color</source>
         <translation>Couleur de fond</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the background color of the current picture on the robot`s screen.</source>
         <translation>Définit la couleur de fond de l&apos;image actuelle sur l&apos;écran du robot.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Painter Color</source>
         <translation>Couleur du pinceau</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the painter color.</source>
         <translation>Définit la couleur du pinceau.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Painter Width</source>
         <translation>Épaisseur du pinceau</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the painter width.</source>
         <translation>Définit l&apos;épaisseur du pinceau.</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+1"/>
-        <location line="+390"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location line="-452"/>
         <source>Print Text</source>
         <translation>Afficher du texte</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Prints a given line in the specified coordinates and font size on the robot`s screen. The value of &apos;Text&apos; property is interpreted as a plain text unless &apos;Evaluate&apos; property is set to true, then it will be interpreted as an expression (that may be useful for example when debugging variables values).</source>
         <translation>Affiche une ligne de texte aux coordonnées et à la taille de police spécifiées sur l&apos;écran du robot. La valeur de la propriété « Texte » est interprétée comme un texte brut, sauf si la propriété « Évaluer » est activée, auquel cas elle est traitée comme une expression (ce qui peut être utile, par exemple, lors du débogage des valeurs des variables).</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Font size:</source>
         <translation>Taille de police :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>20</source>
         <translation>20</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Font size</source>
         <translation>Taille de police</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter some text here</source>
         <translation>Saisissez un texte ici</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Read Lidar To Variable</source>
         <translation>Lire le LIDAR dans une variable</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Assigns a value from lidar to a given variable.</source>
         <translation>Affecte une valeur provenant du LIDAR à une variable donnée.</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location line="+357"/>
         <source>Smile</source>
         <translation>Smiley</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a smile on the robot`s screen :)</source>
         <translation>Affiche un smiley sur l&apos;écran du robot :)</translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location line="+11"/>
         <source>Stop Videocamera</source>
         <translation>Arrêter la caméra vidéo</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Stops line or object or color detector by videocamera.</source>
         <translation>Arrête le détecteur de ligne, d&apos;objet ou de couleur par caméra vidéo.</translation>
     </message>
     <message>
-        <location line="+49"/>
-        <location line="+3"/>
         <source>Disable Video Streaming</source>
         <translation>Désactiver le flux vidéo</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Disables video stream on robot.</source>
         <translation>Désactive le flux vidéo sur le robot.</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>System Call</source>
         <translation>Appel système</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Invokes bash script-style command on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Command&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
         <translation>Exécute une commande de type script bash sur le robot. Si la propriété « Évaluer » est activée, la valeur de la propriété « Commande » est interprétée comme une formule, sinon elle est traitée comme une chaîne de caractères simple.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Command:</source>
         <translation>Commande :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Code</source>
         <translation>Code</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>echo 123</source>
         <translation>echo 123</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Command</source>
         <translation>Commande</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>S1</source>
         <translation>S1</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+108"/>
         <source>Clear Encoder</source>
         <translation>Réinitialiser l&apos;encodeur</translation>
     </message>
     <message>
-        <location line="-106"/>
-        <location line="+108"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Remet à zéro la limite de compteur des moteurs sur les ports donnés.</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>E1, E2, E3, E4</source>
         <translation>E1, E2, E3, E4</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location line="+413"/>
         <source>Wait for Encoder</source>
         <translation>Attendre l&apos;encodeur</translation>
     </message>
     <message>
-        <location line="-411"/>
-        <location line="+413"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Attend que la limite de compteur du moteur sur le port donné atteigne la valeur du paramètre « Limite de compteur ».</translation>
     </message>
     <message>
-        <location line="-406"/>
-        <location line="+413"/>
-        <location line="+117"/>
-        <location line="+64"/>
-        <location line="+124"/>
-        <location line="+43"/>
-        <location line="+62"/>
         <source>Port:</source>
         <translation>Port :</translation>
     </message>
     <message>
-        <location line="-1769"/>
         <source>Join Network</source>
         <translation>Rejoindre le réseau</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Address:</source>
         <translation>Adresse :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>192.168.77.1</source>
         <translation>192.168.77.1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hull Number</source>
         <translation>Numéro de coque</translation>
     </message>
     <message>
-        <location line="+912"/>
-        <location line="+413"/>
         <source>Tacho Limit:</source>
         <translation>Limite de compteur :</translation>
     </message>
     <message>
-        <location line="-405"/>
-        <location line="+299"/>
-        <location line="+114"/>
-        <location line="+55"/>
-        <location line="+62"/>
-        <location line="+64"/>
-        <location line="+167"/>
-        <location line="+241"/>
         <source>Sign:</source>
         <translation>Valeur lue :</translation>
     </message>
     <message>
-        <location line="-976"/>
-        <location line="+307"/>
-        <location line="+106"/>
-        <location line="+55"/>
-        <location line="+64"/>
-        <location line="+71"/>
-        <location line="+158"/>
-        <location line="+240"/>
         <source>Sign</source>
         <translation>Valeur lue</translation>
     </message>
     <message>
-        <location line="-955"/>
         <source>B1, B2, B3, B4</source>
         <translation>B1, B2, B3, B4</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>TrikV6EngineMovementCommand</source>
         <translation>Bloc moteurs de base TRIK v6</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+55"/>
-        <location line="+55"/>
         <source>M3, M4</source>
         <translation>M3, M4</translation>
     </message>
     <message>
-        <location line="-109"/>
-        <location line="+55"/>
-        <location line="+55"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location line="-110"/>
-        <location line="+55"/>
-        <location line="+55"/>
         <source>Power (%)</source>
         <translation>Puissance (%)</translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Motors Backward</source>
         <translation>Moteurs arrière</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified in accordance with TRIK controller notations (for example M1, E2) and divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Active les moteurs sur les ports indiqués en mode inverse avec la puissance indiquée. Les ports sont spécifiés selon la notation du contrôleur TRIK (par exemple M1, E2) et séparés par des virgules. La puissance est indiquée en pourcentage par un nombre de -100 à 100 ; si un nombre négatif est spécifié, le moteur est activé en mode normal.</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+55"/>
         <source>Power:</source>
         <translation>Puissance :</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Motors Forward</source>
         <translation>Moteurs avant</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports with the given power. Ports are specified in accordance with TRIK controller notations (for example M1, E2) and divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Active les moteurs sur les ports indiqués avec la puissance indiquée. Les ports sont spécifiés selon la notation du contrôleur TRIK (par exemple M1, E2) et séparés par des virgules. La puissance est indiquée en pourcentage par un nombre de -100 à 100 ; si un nombre négatif est spécifié, le moteur est activé en mode inverse.</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Stop Motors</source>
         <translation>Arrêter les moteurs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Disables motors on the given ports.</source>
         <translation>Désactive les moteurs sur les ports indiqués.</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>M1, M2, M3, M4</source>
         <translation>M1, M2, M3, M4</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Wait for Accelerometer</source>
         <translation>Attendre l&apos;accéléromètre</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Acceleration:</source>
         <translation>Accélération :</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Axis:</source>
         <translation>Axe :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Acceleration</source>
         <translation>Accélération</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Acceleration Axis</source>
         <translation>Axe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Button</source>
         <translation>Attendre l&apos;appui sur un bouton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Attend l&apos;appui sur un bouton du boîtier du robot.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+506"/>
         <source>Button:</source>
         <translation>Bouton :</translation>
     </message>
     <message>
-        <location line="-482"/>
-        <location line="+506"/>
         <source>Button</source>
         <translation>Bouton</translation>
     </message>
     <message>
-        <location line="-432"/>
         <source>Wait for Gyroscope</source>
         <translation>Attendre le gyroscope</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;Degrees&apos; parameter value.</source>
         <translation>Attend que la valeur retournée par le gyroscope sur le port indiqué soit supérieure ou inférieure à celle du paramètre &apos;Degrés&apos;.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Degrees:</source>
         <translation>Degrés :</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Degrees</source>
         <translation>Degrés</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Infrared Distance</source>
         <translation>Attendre le capteur de distance infrarouge</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the infrared sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value. By default on ports A1 and A2 the distance is specified in centimeters (from 0 to 100). It is not recommended to plug IR sensor into other ports because its raw value will be processed by software on robot with expectation of another sensor type.</source>
         <translation>Attend que la distance retournée par le capteur infrarouge ne soit pas comparable à celle indiquée dans le paramètre &apos;Distance&apos;. Un autre paramètre est le numéro du port auquel le capteur est connecté. L&apos;opération de comparaison avec la distance saisie est également spécifiée en paramètre. Par défaut, sur les ports A1 et A2, la distance est indiquée en centimètres (de 0 à 100). Il n&apos;est pas recommandé de brancher le capteur IR sur d&apos;autres ports car sa valeur brute sera traitée par le logiciel du robot en supposant un autre type de capteur.</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+231"/>
         <source>Distance:</source>
         <translation>Distance :</translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+229"/>
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location line="-216"/>
         <source>Wait for Light</source>
         <translation>Attendre la lumière</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Attend que la valeur retournée par le capteur de lumière sur le port indiqué soit supérieure ou inférieure à celle du paramètre &apos;Pourcentages&apos; (0 à 100).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Percents:</source>
         <translation>Pourcentages :</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Percents</source>
         <translation>Pourcentages</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Message</source>
         <translation>Recevoir un message</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Stores a message from another robot into a given variable. When no incoming messages are present at the moment, a robot will wait for incoming message if &apos;Synchronized&apos; property is true, and empty string will be assigned to a variable otherwise.</source>
         <translation>Stocke un message provenant d&apos;un autre robot dans une variable donnée. Si la propriété &quot;Attendre le message&quot; est activée, le robot attendra lorsqu&apos;aucun message n&apos;est disponible ; sinon, une chaîne vide est affectée à la variable.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Synchronized:</source>
         <translation>Attendre le message :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Synchronized</source>
         <translation>Attendre le message</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Motion</source>
         <translation>Attendre le mouvement</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the motion sensor on the given port is triggered.</source>
         <translation>Attend que le capteur de mouvement sur le port indiqué soit activé.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Wait for Ultrasonic Distance</source>
         <translation>Attendre le capteur de distance ultrasonore</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the ultrasonic sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, from 0 to 300).</source>
         <translation>Attend que la distance retournée par le capteur ultrasonore ne soit pas comparable à celle indiquée dans le paramètre &apos;Distance&apos; (la distance est indiquée en centimètres, de 0 à 300). Un autre paramètre est le numéro du port auquel le capteur de distance est connecté. L&apos;opération de comparaison avec la distance saisie est également spécifiée en paramètre.</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Wait for Touch Sensor</source>
         <translation>Attendre le capteur de contact</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Attend que le capteur de contact soit activé. Le paramètre est le numéro du port auquel le capteur est connecté. Valeurs autorisées : 1, 2, 3, 4.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Wait Gamepad Button</source>
         <translation>Attendre le bouton de la manette</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for Android gamepad &apos;magic button&apos; press. Buttons are identified by numbers from 1 to 5 (from left to right)</source>
         <translation>Attend l&apos;appui sur l&apos;un des &apos;boutons magiques&apos; de la manette Android. Les boutons sont identifiés par des numéros de 1 à 5 (de gauche à droite)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait gamepad button</source>
         <translation>Attendre le bouton de la manette</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+3"/>
         <source>Wait for Gamepad Connect</source>
         <translation>Attendre la connexion de la manette</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Waits until Android gamepad is connected.</source>
         <translation>Attend que la manette Android soit connectée.</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
         <source>Wait for Gamepad Disconnect</source>
         <translation>Attendre la déconnexion de la manette</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Waits until Android gamepad is disconnected.</source>
         <translation>Attend que la manette Android soit déconnectée.</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
         <source>Wait for Gamepad Wheel</source>
         <translation>Attendre le &apos;volant&apos; de la manette</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Waits till the value returned by gamepad wheel be greater or less than the given in the &apos;Angle&apos; parameter value. Angle is measured from -100 (max left) to 100 (max right).</source>
         <translation>Attend que la valeur retournée par le &apos;volant&apos; de la manette ne soit pas supérieure (ou inférieure) à la valeur indiquée. L&apos;angle est mesuré de -100 (extrême gauche) à 100 (extrême droite).</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Angle</source>
         <translation>Angle</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait Pad Press</source>
         <translation>Attendre l&apos;appui sur la manette</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for Android gamepad pad press (left pad has number 1, right pad - number 2).</source>
         <translation>Attend l&apos;appui sur l&apos;une des zones actives de la manette Android. La zone gauche a le numéro 1, la droite le numéro 2.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait pad press</source>
         <translation>Attendre l&apos;appui sur la manette</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Pad:</source>
         <translation>Manette :</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Pad</source>
         <translation>Manette</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Write To File</source>
         <translation>Écrire dans un fichier</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
         <translation>Écrit la valeur indiquée dans un fichier. Le chemin du fichier peut être absolu ou relatif au dossier contenant trik-studio.exe.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="+160"/>
         <source>RobotsDiagram</source>
         <translation>Diagramme de comportement du robot</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Actions</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Wait</source>
         <translation>Attente</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Drawing</source>
         <translation>Dessin</translation>
     </message>
@@ -1264,28 +851,22 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="-1570"/>
         <source>Hull Number</source>
         <translation>Numéro de coque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
-        <location line="+505"/>
-        <location line="+413"/>
         <source>Tacho Limit</source>
         <translation>Limite de tours</translation>
     </message>
     <message>
-        <location line="+242"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location line="+449"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
@@ -1293,389 +874,302 @@
 <context>
     <name>TrikMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="+40"/>
         <source>E1</source>
         <translation>E1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E2</source>
         <translation>E2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E3</source>
         <translation>E3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E4</source>
         <translation>E4</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>greater</source>
         <translation>supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>inférieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>pas supérieur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>pas inférieur</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+6"/>
         <source>black</source>
         <translation>noir</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
         <source>blue</source>
         <translation>bleu</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
-        <location line="+14"/>
         <source>green</source>
         <translation>vert</translation>
     </message>
     <message>
-        <location line="-20"/>
-        <location line="+6"/>
-        <location line="+14"/>
         <source>red</source>
         <translation>rouge</translation>
     </message>
     <message>
-        <location line="-20"/>
-        <location line="+6"/>
         <source>white</source>
         <translation>blanc</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
         <source>yellow</source>
         <translation>jaune</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Color sensor</source>
         <translation>Capteur de couleur</translation>
     </message>
     <message>
-        <location line="-22"/>
-        <location line="+22"/>
         <source>Line sensor</source>
         <translation>Capteur de ligne</translation>
     </message>
     <message>
-        <location line="-22"/>
-        <location line="+22"/>
         <source>Object sensor</source>
         <translation>Capteur d&apos;objet</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>norm</source>
         <translation>norme</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>axe x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>axe y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>axe z</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>In</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Entrée-sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Sortie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Retourne</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Composite</source>
         <translation>Composition</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Partagé</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Concurrent</source>
         <translation>Concurrent</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Protégé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Séquentiel</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>B1</source>
         <translation>B1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B2</source>
         <translation>B2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B3</source>
         <translation>B3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B4</source>
         <translation>B4</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A5</source>
         <translation>A5</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A6</source>
         <translation>A6</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>off</source>
         <translation>désactivé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>orange</source>
         <translation>orange</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>D1</source>
         <translation>D1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>D2</source>
         <translation>D2</translation>
     </message>
     <message>
-        <location line="-24"/>
         <source>float</source>
         <translation>glissement</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Package</source>
         <translation>Paquet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Privé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Protégé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Public</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>15</source>
         <translation>15</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>30</source>
         <translation>30</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>80</source>
         <translation>80</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Down</source>
         <translation>Bas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enter</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Esc</source>
         <translation>Échap</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Right</source>
         <translation>Droite</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Up</source>
         <translation>Haut</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>cyan</source>
         <translation>cyan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark blue</source>
         <translation>bleu foncé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark cyan</source>
         <translation>cyan foncé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark gray</source>
         <translation>gris foncé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark green</source>
         <translation>vert foncé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark magenta</source>
         <translation>magenta foncé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark red</source>
         <translation>rouge foncé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark yellow</source>
         <translation>jaune foncé</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>gray</source>
         <translation>gris</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>light gray</source>
         <translation>gris clair</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>magenta</source>
         <translation>magenta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>brake</source>
         <translation>interrompre</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+22"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>body</source>
         <translation>corps de la boucle</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+22"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/ev3/ev3GeneratorBase_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/ev3/ev3GeneratorBase_fr.ts
@@ -4,13 +4,10 @@
 <context>
     <name>ev3::Ev3GeneratorFactory</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/sendMailGenerator.cpp" line="35"/>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/receiveMailGenerator.cpp" line="38"/>
         <source>There is already mailbox with same name, but different msg type</source>
         <translation>Il existe déjà une boîte aux lettres portant le même nom, mais avec un type de message différent</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/receiveMailGenerator.cpp" line="42"/>
         <source>There are too many mailboxes, max size is 30</source>
         <translation>Il y a trop de boîtes aux lettres, la taille maximale est de 30</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/ev3/ev3RbfGenerator_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/ev3/ev3RbfGenerator_fr.ts
@@ -4,22 +4,18 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfMasterGenerator.cpp" line="60"/>
         <source>There is no opened diagram</source>
         <translation>Aucun diagramme n&apos;est ouvert</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="821"/>
         <source>/* Warning: cast from string to numeric type is not supported */ 0</source>
         <translation>/* Avertissement : la conversion de type d&apos;une chaîne vers un type numérique n&apos;est pas prise en charge */ 0</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="825"/>
         <source>/* Warning: autocast from array to other type is not supported */ 0</source>
         <translation>/* Avertissement : la conversion automatique d&apos;un tableau vers un autre type n&apos;est pas prise en charge */ 0</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="829"/>
         <source>/* Warning: autocast is supported only for numeric types */ 0</source>
         <translation>/* Avertissement : la conversion automatique est uniquement prise en charge pour les types numériques */ 0</translation>
     </message>
@@ -27,92 +23,74 @@
 <context>
     <name>ev3::rbf::Ev3RbfGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="34"/>
         <source>Autonomous mode (USB)</source>
         <translation>Mode autonome (USB)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="35"/>
         <source>Autonomous mode (Bluetooth)</source>
         <translation>Mode autonome (Bluetooth)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="41"/>
         <source>Generate to Ev3 Robot Byte Code File</source>
         <translation>Générer un fichier de code binaire pour le robot EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="45"/>
         <source>Upload program</source>
         <translation>Téléverser le programme</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="56"/>
         <source>Run program</source>
         <translation>Exécuter le programme</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="64"/>
         <source>Stop robot</source>
         <translation>Arrêter le programme</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="69"/>
         <source>EV3 Source Code language</source>
         <translation>Langage du code source EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="99"/>
         <source>Generate Ev3 Robot Byte Code File</source>
         <translation>Générer un fichier de code binaire pour le robot EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="100"/>
         <source>Upload EV3 Program</source>
         <translation>Téléverser le programme EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="101"/>
         <source>Run EV3 Program</source>
         <translation>Exécuter le programme EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="102"/>
         <source>Stop EV3 Program</source>
         <translation>Arrêter le programme EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="141"/>
         <source>Can&apos;t write source code files to disk!</source>
         <translation>Impossible d&apos;écrire les fichiers de code source sur le disque !</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="147"/>
         <source>Compilation error occured.</source>
         <translation>Une erreur de compilation est survenue.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="166"/>
         <source>The program has been uploaded</source>
         <translation>Le programme a été téléversé</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="167"/>
         <source>Do you want to run it?</source>
         <translation>Voulez-vous l&apos;exécuter ?</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="282"/>
         <source>Could not upload file to robot. Connect to a robot via %1.</source>
         <translation>Impossible de téléverser le fichier sur le robot. Connectez-vous à un robot via %1.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="283"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="283"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/generatorBase_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/generatorBase_fr.ts
@@ -4,32 +4,26 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/converters/reservedVariablesConverter.cpp" line="+64"/>
         <source>Device on port %1 is not configured. Please select it on the &quot;Configure devices&quot; panel on the right-hand side.</source>
         <translation>Le capteur sur le port %1 n&apos;est pas configuré. S&apos;il vous plait, sélectionné son type sur le panel &quot;Configuration des capteurs&quot; sur votre droite.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>/* ERROR: SELECT DEVICE TYPE */</source>
         <translation>/* ERREUR SELECTIONNEZ LE TYPE DU CAPTEUR */</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="+79"/>
         <source>There is no opened diagram</source>
         <translation>Il n&apos;y a pas de diagramme d&apos;ouvert</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/parts/subprograms.cpp" line="+83"/>
         <source>Graphical diagram instance not found</source>
         <translation>L&apos;instance graphique du diagramme n&apos;est pas trouvé</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Please enter valid c-style name for subprogram &quot;</source>
         <translation>Entrez un identificateur valide de style C pour le sous-programme &quot;</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Subprograms should have unique names, please rename</source>
         <translation>Les sous-programmes doivent avoir des noms uniques, veuillez les renommer</translation>
     </message>
@@ -38,97 +32,78 @@
         <translation type="vanished">Cet identificateur est deja utilisé:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="+44"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>Impossible de générer le code car le diagramme ne contient pas de nœud initial</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Initial node must not have incoming links</source>
         <translation>Le nœud initial ne doit pas avoir de liens entrants</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>This element must have exactly ONE outgoing link</source>
         <translation>Cet élément doit avoir exactement un lien de sortie</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Final node must not have outgoing links</source>
         <translation>Le nœud terminal ne doit pas avoir de liens sortants</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>If block must have exactly TWO outgoing links</source>
         <translation>Le bloc conditionnel doit avoir exactement deux liens sortants</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Two outgoing links marked with &apos;true&apos; found</source>
         <translation>Les deux liens sortants sont marqués comme &apos;vrai&apos;</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Two outgoing links marked with &apos;false&apos; found</source>
         <translation>Les deux liens sortants sont marqués comme &apos;faux&apos;</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>There must be at least one link with &quot;true&quot; or &quot;false&quot; marker on it</source>
         <translation>Il doit exister au moins un lien marqué comme &quot;vrai&quot; ou &quot;faux&quot;</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Loop block must have exactly TWO outgoing links</source>
         <translation>Le bloc de boucle doit avoir exactement deux liens sortants</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Two outgoing links marked with &quot;body&quot; found</source>
         <translation>Deux liens sortants marqués sont marqués comme &quot;corps de boucle&quot;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Le nœud de boucle doit avoir un lien sortant marqué comme &quot;corps de boucle&quot;</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Outgoing links from loop block must be connected to different blocks</source>
         <translation>Les liens sortants du bloc boucle doivent être raccordé aux deux blocs différents</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>There must be at list TWO links outgoing from switch block</source>
         <translation>Le bloc de choix multiple doit avoir au moins deux liens sortants</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>There must be exactly one link without marker on it (default branch)</source>
         <translation>Il doit exister exactement un lien sans un marquer associé (branche par defaut)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Duplicate case branch: &apos;%1&apos;</source>
         <translation>Des doublons ont étés détéctés pour la branche &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>There must be a link without marker on it (default branch)</source>
         <translation>Il doit exister un lien sans un marquer associé (branche par defaut)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown block type</source>
         <translation>Un bloc inconnu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Un bloc de parallelisation de taches doit posseder au moins deux liens sortants</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Outgoing link is not connected</source>
         <translation>Le lien sortant n&apos;est pas raccordé</translation>
     </message>
@@ -136,17 +111,14 @@
 <context>
     <name>generatorBase::MasterGeneratorBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="+40"/>
         <source>This diagram cannot be generated into the structured code. Generating it into the code with &apos;goto&apos; statements.</source>
         <translation>Ce diagramme ne peut pas être transformé en code structuré. Le code contenant &apos;goto&apos; sera généré.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>This diagram cannot be even generated into the code with &apos;goto&apos;statements. Please contact the developers.</source>
         <translation>Ce diagramme ne peut pas être transformé même en code avec des expressions &apos;goto&apos;. S&apos;il vous plait, contactez les developpeurs.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This diagram cannot be generated into the structured code.</source>
         <translation>Ce diagramme ne peut pas être transformé en code structuré.</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/nxt/nxtOsekCGenerator_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/nxt/nxtOsekCGenerator_fr.ts
@@ -4,22 +4,18 @@
 <context>
     <name>nxt::NxtFlashTool</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="+75"/>
         <source>Robot is already being flashed</source>
         <translation>Le robot est en train d&apos;être flashé</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Firmware file not found in nxt-tools directory.</source>
         <translation>Fichier de micrologiciel introuvable dans le répertoire nxt-tools.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Flashing robot is possible only by USB. Please switch to USB mode.</source>
         <translation>La mise à jour du robot n&apos;est possible qu&apos;en USB. Veuillez passer en mode USB.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Firmware flash started. Please don&apos;t disconnect robot during the process</source>
         <translation>Le téléversement du firmware est commencé. S&apos;il vous plait, ne déconnectéz pas le robot jusqu&apos;à ce que le processus se termine</translation>
     </message>
@@ -40,12 +36,10 @@
         <translation type="vanished">QReal necessite les droits de superutilisateur pour mettre à jour le code du robot NXT</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>The program has been uploaded</source>
         <translation>Le téléversement du programme est terminé</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to run it?</source>
         <translation>Est-ce que vous voulez l&apos;executer ?</translation>
     </message>
@@ -62,102 +56,82 @@
         <translation type="vanished">Le firmware est flashé !</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Uploading is already running</source>
         <translation>Le téléversement est deja lancé</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Uploading program started. Please don&apos;t disconnect robot during the process</source>
         <translation>Le téléversement du programme est commencé. S&apos;il vous plait, ne déconnectéz pas le robot jusqu&apos;à ce que le processus se termine</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Uploading failed. Make sure that X-server allows root to run GUI applications</source>
         <translation>Échec de téléversement. Assurez-vous que le serveur X permet de lancer les applications à l&apos;interface graphique</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Could not upload program. Make sure the robot is connected and ON</source>
         <translation>Échec de téléversement du programme. Assurez-vous que le robot soit connecté et qu&apos;il ne soit pas éteint</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>If you are using GNU/Linux visit https://help.trikset.com/nxt/run-upload-programs to get instructions</source>
         <translation>Si vous utilisez GNU/Linux, rendez-vous sur https://help.trikset.com/nxt/run-upload-programs pour obtenir des instructions</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Error in reading from firmware file: %1</source>
         <translation>Erreur lors de la lecture du fichier de micrologiciel : %1</translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Could not find %1. Check your program was compiled and try again.</source>
         <translation>Impossible de trouver %1. Vérifiez que votre programme a été compilé et réessayez.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Could not delete old file. Make sure the robot is connected, turned on.</source>
         <translation>Impossible de supprimer l&apos;ancien fichier. Assurez-vous que le robot est connecté et allumé.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Could not upload program. Make sure the robot is connected, turned on and has enough free memory.</source>
         <translation>Impossible de charger le programme. Vérifiez que le robot est connecté, allumé et dispose de suffisamment de mémoire libre.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Could not close file on brick. Probably connection to NXT lost at the last stage of uploading</source>
         <translation>Impossible de fermer le fichier sur le brick. La connexion à NXT a probablement été perdue à la dernière étape du chargement.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Uploading completed successfully</source>
         <translation>Téléversement réussi</translation>
     </message>
     <message>
-        <location line="-303"/>
         <source>Compilation error occured. Please check your function blocks syntax. If you sure in their validness contact developers</source>
         <translation>Une erreur de compilation s&apos;est produite. Vérifiez le syntaxe à l&apos;intérieur des blocs &quot;fonction&quot;. S&apos;ils sont valides, contactez les developpeurs</translation>
     </message>
     <message>
-        <location line="-186"/>
         <source>Could not open %1 for reading.</source>
         <translation>Impossible d&apos;ouvrir %1 en lecture.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Firmware file is too large to fit into NXT brick memory.</source>
         <translation>Le fichier de micrologiciel est trop volumineux pour tenir dans la mémoire du brick NXT.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not write firmware into NXT memory.</source>
         <translation>Impossible d&apos;écrire le micrologiciel dans la mémoire NXT.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Firmware successfully flashed into robot, but starting it failed.</source>
         <translation>Le micrologiciel a été correctement chargé dans le robot, mais son démarrage a échoué. Essayez de redémarrer le robot.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Flashing process completed successfully.</source>
         <translation>Le processus de mise à jour a été terminé avec succès.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Flashing NXT brick...</source>
         <translation>Mise à jour du brick NXT en cours...</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>You need to have superuser privileges to flash NXT robot</source>
         <translation>Vous devez disposer des privilèges superutilisateur pour mettre à jour le robot NXT.</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>QReal requires superuser privileges to upload programs on NXT robot</source>
         <translation>QReal necessite les droits de superutilisateur pour mettre à jour le programme du robot NXT</translation>
     </message>
@@ -165,43 +139,34 @@
 <context>
     <name>nxt::osekC::NxtOsekCGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="+32"/>
         <source>Generation (NXT OSEK C)</source>
         <translation>Génération (NXT OSEK C)</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+131"/>
         <source>NXT tools package is not installed</source>
         <translation>Le paquet d&apos;outils NXT n&apos;est pas installé.</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Generate code</source>
         <translation>Générer le code</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Flash robot</source>
         <translation>Flasher le robot</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Upload program</source>
         <translation>Téléverser le programme</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Generate NXT OSEK code</source>
         <translation>Générer le code NXT OSEK</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload program to NXT device</source>
         <translation>Téléverser le programme sur le dispositif NXT</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>flash.sh not found. Make sure it is present in QReal installation directory</source>
         <translation>flash.sh n&apos;est pas trouvé. Assurez-vous qu&apos;il soit présent dans le repertoire de  QReal</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/pioneer/pioneerLuaGenerator_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/pioneer/pioneerLuaGenerator_fr.ts
@@ -4,27 +4,22 @@
 <context>
     <name>PioneerAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Formulaire</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="35"/>
         <source>Connection Settings</source>
         <translation>Paramètres de connexion</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="50"/>
         <source>Base station IP:</source>
         <translation>Adresse IP de la station de base :</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="64"/>
         <source>Base station port:</source>
         <translation>Port de la station de base :</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="78"/>
         <source>Base station connection mode:</source>
         <translation>Mode de connexion de la station de base :</translation>
     </message>
@@ -32,28 +27,22 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaMasterGenerator.cpp" line="111"/>
         <source>There is no opened diagram</source>
         <translation>Aucun diagramme n&apos;est ouvert</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="121"/>
         <source>Generation internal error, please send bug report to developers.Additional info: zone node %1 can not be used as labeled node.</source>
         <translation>Erreur interne de génération, veuillez envoyer un rapport d&apos;erreur aux développeurs. Informations supplémentaires : le nœud de zone %1 ne peut pas être utilisé comme nœud étiqueté.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="159"/>
         <source>Generation internal error, synchronous zone parent is a zone node.</source>
         <translation>Erreur interne de génération. Informations supplémentaires : dans l&apos;arbre sémantique, le parent d&apos;un nœud de zone est lui-même un nœud de zone.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="165"/>
         <source>Generation internal error, synchronous fragment zone is absent.</source>
         <translation>Erreur interne de génération. Informations supplémentaires : la zone du nœud de début du fragment synchrone est absente.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="175"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="283"/>
         <source>Generation internal error, zone contains zone node.</source>
         <translation>Erreur interne de génération. Informations supplémentaires : dans l&apos;arbre sémantique, un nœud de zone contient un autre nœud de zone comme fils direct.</translation>
     </message>
@@ -61,50 +50,38 @@
 <context>
     <name>pioneer::lua::HttpCommunicator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="60"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="100"/>
         <source>Pioneer base station IP address is not set. It can be set in Settings window.</source>
         <translation>L&apos;adresse IP de la station de base Pioneer n&apos;est pas définie. Elle peut être configurée dans la fenêtre &quot;Paramètres&quot; -&gt; &quot;Robots&quot; -&gt; &quot;Pioneer&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="66"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="106"/>
         <source>Pioneer base station port is not set. It can be set in Settings window.</source>
         <translation>Le port de la station de base Pioneer n&apos;est pas défini. Il peut être configuré dans la fenêtre &quot;Paramètres&quot; -&gt; &quot;Robots&quot; -&gt; &quot;Pioneer&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="72"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="81"/>
         <source>Generation failed, upload aborted.</source>
         <translation>La génération a échoué, la transmission est annulée.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="87"/>
         <source>Uploading to: %1, please wait...</source>
         <translation>Envoi vers : %1, veuillez patienter...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="111"/>
         <source>Starting program. Senging request to: %1, please wait...</source>
         <translation>Démarrage du programme. Envoi de la requête à : %1, veuillez patienter...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="121"/>
         <source>Stopping program is not supported for HTTP communication mode.</source>
         <translation>L&apos;arrêt du programme n&apos;est pas pris en charge en mode de communication HTTP. Veuillez utiliser l&apos;outil &quot;controller&quot; pour communiquer avec le robot (activable dans les paramètres).</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="134"/>
         <source>Uploading finished.</source>
         <translation>Envoi terminé.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="142"/>
         <source>Start finished.</source>
         <translation>Démarrage terminé.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="153"/>
         <source>Pioneer base station took too long to respond. Request aborted.</source>
         <translation>La station de base Pioneer ne répond pas.</translation>
     </message>
@@ -112,62 +89,50 @@
 <context>
     <name>pioneer::lua::PioneerLuaGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="45"/>
         <source>Pioneer model (real copter)</source>
         <translation>Modèle Pioneer (véritable quadricoptère)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="52"/>
         <source>Generate to Pioneer Lua</source>
         <translation>Générer en Lua pour Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="66"/>
         <source>Upload generated program to Pioneer</source>
         <translation>Transmettre le programme généré vers Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="105"/>
         <source>Generate Lua script for Pioneer Quadcopter</source>
         <translation>Générer un script Lua pour le quadricoptère Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="110"/>
         <source>Upload Pioneer program</source>
         <translation>Transmettre le programme Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="163"/>
         <source>Choose robot`s mode</source>
         <translation>Choisir le mode du robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="184"/>
         <source>Robot`s IP-address</source>
         <translation>Adresse IP du robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="193"/>
         <source>Robot`s port</source>
         <translation>Port du robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="288"/>
         <source>Sorry, but uploading works only on Windows</source>
         <translation>Désolé, la transmission fonctionne uniquement sous Windows</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="293"/>
         <source>site</source>
         <translation>site</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="294"/>
         <source>Please download uploader from </source>
         <translation>Veuillez télécharger l&apos;outil d&apos;envoi depuis </translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="322"/>
         <source>Exit code </source>
         <translation>Code de sortie </translation>
     </message>
@@ -175,7 +140,6 @@
 <context>
     <name>pioneer::lua::PioneerLuaMasterGenerator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaMasterGenerator.cpp" line="145"/>
         <source>Generation failed. Possible causes are internal error in generator or too complex program structure.</source>
         <translation>La génération a échoué. Les causes possibles sont une erreur interne du générateur ou une structure de programme trop complexe. Veuillez contacter les développeurs.</translation>
     </message>
@@ -183,63 +147,50 @@
 <context>
     <name>pioneer::lua::PioneerStateMachineGenerator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="53"/>
         <source>The diagram must have the same number of &quot;Conditonal&quot; and &quot;End If&quot; blocks.</source>
         <translation>Le diagramme doit contenir un nombre égal de blocs &quot;Condition&quot; et &quot;Fin Si&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="152"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="237"/>
         <source>&quot;End If&quot; block occurs before &quot;If block&quot;</source>
         <translation>L&apos;utilisation du bloc &quot;Fin Si&quot; sans bloc &quot;Si&quot; préalable n&apos;est pas autorisée</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="195"/>
         <source>Generation internal error, failed to create a node.</source>
         <translation>Erreur interne de génération. Informations supplémentaires : impossible de créer un nœud dans l&apos;arbre sémantique.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="308"/>
         <source>Nested If&apos;s constructions is not allowed.</source>
         <translation>Les structures conditionnelles imbriquées ne sont pas autorisées.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="373"/>
         <source>Generation internal error, zone node corresponds to a block in a diagram.</source>
         <translation>Erreur interne de génération. Informations supplémentaires : un nœud de zone dans l&apos;arbre sémantique correspond à un bloc dans le diagramme. Un nœud de zone ne peut être qu&apos;une partie de la représentation d&apos;un bloc.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="388"/>
         <source>Generation internal error, non-zone node is a start of a fragment.</source>
         <translation>Erreur interne de génération. Informations supplémentaires : un fragment synchrone commence par un nœud de zone.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="440"/>
         <source>Generation internal error, program ends abruptly.</source>
         <translation>Erreur interne de génération. Informations supplémentaires : le programme s&apos;est terminé de façon inattendue. De telles erreurs devraient être détectées lors de la vérification préalable du programme.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="467"/>
         <source>Generation internal error, asynchronous node does not have target node.</source>
         <translation>Erreur interne de génération. Informations supplémentaires : un nœud asynchrone n&apos;a pas de nœud cible auquel transmettre le contrôle après l&apos;opération asynchrone.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="488"/>
         <source>There is a problem with If construction or with loops (loops without sending requests to the autopilot through &quot;Takeoff&quot;, &quot;Landing&quot;, &quot;Go to local point&quot; blocks are not supported yet).</source>
         <translation>Un problème existe dans l&apos;utilisation des structures conditionnelles ou des boucles (les boucles sans requêtes envoyées à l&apos;autopilote via les blocs &quot;Décollage&quot;, &quot;Atterrissage&quot;, &quot;Aller vers un point local&quot; ne sont pas encore prises en charge).</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="529"/>
         <source>The blocks (&quot;Takeoff&quot;, &quot;Landing&quot;, &quot;Go to local point&quot;) which work with autopilot were observed in both (or only in one) conditional branches.</source>
         <translation>Les blocs (&quot;Décollage&quot;, &quot;Atterrissage&quot;, &quot;Aller vers un point local&quot;) interagissant avec l&apos;autopilote du quadricoptère ont été détectés dans une ou plusieurs branches conditionnelles.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="531"/>
         <source>Such blocks must appear and finish both branches (the &quot;End if&quot; block must have two such parents) or not appear at branches at all.</source>
         <translation>Ces blocs doivent apparaître et terminer les deux branches conditionnelles (le bloc &quot;Fin Si&quot; doit avoir deux tels prédécesseurs) ou ne pas apparaître du tout.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="533"/>
         <source>Such blocks may appear in each branch several times but one of them must finish it in each branch.</source>
         <translation>Ces blocs peuvent apparaître plusieurs fois dans chaque branche conditionnelle, mais l&apos;un d&apos;eux doit être final dans chaque branche.</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/trik/trikGeneratorBase_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/trik/trikGeneratorBase_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikGeneratorBase/src/trikBlocksValidator.cpp" line="+111"/>
         <source>Property should not be empty.</source>
         <translation>La propriété ne doit pas être vide.</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/trik/trikPythonGeneratorLibrary_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/trik/trikPythonGeneratorLibrary_fr.ts
@@ -4,63 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="+141"/>
         <source>Trying to join a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Tentative de jointure d&apos;un fil avec un identifiant inconnu. Causes possibles : appel de fork depuis un sous-programme ou tentative de fusion de deux fils sans bloc join</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Join block must have exactly one outgoing link</source>
         <translation>Le bloc de jointure doit avoir exactement une liaison sortante</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+45"/>
         <source>Guard property of a link outgoing from a join must contain an id of one of joined threads</source>
         <translation>La propriété de garde d&apos;une liaison sortante d&apos;un bloc de jointure doit contenir l&apos;identifiant de l&apos;un des fils fusionnés</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Joining threads in a loop is forbidden</source>
         <translation>La jointure de fils dans une boucle est interdite</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Trying to fork from a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Tentative d&apos;appel de fork depuis un fil avec un identifiant inconnu. Causes possibles : appel de fork depuis un sous-programme ou tentative de fusion de deux fils sans bloc join</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Le bloc fork doit avoir au moins DEUX liaisons sortantes</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Links outgoing from a fork block must have different thread ids</source>
         <translation>Les liaisons sortantes du bloc fork doivent avoir des identifiants de fil différents</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Fork block must have a link marked with an id of a thread from which the fork is called, &apos;%1&apos; in this case</source>
         <translation>Le bloc fork doit avoir une liaison marquée avec l&apos;identifiant du fil depuis lequel le fork est appelé, &apos;%1&apos; dans ce cas</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Trying to create a thread with an already occupied id &apos;%1&apos;</source>
         <translation>Tentative de création d&apos;un fil avec un identifiant déjà utilisé &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Creation of threads in a cycle is forbidden, check for links to before a fork</source>
         <translation>La création de fils dans une boucle est interdite, vérifiez les liaisons menant vers les blocs avant un fork</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Outgoing link is not connected</source>
         <translation>La liaison sortante n&apos;est connectée à rien</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonControlFlowValidator.cpp" line="+35"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>Rien à générer, le diagramme ne contient pas de nœud initial</translation>
     </message>
@@ -68,57 +55,46 @@
 <context>
     <name>trik::python::TrikPythonGeneratorPluginBase</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="+73"/>
         <source>Network operation timed out</source>
         <translation>L&apos;opération réseau a expiré, impossible de contacter le robot. Vérifiez les paramètres et que le robot est allumé</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Casing model mismatch, check TRIK Studio settings, &quot;Robots&quot; page. It seems that TRIK casing version selected in TRIK Studio differs from version on robot.</source>
         <translation>Le modèle de boîtier du robot ne correspond pas à celui indiqué dans les paramètres. Vérifiez la fenêtre de configuration, onglet &quot;Robots&quot;, le modèle de TRIK sélectionné doit correspondre au boîtier du robot.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Generate python code</source>
         <translation>Générer le code Python</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Upload program</source>
         <translation>Télécharger le programme</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Run program</source>
         <translation>Télécharger et exécuter le programme</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Stop robot</source>
         <translation>Arrêter le robot</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Generate Python code</source>
         <translation>Générer le code pour TRIK en QtScript</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload Python program</source>
         <translation>Télécharger le programme</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Run Python program</source>
         <translation>Exécuter le programme</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop Python program</source>
         <translation>Arrêter l&apos;exécution du programme pour TRIK</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>There are no files to upload. You must open or generate at least one *.js or *.py file.</source>
         <translation>Aucun fichier à télécharger. Vous devez ouvrir ou générer au moins un fichier *.js ou *.py.</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/trik/trikQtsGeneratorLibrary_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/trik/trikQtsGeneratorLibrary_fr.ts
@@ -4,63 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="+141"/>
         <source>Trying to join a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Tentative de jointure d&apos;un fil avec un identifiant inconnu. Causes possibles : appel de fork depuis un sous-programme ou tentative de fusion de deux fils sans bloc join</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Join block must have exactly one outgoing link</source>
         <translation>Le bloc de jointure doit avoir exactement une liaison sortante</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+45"/>
         <source>Guard property of a link outgoing from a join must contain an id of one of joined threads</source>
         <translation>La propriété de garde d&apos;une liaison sortant d&apos;un bloc de jointure doit contenir l&apos;identifiant de l&apos;un des fils fusionnés</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Joining threads in a loop is forbidden</source>
         <translation>La jointure de fils dans une boucle est interdite</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Trying to fork from a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Tentative d&apos;appel de fork depuis un fil avec un identifiant inconnu. Causes possibles : appel de fork depuis un sous-programme ou tentative de fusion de deux fils sans bloc join</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Le bloc fork doit avoir au moins DEUX liaisons sortantes</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Links outgoing from a fork block must have different thread ids</source>
         <translation>Les liaisons sortant d&apos;un bloc fork doivent avoir des identifiants de fil différents</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Fork block must have a link marked with an id of a thread from which the fork is called, &apos;%1&apos; in this case</source>
         <translation>Le bloc fork doit avoir une liaison marquée avec l&apos;identifiant du fil depuis lequel le fork est appelé, &apos;%1&apos; dans ce cas</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Trying to create a thread with an already occupied id &apos;%1&apos;</source>
         <translation>Tentative de création d&apos;un fil avec un identifiant déjà utilisé &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Creation of threads in a cycle is forbidden, check for links to before a fork</source>
         <translation>La création de fils dans une boucle est interdite, vérifiez les liaisons menant vers des blocs situés avant un fork</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Outgoing link is not connected</source>
         <translation>La liaison sortante n&apos;est reliée à rien</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsControlFlowValidator.cpp" line="+37"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>Rien à générer, le diagramme ne contient pas de nœud initial</translation>
     </message>
@@ -68,57 +55,46 @@
 <context>
     <name>trik::qts::TrikQtsGeneratorPluginBase</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="+73"/>
         <source>Network operation timed out</source>
         <translation>L&apos;opération réseau a expiré, aucun réponse du robot. Vérifiez les paramètres et que le robot est allumé</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Casing model mismatch, check TRIK Studio settings, &quot;Robots&quot; page. It seems that TRIK casing version selected in TRIK Studio differs from version on robot.</source>
         <translation>Le modèle de boîtier du robot ne correspond pas à celui indiqué dans les paramètres. Vérifiez la fenêtre de configuration, onglet &quot;Robots&quot;, le modèle de TRIK sélectionné doit correspondre au boîtier du robot.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Generate TRIK code</source>
         <translation>Générer le code JavaScript</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Upload program</source>
         <translation>Téléverser le programme</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Run program</source>
         <translation>Téléverser et exécuter le programme</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Stop robot</source>
         <translation>Arrêter le robot</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Generate TRIK Code</source>
         <translation>Générer le code JavaScript pour TRIK</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload TRIK Program</source>
         <translation>Téléverser le programme TRIK</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Run TRIK Program</source>
         <translation>Exécuter le programme TRIK</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop TRIK Robot</source>
         <translation>Arrêter l&apos;exécution du programme pour TRIK</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>There are no files to upload. You must open or generate at least one *.js or *.py file.</source>
         <translation>Aucun fichier à téléverser. Vous devez ouvrir ou générer au moins un fichier *.js ou *.py.</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/trik/trikV62PythonGenerator_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/trik/trikV62PythonGenerator_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::python::TrikV62PythonGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikV62PythonGenerator/trikV62PythonGeneratorPlugin.cpp" line="+29"/>
         <source>Generation (Python)</source>
         <translation>Génération (Python)</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/generators/trik/trikV62QtsGenerator_fr.ts
+++ b/qrtranslations/fr/plugins/robots/generators/trik/trikV62QtsGenerator_fr.ts
@@ -98,7 +98,6 @@
 <context>
     <name>trik::qts::TrikV62QtsGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikV62QtsGenerator/trikV62QtsGeneratorPlugin.cpp" line="+29"/>
         <source>Generation (Java Script)</source>
         <translation>Génération (JavaScript)</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/interpreters/ev3KitInterpreter_fr.ts
+++ b/qrtranslations/fr/plugins/robots/interpreters/ev3KitInterpreter_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>Ev3AdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="+14"/>
         <source>Form</source>
         <translation>Paramètres EV3</translation>
     </message>
@@ -25,43 +24,34 @@
         <translation type="vanished">Wi-Fi</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Robot&apos;s Folders</source>
         <translation>Dossiers du robot</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>ts</source>
         <translation>ts</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Common folder:</source>
         <translation>Dossier commun :</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use common folder for all projects</source>
         <translation>Utiliser un dossier commun pour tous les projets</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bluetooth Settings</source>
         <translation>Paramètres Bluetooth</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+17"/>
         <source>COM Port:</source>
         <translation>Port série:</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>No COM ports found. If you have a Bluetooth connection with active virtual COM port, please enter its name. Example: COM3</source>
         <translation>Port série n&apos;est pas détecté. Si vous avez une connexion Bluetooth avec un port série virtuel actif, tapez son nom. Par exemple &quot;COM3&quot;</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Specify COM port manually</source>
         <translation>Spécifier le port série manuellement</translation>
     </message>
@@ -69,7 +59,6 @@
 <context>
     <name>Ev3DisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3DisplayWidget.ui" line="+435"/>
         <source>tr(Ev3Display)</source>
         <translation>Affichage EV3</translation>
     </message>
@@ -77,7 +66,6 @@
 <context>
     <name>ev3::Ev3AdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.cpp" line="+29"/>
         <source>2D robot image:</source>
         <translation>Image 2D du robot :</translation>
     </message>
@@ -85,7 +73,6 @@
 <context>
     <name>ev3::Ev3KitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3KitInterpreterPlugin.cpp" line="+108"/>
         <source>Lego EV3</source>
         <translation>Lego EV3</translation>
     </message>
@@ -93,7 +80,6 @@
 <context>
     <name>ev3::robotModel::real::BluetoothRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/bluetoothRealRobotModel.cpp" line="+34"/>
         <source>Interpretation (Bluetooth)</source>
         <translation>Interprétation (Bluetooth)</translation>
     </message>
@@ -108,7 +94,6 @@
 <context>
     <name>ev3::robotModel::real::UsbRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/usbRealRobotModel.cpp" line="+34"/>
         <source>Interpretation (USB)</source>
         <translation>Interprétation (USB)</translation>
     </message>
@@ -116,7 +101,6 @@
 <context>
     <name>ev3::robotModel::real::parts::RangeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/parts/rangeSensor.h" line="+31"/>
         <source>Sonar sensor</source>
         <translation>Capteur de sonar</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/interpreters/interpreterCore_fr.ts
+++ b/qrtranslations/fr/plugins/robots/interpreters/interpreterCore_fr.ts
@@ -53,77 +53,62 @@
 <context>
     <name>PreferencesRobotSettingsPage</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="+23"/>
         <source>Graphics Watcher update intervals</source>
         <translation>Intervalle de mise à jour des graphes</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Sensors  (ms)</source>
         <translation>Capteurs (ms)</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Autoscaling  (ms)</source>
         <translation>Auto-redimensionnement (ms)</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Text info (ms)</source>
         <translation>Information texte (ms)</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Uploading &amp;&amp; Running</source>
         <translation>Téléversement et execution des programmes </translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Running after uploading:</source>
         <translation>Execution après le téléversement : </translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Ask</source>
         <translation>Demander</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Always run</source>
         <translation>Toujours executer</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Never run</source>
         <translation>Ne jamais executer</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>2D-model Editor Settings</source>
         <translation>Paramètres de l&apos;Éditeur de Modèles 2D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enable Region Editor Mode</source>
         <translation>Activer le Mode Éditeur de Régions</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Advanced settings for creating restrictions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>Sensors Settings</source>
         <translation>Configuration des capteurs</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Robotics construction kit</source>
         <translation>Kit de construction robotique</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Robot model</source>
         <translation>Modèle de robot</translation>
     </message>
@@ -159,17 +144,14 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="+27"/>
         <source>TRIK Studio</source>
         <translation>TRIK Studio</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Subprograms</source>
         <translation>Sous-programmes</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The list of all declared subprograms in the project</source>
         <translation>La liste de tous les sous-programmes du projet</translation>
     </message>
@@ -178,82 +160,66 @@
         <translation type="vanished">Conflit de configuration des capteurs, verifiez que les ports des capteurs soient utilisés de manière consistente dans le programme</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="+32"/>
         <source>Run</source>
         <translation>Executer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop robot</source>
         <translation>Arrêter le robot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to robot</source>
         <translation>Se connecter au robot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Robot settings</source>
         <translation>Configuration du robot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as task...</source>
         <translation>Enregistrer comme une tache...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Debug</source>
         <translation>Débogage</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit</source>
         <translation>Éditeur</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Switch to debug mode</source>
         <translation>Passer en mode de débogage</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Switch to edit mode</source>
         <translation>Passer en mode d&apos;edition</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Run interpreter</source>
         <translation>Executer l&apos;interpréteur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop interpreter</source>
         <translation>Arrêter l&apos;interpréteur</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/exerciseExportManager.cpp" line="+53"/>
         <source>Select file to export save to</source>
         <translation>Selectionner le fichier pour l&apos;export</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Fichier TRIK Studio (*.qrs)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="+63"/>
         <source>Blocks</source>
         <translation>Blocs</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Configure devices</source>
         <translation>Configuration de capteurs</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Sensors state</source>
         <translation>État des capteurs</translation>
     </message>
@@ -270,12 +236,10 @@
         <translation type="vanished">temps</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/details/autoconfigurer.cpp" line="+60"/>
         <source>%2 has been auto configured to port %1</source>
         <translation>%2 a été automatiquement configuré sur le port %1</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sensor on port %1 does not correspond to blocks on the diagram.</source>
         <translation>Le capteur sur le port %1 ne correspond pas aux blocs du diagramme.</translation>
     </message>
@@ -290,17 +254,14 @@
 <context>
     <name>interpreterCore::ActionsManager</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="-71"/>
         <source>To main page</source>
         <translation>Vers la page principale</translation>
     </message>
     <message>
-        <location line="+246"/>
         <source>Real robot</source>
         <translation>Robot réel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2D model</source>
         <translation>Modèle 2D</translation>
     </message>
@@ -308,7 +269,6 @@
 <context>
     <name>interpreterCore::DefaultRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/defaultRobotModel.cpp" line="+31"/>
         <source>Empty model</source>
         <translation>Modèle vide</translation>
     </message>
@@ -316,27 +276,22 @@
 <context>
     <name>interpreterCore::RobotsPluginFacade</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="+159"/>
         <source>Robots</source>
         <translation>Robots</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Cannot export exercise to the given location (try to change location)</source>
         <translation>Impossible d&apos;exporter l&apos;exercice vers l&apos;emplacement indiqué (essayez de changer d&apos;emplacement)</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>The specified script file could not be opened for reading </source>
         <translation>Le fichier de script spécifié n&apos;a pas pu être ouvert en lecture</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>No saved code found in the qrs file</source>
         <translation>Aucun code enregistré trouvé dans le fichier qrs</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Toggle robot console panel</source>
         <translation>Afficher/Masquer le panneau de la console du robot</translation>
     </message>
@@ -344,37 +299,30 @@
 <context>
     <name>interpreterCore::UiManager</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="-66"/>
         <source>Miscellaneous</source>
         <translation>Divers</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Robot console</source>
         <translation>Console du robot</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>edit mode</source>
         <translation>mode d&apos;édition</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>debug mode</source>
         <translation>mode de débogage</translation>
     </message>
     <message>
-        <location line="+151"/>
         <source>Edit mode</source>
         <translation>Mode d&apos;édition</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Debug mode</source>
         <translation>Mode de débogage</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Modes</source>
         <translation>Modes</translation>
     </message>
@@ -382,38 +330,30 @@
 <context>
     <name>interpreterCore::interpreter::BlockInterpreter</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="+92"/>
-        <location line="+74"/>
         <source>No connection to robot</source>
         <translation>Aucune connexion au robot</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Interpreter is already running</source>
         <translation>L&apos;interpréteur est déjà en cours d&apos;exécution</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Connected successfully</source>
         <translation>Connexion réussie</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Can&apos;t connect to a robot.</source>
         <translation>Impossible de se connecter au robot.</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Cannot create new thread with already occupied id %1</source>
         <translation>Impossible de créer un nouveau fil avec l&apos;identifiant %1 déjà utilisé</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Threads limit exceeded. Maximum threads count is %1</source>
         <translation>Limite de fils dépassée. Le nombre maximum de fils est %1</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Killing non-existent thread %1</source>
         <translation>Tentative de terminer un fil inexistant %1</translation>
     </message>
@@ -452,42 +392,34 @@
 <context>
     <name>interpreterCore::ui::ExerciseExportDialog</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="+31"/>
         <source>Select non-modifiable parts of exercize</source>
         <translation>Selectionnez les parties non modifiables de l&apos;exercice</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>2D model world is read-only</source>
         <translation>Le monde du modèle 2D est en lecture seule</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sensors are read-only</source>
         <translation>Les capteurs sont en lecture seule</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2D model robot position is read-only</source>
         <translation>La position du robot dans le modèle 2D est en lecture seule</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Motors to wheels binding is read-only</source>
         <translation>La liaison moteurs-roues est en lecture seule</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2D model simulation settings are read-only</source>
         <translation>Les paramètres de simulation du modèle 2D sont en lecture seule</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -495,7 +427,6 @@
 <context>
     <name>interpreterCore::ui::ModeStripe</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/modeStripe.cpp" line="+22"/>
         <source>press %2 or click here to switch to %3</source>
         <translation>Appuyez sur %2 ou cliquez ici pour passer en %3</translation>
     </message>
@@ -503,22 +434,18 @@
 <context>
     <name>interpreterCore::ui::RobotsSettingsPage</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="+58"/>
         <source>Templates directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Choose templates directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>No constructor kit plugins loaded</source>
         <translation>Aucune extension n&apos;est chargée</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>No robot models available for </source>
         <translation>Modèle de robot n&apos;est pas défini dans l&apos;extension</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/interpreters/nullKitInterpreter_fr.ts
+++ b/qrtranslations/fr/plugins/robots/interpreters/nullKitInterpreter_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>nullKitInterpreter::NullKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nullKitInterpreter/src/nullKitInterpreterPlugin.cpp" line="+33"/>
         <source>Empty Kit</source>
         <translation>Modèle vide</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>nullKitInterpreter::NullRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nullKitInterpreter/src/nullRobotModel.cpp" line="+31"/>
         <source>Null model</source>
         <translation>Modèle vide</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/interpreters/nxtKitInterpreter_fr.ts
+++ b/qrtranslations/fr/plugins/robots/interpreters/nxtKitInterpreter_fr.ts
@@ -4,38 +4,30 @@
 <context>
     <name>NxtAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="+14"/>
         <source>Form</source>
         <translation>Configuration de NXT</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>nxtOSEK Generator Settings</source>
         <translation>Paramètres du générateur nxtOSEK</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>TextLabel</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bluetooth Settings</source>
         <translation>Paramètres Bluetooth</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+7"/>
         <source>COM Port:</source>
         <translation>Port série :</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>No COM ports found. If you have a Bluetooth connection with active virtual COM port, please enter its name. Example: COM3</source>
         <translation>Aucu port série n&apos;est détecté. Si vous avez une connexion Bluetooth avec un port série virtuel actif, tapez son nom. Par exemple : COM3</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Specify COM port manually</source>
         <translation>Spécifiez le port en série manuellement</translation>
     </message>
@@ -43,7 +35,6 @@
 <context>
     <name>NxtDisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtDisplayWidget.ui" line="+435"/>
         <source>tr(NxtDisplay)</source>
         <translation>Écran NXT</translation>
     </message>
@@ -51,17 +42,14 @@
 <context>
     <name>nxt::NxtAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.cpp" line="+33"/>
         <source>2D robot image:</source>
         <translation>Image du robot en 2D :</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to arm-none-eabi:</source>
         <translation>Chemin vers arm-none-eabi :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>WARNING: Current directory doesn&apos;t exist. 
 Open &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;link&lt;/a&gt; for instructions</source>
         <translation>AVERTISSEMENT : Le répertoire actuel n&apos;existe pas. 
@@ -71,7 +59,6 @@ Ouvrez le &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot
 <context>
     <name>nxt::NxtKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtKitInterpreterPlugin.cpp" line="+107"/>
         <source>Lego NXT</source>
         <translation>Lego NXT</translation>
     </message>
@@ -101,7 +88,6 @@ Ouvrez le &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot
 <context>
     <name>nxt::robotModel::real::BluetoothRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/bluetoothRealRobotModel.cpp" line="+35"/>
         <source>Interpretation (Bluetooth)</source>
         <translation>Interprétation (Bluetooth)</translation>
     </message>
@@ -109,7 +95,6 @@ Ouvrez le &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot
 <context>
     <name>nxt::robotModel::real::UsbRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/usbRealRobotModel.cpp" line="+34"/>
         <source>Interpretation (USB)</source>
         <translation>Interprétation (USB)</translation>
     </message>
@@ -117,7 +102,6 @@ Ouvrez le &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot
 <context>
     <name>nxt::robotModel::real::parts::SonarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/parts/sonarSensor.h" line="+31"/>
         <source>Sonar sensor</source>
         <translation>Capteur ultrasons</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/interpreters/pioneerKitInterpreter_fr.ts
+++ b/qrtranslations/fr/plugins/robots/interpreters/pioneerKitInterpreter_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>pioneerKitInterpreter::PioneerKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/pioneerKitInterpreter/src/pioneerKitInterpreterPlugin.cpp" line="+33"/>
         <source>Pioneer Kit</source>
         <translation>Kit Pioneer</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/interpreters/robotsPlugin_fr.ts
+++ b/qrtranslations/fr/plugins/robots/interpreters/robotsPlugin_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/robotsPlugin/robotsPlugin.cpp" line="+51"/>
         <source>Robots</source>
         <translation>Robots</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/interpreters/trikKitInterpreterCommon_fr.ts
+++ b/qrtranslations/fr/plugins/robots/interpreters/trikKitInterpreterCommon_fr.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+166"/>
         <source>Bogus input values</source>
         <translation>Valeurs d&apos;entrée incorrectes</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error: File %1 couldn&apos;t be opened!</source>
         <translation>Erreur : Le fichier %1 n&apos;a pas pu être ouvert !</translation>
     </message>
@@ -17,62 +15,50 @@
 <context>
     <name>TrikAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="+14"/>
         <source>Form</source>
         <translation>Préférences TRIK</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>TCP Settings</source>
         <translation>Configuration de TCP</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enter robot IP-address here</source>
         <translation>Tapez l&apos;adresse IP du robot ici</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Camera Settings</source>
         <translation>Paramètres de la caméra</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Use real camera</source>
         <translation>Utiliser la caméra réelle</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Network Settings</source>
         <translation>Paramètres réseau</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enable Mailbox</source>
         <translation>Activer la boîte aux lettres</translation>
     </message>
     <message>
-        <location line="-74"/>
         <source>Camera:</source>
         <translation>Caméra :</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Use images from project</source>
         <translation>Utiliser les images intégrées au projet</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Images:</source>
         <translation>Images :</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Browse...</source>
         <translation>Parcourir...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Pack images to project</source>
         <translation>Intégrer les images au projet</translation>
     </message>
@@ -80,7 +66,6 @@
 <context>
     <name>TrikDisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikDisplayWidget.ui" line="+14"/>
         <source>Trik Display</source>
         <translation>L&apos;écran Trik</translation>
     </message>
@@ -95,14 +80,12 @@
 <context>
     <name>TwoDExecutionControl</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp" line="+28"/>
         <source>&apos;%1&apos; is disabled
 </source>
         <translation>%1 est désactivé
 </translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>No cofigured random device</source>
         <translation>Aucun générateur de nombres aléatoires configuré</translation>
     </message>
@@ -110,22 +93,18 @@
 <context>
     <name>trik::TrikAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="+33"/>
         <source>2D robot image:</source>
         <translation>Image du robot en 2D :</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Select Directory</source>
         <translation>Sélectionner un répertoire</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You should restart the program to apply changes</source>
         <translation>Redémarrez le programme pour appliquer les modifications</translation>
     </message>
@@ -133,84 +112,66 @@
 <context>
     <name>trik::TrikBrick</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+84"/>
-        <location line="+76"/>
         <source>2d model shell part was not found</source>
         <translation>La coque du modèle 2D est introuvable</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+283"/>
         <source>Trying to read from file %1 failed</source>
         <translation>Échec de la lecture du fichier %1</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>No configured motor on port: %1</source>
         <translation>Aucun moteur configuré sur le port : %1</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>No configured scalar sensor on port: %1</source>
         <translation>Aucun capteur scalaire configuré sur le port : %1</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No configured lidar on port: %1</source>
         <translation>Aucun lidar configuré sur le port : %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>No configured accelerometer</source>
         <translation>Accéléromètre non configuré</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>No configured gyroscope</source>
         <translation>Gyroscope non configuré</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>No configured LineSensor on port: %1</source>
         <translation>Aucun capteur de ligne configuré sur le port : %1</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>No configured ColorSensor on port: %1</source>
         <translation>Aucun capteur de couleur configuré sur le port : %1</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Sensor not implemented in simulation mode. Used port: %1</source>
         <translation>Capteur non implémenté en mode simulation. Port utilisé : %1</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>No configured encoder on port: %1</source>
         <translation>Aucun encodeur configuré sur le port : %1</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>No configured led</source>
         <translation>LED non configurée</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Get photo with camera started</source>
         <translation>Capture d&apos;une photo avec la caméra démarrée</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Get photo with camera finished</source>
         <translation>Capture d&apos;une photo avec la caméra terminée</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Cannot get a photo from camera (possibly because of wrong camera name)</source>
         <translation>Impossible d&apos;obtenir une photo depuis la caméra (probablement en raison d&apos;un nom de caméra incorrect)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot get a photo from folders/project (possibly because of wrong path/empty project)</source>
         <translation>Impossible d&apos;obtenir une photo depuis les dossiers/projet (probablement en raison d&apos;un chemin incorrect ou d&apos;un projet vide)</translation>
     </message>
@@ -229,32 +190,26 @@
 <context>
     <name>trik::TrikKitInterpreterPluginBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="+39"/>
         <source>Start</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Stop</source>
         <translation>Arrêter</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>TRIK_PYTHONPATH must be set correctly to run Python script.</source>
         <translation>La variable d&apos;environnement TRIK_PYTHONPATH doit être correctement définie pour exécuter un script Python.</translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Run program</source>
         <translation>Exécuter le programme</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Stop robot</source>
         <translation>Arrêter le robot</translation>
     </message>
     <message>
-        <location line="+199"/>
         <source>Enter robot`s IP-address here...</source>
         <translation>Saisissez ici l&apos;adresse IP du robot...</translation>
     </message>
@@ -262,8 +217,6 @@
 <context>
     <name>trik::TrikTextualInterpreter</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="-96"/>
-        <location line="+15"/>
         <source>Unsupported script file type</source>
         <translation>Type de fichier de script non pris en charge</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/interpreters/trikV62KitInterpreter_fr.ts
+++ b/qrtranslations/fr/plugins/robots/interpreters/trikV62KitInterpreter_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::TrikV62KitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikV62KitInterpreter/src/trikV62KitInterpreterPlugin.cpp" line="+47"/>
         <source>TRIK</source>
         <translation>TRIK</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>trik::robotModel::real::RealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikV62KitInterpreter/src/robotModel/real/trikV62RealRobotModel.cpp" line="+69"/>
         <source>Interpretation (Wi-Fi)</source>
         <translation>Interprétation (Wi-Fi)</translation>
     </message>

--- a/qrtranslations/fr/plugins/robots/utils_fr.ts
+++ b/qrtranslations/fr/plugins/robots/utils_fr.ts
@@ -4,18 +4,14 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="+27"/>
         <source>Current TRIK runtime version can not be received</source>
         <translation>La version actuelle du firmware TRIK ne peut pas être récupérée</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>TRIK runtime version is too old, please update it by pressing &apos;Upload Runtime&apos; button on toolbar</source>
         <translation>La version du logiciel du robot est trop ancienne, veuillez la mettre à jour en cliquant sur le bouton « Télécharger le logiciel sur le robot » dans la barre d&apos;outils</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+5"/>
         <source>From robot: </source>
         <translation>Depuis le robot : </translation>
     </message>
@@ -23,7 +19,6 @@
 <context>
     <name>SensorsGraph</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.ui" line="+25"/>
         <source>SensorsGraph</source>
         <translation>Capteurs</translation>
     </message>
@@ -31,23 +26,18 @@
 <context>
     <name>trik::UploaderTool</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="+131"/>
         <source>WinSCP process failed to launch, check path in settings.</source>
         <translation>Échec du lancement du processus WinSCP, vérifiez le chemin d&apos;accès dans les paramètres.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+15"/>
         <source>Uploading failed, check connection and try again.</source>
         <translation>Le téléchargement a échoué, vérifiez la connexion et réessayez.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Uploaded successfully!</source>
         <translation>Téléchargement réussi !</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>%1 is not installed. Please install %1 first.</source>
         <translation>%1 n&apos;est pas installé. Veuillez d&apos;abord installer %1.</translation>
     </message>
@@ -70,12 +60,10 @@
 <context>
     <name>utils::robotCommunication::TcpRobotCommunicator</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicator.cpp" line="+81"/>
         <source>Empty program name, can not upload</source>
         <translation>Nom du programme vide, impossible de télécharger</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Can not read generated file, uploading aborted</source>
         <translation>Impossible de lire le fichier généré, téléchargement annulé</translation>
     </message>
@@ -83,12 +71,10 @@
 <context>
     <name>utils::robotCommunication::TcpRobotCommunicatorWorker</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicatorWorker.cpp" line="+232"/>
         <source>Unable to resolve host.</source>
         <translation>Impossible de résoudre le nom d&apos;hôte.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Connection failed. IP: %1</source>
         <translation>Échec de la connexion. IP : %1</translation>
     </message>
@@ -96,17 +82,14 @@
 <context>
     <name>utils::sensorsGraph::SensorViewer</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorViewer.cpp" line="+109"/>
         <source>Save values history</source>
         <translation>Enregistrer l&apos;historique des valeurs</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Comma-Separated Values Files (*.csv)</source>
         <translation>Fichiers de valeurs séparées par des virgules (*.csv)</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>value: </source>
         <translation>valeur : </translation>
     </message>
@@ -114,32 +97,26 @@
 <context>
     <name>utils::sensorsGraph::SensorsGraph</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="+141"/>
         <source>Stop tracking</source>
         <translation>Arrêter le suivi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Start tracking</source>
         <translation>Démarrer le suivi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reset plot</source>
         <translation>Réinitialiser le graphique</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Zoom In</source>
         <translation>Zoom avant</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Zoom Out</source>
         <translation>Zoom arrière</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export values...</source>
         <translation>Exporter les valeurs...</translation>
     </message>

--- a/qrtranslations/fr/plugins/tools/subprogramsImporterExporter_fr.ts
+++ b/qrtranslations/fr/plugins/tools/subprogramsImporterExporter_fr.ts
@@ -4,17 +4,14 @@
 <context>
     <name>SubprogramsCollectionDialog</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="29"/>
         <source>Subprograms collection manager</source>
         <translation>Gestionnaire de collection de sous-programmes</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="41"/>
         <source>Select All</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="43"/>
         <source>Deselect All</source>
         <translation>Tout désélectionner</translation>
     </message>
@@ -22,22 +19,18 @@
 <context>
     <name>subprogramsCollectionDialog</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Boîte de dialogue</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="20"/>
         <source>Available subprograms:</source>
         <translation>Sous-programmes disponibles :</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="27"/>
         <source>Select all</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="66"/>
         <source>WARNING: existing subprograms will be overwritten!</source>
         <translation>AVERTISSEMENT : les sous-programmes existants seront écrasés !</translation>
     </message>
@@ -45,83 +38,66 @@
 <context>
     <name>subprogramsImporterExporter::SubprogramsImporterExporterPlugin</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="38"/>
         <source>Subprograms</source>
         <translation>Sous-programmes</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="41"/>
         <source>Import from file...</source>
         <translation>Importer depuis un fichier...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="42"/>
         <source>Export to file...</source>
         <translation>Exporter vers un fichier...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="43"/>
         <source>Save to collection...</source>
         <translation>Enregistrer dans la collection...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="44"/>
         <source>Load from collection</source>
         <translation>Charger depuis la collection</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="45"/>
         <source>Clear collection</source>
         <translation>Effacer la collection</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="100"/>
         <source>Select subprograms file (name for new one)</source>
         <translation>Sélectionner le fichier de sous-programmes (nom pour un nouveau)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="101"/>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="144"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Fichier de sauvegarde QReal (*.qrs)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="122"/>
         <source>There are no subprograms in your project.</source>
         <translation>Il n&apos;y a aucun sous-programme dans votre projet.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="143"/>
         <source>Select subprograms file</source>
         <translation>Sélectionner le fichier de sous-programmes</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="200"/>
         <source>There are not subprograms in your project</source>
         <translation>Il n&apos;y a pas de sous-programmes dans votre projet</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="241"/>
         <source>There are no subprograms in your collection for %1 robot.</source>
         <translation>Il n&apos;y a pas de sous-programmes dans votre collection pour le robot %1.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="288"/>
         <source>Clear the collection</source>
         <translation>Effacer la collection</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="289"/>
         <source>Remove all subprograms for all kits from the collection?</source>
         <translation>Supprimer tous les sous-programmes pour tous les kits de la collection ?</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="300"/>
         <source>There is no opened project</source>
         <translation>Aucun projet n&apos;est ouvert</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="322"/>
         <source>There are different subprograms with the same name in your project. Please make them unique.</source>
         <translation>Il existe des sous-programmes différents portant le même nom dans votre projet. Veuillez les rendre uniques.</translation>
     </message>

--- a/qrtranslations/fr/plugins/tools/updatesChecker_fr.ts
+++ b/qrtranslations/fr/plugins/tools/updatesChecker_fr.ts
@@ -4,22 +4,18 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="+23"/>
         <source>New updates are available!</source>
         <translation>De nouvelles mises à jour sont disponibles !</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Update</source>
         <translation>Mise à jour</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Later</source>
         <translation>Plus tard</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Yeah!</source>
         <translation>Oui !</translation>
     </message>
@@ -27,27 +23,22 @@
 <context>
     <name>updatesChecker::UpdatesCheckerPlugin</name>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="+33"/>
         <source>Check for updates</source>
         <translation>Vérifier si des mises à jour sont disponibles</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>There is some connection problem, may be network is disabled</source>
         <translation>Problème de connexion, il est possible que le réseau soit désactivé</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>There is some unrecognized error with updating process</source>
         <translation>Une erreur inconnue s&apos;est produite lors de la mise à jour (veuillez contacter les développeurs)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>No updates available</source>
         <translation>Pas de mises à jour disponibles</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Check for updates on start</source>
         <translation>Vérifier si des mises à jour sont disponibles à chaque lancement du programme</translation>
     </message>

--- a/qrtranslations/fr/qrgui/dialogs_fr.ts
+++ b/qrtranslations/fr/qrgui/dialogs_fr.ts
@@ -4,27 +4,22 @@
 <context>
     <name>AddNodeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="+14"/>
         <source>Node properties</source>
         <translation>Propriété du nœud</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>name: *</source>
         <translation>Nom : *</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Make it root element of a diagram</source>
         <translation>Désiner racine du diagramme</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>* Need to be filled</source>
         <translation>* Doit être rempli</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -32,17 +27,14 @@
 <context>
     <name>ChooseTypeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/chooseTypeDialog.ui" line="+14"/>
         <source>Choose element type</source>
         <translation>Choisissez le type d&apos;élement</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Entity</source>
         <translation>Entité</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Relationship</source>
         <translation>Relations</translation>
     </message>
@@ -50,37 +42,30 @@
 <context>
     <name>DynamicPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="+35"/>
         <source>Dialog</source>
         <translation>Restauration de la propriété</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Subprogram name:</source>
         <translation>Nom de la sous-programme :</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Subprogram arguments:</source>
         <translation>Arguments du sous-programme :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Add Argument</source>
         <translation>Ajouter un argument</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Subprogram picture:</source>
         <translation>Image :</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Subprogram picture background:</source>
         <translation>Fond :</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save All</source>
         <translation>Tout enregistrer</translation>
     </message>
@@ -88,118 +73,90 @@
 <context>
     <name>EdgePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="+14"/>
         <source>Edge properties</source>
         <translation>Propriétés du lien</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>name: *</source>
         <translation>nom : *</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>labelText:</source>
         <translation>marqueur texte :</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>labelType:</source>
         <translation>Type du marqueur :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Dynamic text</source>
         <translation>Texte dynamique</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Static text</source>
         <translation>Texte statique</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Line</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>lineType:</source>
         <translation>Type de ligne :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>solidLine</source>
         <translation>Plein</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>dashLine</source>
         <translation>Trait tireté</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>dotLine</source>
         <translation>Pointillé</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>beginType:</source>
         <translation>Forme de debut :</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+80"/>
         <source>no_arrow</source>
         <translation>pas_de_flèche</translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>open_arrow</source>
         <translation>flèche_ouverte</translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>empty_arrow</source>
         <translation>flèche_vide</translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>filled_arrow</source>
         <translation>flèche_pleine</translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>empty_rhomb</source>
         <translation>losange_vide</translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>filled_rhomb</source>
         <translation>losange_plein</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>endType:</source>
         <translation>Forme de la fin du trait:</translation>
     </message>
     <message>
-        <location line="-138"/>
         <source>* Need to be filled</source>
         <translation>* Doit être rempli</translation>
     </message>
     <message>
-        <location line="+230"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -207,32 +164,26 @@
 <context>
     <name>EditPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Propriétés</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>name: *</source>
         <translation>nom : *</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>attributeType: *</source>
         <translation>Type : *</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>defaultValue: </source>
         <translation>Valeur par défaut :</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>* Need to be filled</source>
         <translation>* Doit être rempli</translation>
     </message>
@@ -240,67 +191,54 @@
 <context>
     <name>FindReplaceDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Rechercher et remplacer</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Find what:</source>
         <translation>Rechercher :</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Replace with:</source>
         <translation>Remplacer par :</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>by name</source>
         <translation>par nom</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>by type</source>
         <translation>par type</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>by property</source>
         <translation>par propriété</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>by property content</source>
         <translation>par le contenu de propriété</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>by regular expression</source>
         <translation>par une expression régulière</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>case sensitivity</source>
         <translation>sensibilité à la casse</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.cpp" line="+43"/>
         <source>Search</source>
         <translation>Recherche</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source> / </source>
         <translation> / </translation>
     </message>
@@ -308,27 +246,22 @@
 <context>
     <name>PropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Propriétés</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Change</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -336,9 +269,6 @@
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="+123"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="+47"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="+47"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
@@ -346,22 +276,18 @@
 <context>
     <name>RestoreElementDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Restauration d&apos;élement</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>In earlier language versions already used the elements with the same name:</source>
         <translation>Dans les versions précédentes du langage des élements avec ce nom ont étés deja utilisés :</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Restore</source>
         <translation>Restaurer</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Create New</source>
         <translation>Créer nouveau</translation>
     </message>
@@ -369,22 +295,18 @@
 <context>
     <name>RestorePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Restauration d&apos;une propriété</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>In earlier language versions already used the properties with the same name:</source>
         <translation>Dans les versions précédentes du langage des propriétés avec ce nom ont étés deja utilisées :</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Restore</source>
         <translation>Restaurer</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Create New</source>
         <translation>Créer nouveau</translation>
     </message>
@@ -392,32 +314,26 @@
 <context>
     <name>qReal::EditPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="-20"/>
         <source>Warning:</source>
         <translation>Attention :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You changed the type of property. In case of incorrect conversion it may result in resetting of the existing property value.</source>
         <translation>Vous avez modifié le type de propriété. Dans le cas d&apos;une conversion incorrecte ça peut écraser la valeur de la propriété existante.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Proceed anyway</source>
         <translation>Continuer malgré cela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cancel the type conversion</source>
         <translation>Annuler la conversion de type</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>All required properties should be filled</source>
         <translation>Toutes les propriétés obligatoires doivent être remplies</translation>
     </message>
@@ -426,17 +342,14 @@
         <translation type="obsolete">Toutes les propriétés indespensables doivent être renseignées !</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Restore properties</source>
         <translation>Restaurer les propriétés</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add new property</source>
         <translation>Rajouter une nouvelle propriété</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Properties editor: </source>
         <translation>Editeur de propriétés :</translation>
     </message>
@@ -455,7 +368,6 @@
 <context>
     <name>qReal::ProgressDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/progressDialog/progressDialog.cpp" line="+26"/>
         <source>Please wait...</source>
         <translation>Patientez, s&apos;il vous plait...</translation>
     </message>
@@ -463,27 +375,22 @@
 <context>
     <name>qReal::RestoreElementDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="+48"/>
         <source>Existed</source>
         <translation>Deja utilisé</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Deleted</source>
         <translation>Supprimé</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
@@ -491,32 +398,26 @@
 <context>
     <name>qReal::RestorePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="+29"/>
         <source>Property name</source>
         <translation>Nom de la propriété</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>State</source>
         <translation>État</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Default value</source>
         <translation>Valeur par défaut</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Deleted</source>
         <translation>Supprimé</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Existed</source>
         <translation>Deja utilisé</translation>
     </message>
@@ -524,7 +425,6 @@
 <context>
     <name>qReal::SuggestToCreateDiagramDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramDialog.cpp" line="+32"/>
         <source>Create diagram</source>
         <translation>Créer un diagramme</translation>
     </message>
@@ -532,12 +432,10 @@
 <context>
     <name>qReal::SuggestToCreateDiagramWidget</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramWidget.cpp" line="+47"/>
         <source>editor: </source>
         <translation>editeur : </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>, diagram: </source>
         <translation>, diagramme : </translation>
     </message>
@@ -545,7 +443,6 @@
 <context>
     <name>qReal::SuggestToCreateProjectDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateProjectDialog.cpp" line="+33"/>
         <source>Create project</source>
         <translation>Créer un projet</translation>
     </message>
@@ -553,12 +450,10 @@
 <context>
     <name>qReal::gui::AddNodeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="-1"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>All required properties should be filled</source>
         <translation>Toutes les propriétés obligatoires doivent être remplies</translation>
     </message>
@@ -570,64 +465,50 @@
 <context>
     <name>qReal::gui::DynamicPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="+49"/>
         <source>Properties</source>
         <translation>Propriétés</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+104"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There is already a subprogram with that name</source>
         <translation>Un sous-programme portant ce nom existe déjà</translation>
     </message>
     <message>
-        <location line="+187"/>
         <source>Name is not filled in row %1</source>
         <translation>Le nom du paramètre %1 n&apos;est pas renseigné</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name should start with a letter(row %1)</source>
         <translation>Le nom de l&apos;argument doit commencer par une lettre (ligne %1)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Value in row %1 is not integer</source>
         <translation>La valeur du paramètre %1 n&apos;est pas un entier</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value in row %1 is not float</source>
         <translation>La valeur du paramètre %1 n&apos;est pas un nombre</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Duplicate names</source>
         <translation>Noms identiques</translation>
     </message>
     <message>
-        <location line="-269"/>
-        <location line="+277"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -635,12 +516,10 @@
 <context>
     <name>qReal::gui::EdgePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="-1"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>All required properties should be filled</source>
         <translation>Toutes les propriétés obligatoires doivent être remplies</translation>
     </message>
@@ -652,7 +531,6 @@
 <context>
     <name>qReal::gui::PropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.cpp" line="+41"/>
         <source>Properties: </source>
         <translation>Propriétés :</translation>
     </message>

--- a/qrtranslations/fr/qrgui/editor_fr.ts
+++ b/qrtranslations/fr/qrgui/editor_fr.ts
@@ -22,32 +22,26 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="+23"/>
         <source>Add connection</source>
         <translation>Rajouter une connexion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to other</source>
         <translation>Connecter à un autre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disconnect</source>
         <translation>Déconnecter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Go to connected element</source>
         <translation>Aller à l&apos;élement connecté</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Expand explosion</source>
         <translation>Déplier</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Collapse explosion</source>
         <translation>Replier</translation>
     </message>
@@ -145,17 +139,14 @@
 <context>
     <name>qReal::gui::editor::BrokenLine</name>
     <message>
-        <location filename="../../../qrgui/editor/private/brokenLine.cpp" line="+24"/>
         <source>Delete point</source>
         <translation>Supprimer le point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete segment</source>
         <translation>Supprimer le segment</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Remove all points</source>
         <translation>Supprimer tous les points</translation>
     </message>
@@ -163,12 +154,10 @@
 <context>
     <name>qReal::gui::editor::EdgeElement</name>
     <message>
-        <location filename="../../../qrgui/editor/edgeElement.cpp" line="+62"/>
         <source>Reverse</source>
         <translation>Inverser</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Change shape type</source>
         <translation>Changer le type de forme</translation>
     </message>
@@ -176,28 +165,22 @@
 <context>
     <name>qReal::gui::editor::EditorViewScene</name>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="+294"/>
         <source>Create new element</source>
         <translation>Créer un nouvel élément</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location line="+9"/>
         <source>Connect with the current item</source>
         <translation>Connecter à l&apos;élément actuel</translation>
     </message>
     <message>
-        <location line="+328"/>
         <source>Replace by...</source>
         <translation>Remplacer par...</translation>
     </message>
     <message>
-        <location line="+232"/>
         <source>Add child</source>
         <translation>Ajouter un élément</translation>
     </message>
     <message>
-        <location line="+492"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -221,17 +204,14 @@
 <context>
     <name>qReal::gui::editor::LineFactory</name>
     <message>
-        <location filename="../../../qrgui/editor/private/lineFactory.cpp" line="+49"/>
         <source>Broken</source>
         <translation>Ligne brisée</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Square</source>
         <translation>Rectangulaire</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Courbe</translation>
     </message>
@@ -239,7 +219,6 @@
 <context>
     <name>qReal::gui::editor::NodeElement</name>
     <message>
-        <location filename="../../../qrgui/editor/nodeElement.cpp" line="+53"/>
         <source>Switch on grid</source>
         <translation>Activer la grille</translation>
     </message>
@@ -247,12 +226,10 @@
 <context>
     <name>qReal::gui::editor::PropertyEditorView</name>
     <message>
-        <location filename="../../../qrgui/editor/propertyEditorView.cpp" line="+305"/>
         <source>Specify directory:</source>
         <translation>Spécifiez le répertoire :</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select file:</source>
         <translation>Sélectionner le fichier :</translation>
     </message>
@@ -260,7 +237,6 @@
 <context>
     <name>qReal::gui::editor::PushButtonPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/editor/private/pushButtonProperty.cpp" line="+38"/>
         <source>Click to choose</source>
         <translation>Cliquez pour choisir</translation>
     </message>
@@ -268,7 +244,6 @@
 <context>
     <name>qReal::gui::editor::SquareLine</name>
     <message>
-        <location filename="../../../qrgui/editor/private/squareLine.cpp" line="+27"/>
         <source>Lay out</source>
         <translation>Réorganiser</translation>
     </message>
@@ -276,24 +251,18 @@
 <context>
     <name>qReal::gui::editor::view::details::ExploserView</name>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="+80"/>
-        <location line="+111"/>
         <source>New </source>
         <translation>Nouveau </translation>
     </message>
     <message>
-        <location line="-61"/>
-        <location line="+14"/>
         <source>Change Properties</source>
         <translation>Modifier les propriétés</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Change Appearance</source>
         <translation>Modifier l&apos;apparence</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Add element to palette</source>
         <translation>Ajouter l&apos;élément à la palette</translation>
     </message>

--- a/qrtranslations/fr/qrgui/hotKeyManager_fr.ts
+++ b/qrtranslations/fr/qrgui/hotKeyManager_fr.ts
@@ -4,12 +4,10 @@
 <context>
     <name>PreferencesHotKeyManagerPage</name>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.cpp" line="+98"/>
         <source>Question</source>
         <translation>Question</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>This will clear all current shortcuts. Are you sure?</source>
         <translation>Tous les raccourcis clavier seront supprimés. En êtes-vous sûr ?</translation>
     </message>
@@ -17,67 +15,54 @@
 <context>
     <name>hotKeyManagerPage</name>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulaire</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Keyboard Shortcuts</source>
         <translation>Raccourcis clavier</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Import...</source>
         <translation>Importer...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Export...</source>
         <translation>Exporter...</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Command</source>
         <translation>Commande</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Shortcut 1</source>
         <translation>Raccourci 1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Shortcut 2</source>
         <translation>Raccourci 2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Shortcut 3</source>
         <translation>Raccourci 3</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Reset All</source>
         <translation>Tout effacer</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Shortcut</source>
         <translation>Raccourci</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Reset</source>
         <translation>Réinitialiser</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Key sequence</source>
         <translation>Sequence de touches</translation>
     </message>

--- a/qrtranslations/fr/qrgui/mainWindow_fr.ts
+++ b/qrtranslations/fr/qrgui/mainWindow_fr.ts
@@ -4,12 +4,10 @@
 <context>
     <name>ErrorListWidget</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorListWidget.cpp" line="+60"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
@@ -17,52 +15,34 @@
 <context>
     <name>FindManager</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="+39"/>
-        <location line="+42"/>
-        <location line="+1"/>
         <source>by name</source>
         <translation>par nom</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>by type</source>
         <translation>par type</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>by property</source>
         <translation>par propriété</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+45"/>
-        <location line="+1"/>
         <source>by property content</source>
         <translation>par le contenu de propriété</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+4"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>case sensitivity</source>
         <translation>sensibilité à la casse</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+3"/>
-        <location line="+25"/>
-        <location line="+9"/>
         <source>by regular expression</source>
         <translation>par une expression régulière</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>, </source>
         <translation>, </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>   :: </source>
         <translation>   :: </translation>
     </message>
@@ -70,72 +50,58 @@
 <context>
     <name>MainWindowUi</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="+14"/>
         <source>QReal</source>
         <translation>QReal</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&amp;View</source>
         <translation>&amp;Affichage</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Panels</source>
         <translation>Tableaux</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Settings</source>
         <translation>&amp;Paramètres</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Tools</source>
         <translation>&amp;Outils</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Edit</source>
         <translation>&amp;Edition</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>File Toolbar</source>
         <translation>Barre de fichiers</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Mini Map</source>
         <translation>Minicarte</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Palette</source>
         <translation>Palette</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Edit Toolbar</source>
         <translation>Barre d&apos;edition</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>View Toolbar</source>
         <translation>Barre d&apos;affichage</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Logical Model Explorer</source>
         <translation>Navigateur de modèle logique</translation>
     </message>
@@ -144,87 +110,70 @@
         <translation type="obsolete">Sortie</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Errors</source>
         <translation>Erreurs</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Graphical Model Explorer</source>
         <translation>Navigateur de modèle graphique</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Property Editor</source>
         <translation>Editeur de propriétés</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Interpreter Toolbar</source>
         <translation>Barre d&apos;interpréteur</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Generators Toolbar</source>
         <translation>Barre de générateurs</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Quit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Zoom In</source>
         <translation>Zoom avant</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl++</source>
         <translation>Ctrl++</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Zoom Out</source>
         <translation>Zoom arrière</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+-</source>
         <translation>Ctrl+-</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Antialiasing</source>
         <translation>Anticrénelage</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>OpenGL Renderer</source>
         <translation>Moteur de rendu OpenGL</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export to SVG</source>
         <translation>Exporter en SVG</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Open in new tab</source>
         <translation>Ouvrir dans un nouvel onglet</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Small Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
@@ -233,7 +182,6 @@
         <translation type="vanished">À propos...</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>About Qt...</source>
         <translation>À propos Qt...</translation>
     </message>
@@ -242,285 +190,226 @@
         <translation type="vanished">Afficher l&apos;écran de démarrage</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Open Logs</source>
         <translation>Ouvrir les journaux</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>About </source>
         <translation>À propos </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Save as...</source>
         <translation>Enregistrer sous...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Open...</source>
         <translation>Ouvrir...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Show grid</source>
         <translation>Afficher la grille</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch on grid</source>
         <translation>Actionner la grille</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Mouse gestures</source>
         <translation>Gestes souris</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Preferences...</source>
         <translation>Préférences...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Switch on alignment</source>
         <translation>Actionner l&apos;alignement</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Show alignment</source>
         <translation>Afficher l&apos;alignement</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Debug</source>
         <translation>Déboguer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>F9</source>
         <translation>F9</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Generate and build</source>
         <translation>Générer et assembler</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+F9</source>
         <translation>Ctrl+F9</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+3"/>
         <source>Set breakpoints</source>
         <translation>Points d&apos;arrêt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+F3</source>
         <translation>Ctrl+F3</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cont</source>
         <translation>Continuer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+F6</source>
         <translation>Ctrl+F6</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Configure</source>
         <translation>Configurer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+F2</source>
         <translation>Ctrl+F2</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>New Diagram</source>
         <translation>Nouveau diagramme</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create new diagram in a current model</source>
         <translation>Créer un nouveau diagramme dans le modèle courant</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+3"/>
         <source>Fullscreen Mode</source>
         <translation>Mode plein écran</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+F</source>
         <translation>Ctrl+Shift+F</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>New Project</source>
         <translation>Nouveau projet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+N</source>
         <translation>Ctrl+Shift+N</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Import...</source>
         <translation>Importer...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Import QReal project into current.</source>
         <translation>Importer un projet QReal dans le projet courant.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Save diagram as a picture...</source>
         <translation>Enregistrer le diagramme comme une image...</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Close project</source>
         <translation>Fermer le projet</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Find...</source>
         <translation>Rechercher...</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Find and replace</source>
         <translation>Rechercher et remplacer</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Replace by...</source>
         <translation>Remplacer par...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Undo</source>
         <translation>Défaire</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Z</source>
         <translation>Ctrl+Z</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Redo</source>
         <translation>Refaire</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+Z</source>
         <translation>Ctrl+Shift+Z</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export to XML</source>
         <translation>Exporter comme XML</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Show all text</source>
         <translation>Afficher tout le texte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+T</source>
         <translation>Ctrl+Shift+T</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+3"/>
         <source>Hide bottom docks</source>
         <translation>Masquer les panneaux en bas de la fenêtre</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Esc</source>
         <translation>Échap</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Restore default settings and Quit</source>
         <translation>Restaurer les paramètres par défaut et quitter</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Open Examples...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
@@ -528,7 +417,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="+160"/>
         <source>Can`t open project file</source>
         <translation>Le projet ne peut pas être ouvert</translation>
     </message>
@@ -536,7 +424,6 @@
 <context>
     <name>ReferenceList</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/referenceList.ui" line="+14"/>
         <source>Choose a reference value</source>
         <translation>Choisissez une valeur de référence</translation>
     </message>
@@ -544,165 +431,130 @@
 <context>
     <name>ShapeEdit</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="+14"/>
         <source>Form</source>
         <translation>Forme</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Save</source>
         <translation>Enregister</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Draw ellipse</source>
         <translation>Dessiner une ellipse</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Add static text</source>
         <translation>Ajouter du texte statique</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Add dynamic text</source>
         <translation>Ajouter du texte dynamique</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Save as picture</source>
         <translation>Enregistrer comme une image</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Draw curve</source>
         <translation>Dessiner une courbe</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Save to Xml</source>
         <translation>Enregister comme Xml</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Font</source>
         <translation>Police</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Family</source>
         <translation>Famille</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+433"/>
-        <location line="+139"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location line="-551"/>
         <source>Text format</source>
         <translation>Format du texte</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Italic</source>
         <translation>Italique</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source> Bold</source>
         <translation>Gras</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Underline</source>
         <translation>Souligné</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Stylus</source>
         <translation>Stylo</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Add line port</source>
         <translation>Rajouter un port linèaire</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Add point port</source>
         <translation>Rajouter un port ponctuel</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Add picture text</source>
         <translation>Ajouter un texte-image</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Draw rectangle</source>
         <translation>Dessiner un rectangle</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Pen</source>
         <translation>Stylo</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+145"/>
         <source>Style</source>
         <translation>Style</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Width</source>
         <translation>Epaisseur</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Brush</source>
         <translation>Brosse</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Image</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Draw line</source>
         <translation>Dessiner une ligne</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>VisibilityConditions</source>
         <translation>Les conditions de visibilité</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Delete Item</source>
         <translation>Supprimer un élément</translation>
     </message>
@@ -710,7 +562,6 @@
 <context>
     <name>VisibilityConditionsDialog</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/visibilityConditionsDialog.ui" line="+14"/>
         <source>Specify conditions in which choosen element must be shown</source>
         <translation>Specifiez les conditions sous lesquelles l&apos;élément doit être affiché</translation>
     </message>
@@ -718,7 +569,6 @@
 <context>
     <name>qReal::MainWindow</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="+676"/>
         <source>Could not save file, try to save it to another place</source>
         <translation>Impossible d&apos;enregistrer le fichier, essayez de l&apos;enregistrer à un autre emplacement</translation>
     </message>
@@ -727,12 +577,10 @@
         <translation type="vanished">À propo de QReal</translation>
     </message>
     <message>
-        <location line="-478"/>
         <source>Restore default settings</source>
         <translation>Restaurer les paramètres par défaut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you realy want to restore default settings?
 WARNING: Settings restoring cannot be undone
 WARNING: The settings will be restored after application restart</source>
@@ -741,160 +589,126 @@ AVERTISSEMENT : La restauration des paramètres est irréversible
 AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apos;application</translation>
     </message>
     <message>
-        <location line="+775"/>
-        <location line="+11"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Plugin unloading failed: </source>
         <translation>Le déchargement d&apos;une extention a échoué :</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Plugin loading failed: </source>
         <translation>Le chargement d&apos;une extention a échoué :</translation>
     </message>
     <message>
-        <location line="+110"/>
-        <location line="+16"/>
-        <location line="+23"/>
         <source>Shape Editor</source>
         <translation>Editeur de formes</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Text Editor</source>
         <translation>Editeur de texte</translation>
     </message>
     <message>
-        <location line="+220"/>
         <source>New diagram</source>
         <translation>Nouveau diagramme</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open project</source>
         <translation>Ouvrir un projet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save project</source>
         <translation>Enregister le projet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save project as</source>
         <translation>Enregister le projet sous</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New project</source>
         <translation>Nouveau projet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation>Défaire</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation>Refaire</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation>Zoom avant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation>Zoom arrière</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close current tab</source>
         <translation>Fermer l&apos;onglet courant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close all tabs</source>
         <translation>Fermer tous les onglets</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find and replace</source>
         <translation>Rechercher et remplacer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all text</source>
         <translation>Afficher tout le texte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle errors panel</source>
         <translation>Afficher/masquer le panneau des erreurs</translation>
     </message>
     <message>
-        <location line="+202"/>
         <source>Gestures Show</source>
         <translation>Afficher les gestes</translation>
     </message>
     <message>
-        <location line="+340"/>
         <source>Shortcuts</source>
         <translation>Raccourcis</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>External tools</source>
         <translation>Outils externes</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Failed to open %1</source>
         <translation>Échec de l&apos;ouverture de %1</translation>
     </message>
     <message>
-        <location line="+195"/>
         <source>Recent projects</source>
         <translation>Projets récents</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Recent files</source>
         <translation>Fichiers récents</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Save File</source>
         <translation>Enregister le fichier</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Images (*.png *.jpg)</translation>
     </message>
     <message>
-        <location line="+161"/>
         <source>Getting Started</source>
         <translation>Commencer</translation>
     </message>
@@ -902,57 +716,46 @@ AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apo
 <context>
     <name>qReal::ProjectManagerWrapper</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="-89"/>
         <source>Save</source>
         <translation>Enregister</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Save</source>
         <translation>&amp;Enregister</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Annuler</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Discard</source>
         <translation>&amp;Jeter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to save current project?</source>
         <translation>Voulez-vous sauvegarder le projet courant ?</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Unsaved project</source>
         <translation>Projet non sauvegardé</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source> [modified]</source>
         <translation>[modifié]</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Select file to save current metamodel to</source>
         <translation>Choisir un fichier pour enregister le metamodèle courant</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>QReal Save File (*.qrs)</source>
         <translation>Fichier de sauvegarde QReal (*.qrs)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>All files (*.*)</source>
         <translation>Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Fichier de sauvegarde QReal (*.qrs)</translation>
     </message>
@@ -960,7 +763,6 @@ AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apo
 <context>
     <name>qReal::ShapeEdit</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.cpp" line="+352"/>
         <source>Saving</source>
         <translation>Enregistrement</translation>
     </message>
@@ -972,7 +774,6 @@ AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apo
         <translation type="vanished">Ouvrir un projet existant</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="+135"/>
         <source>New project</source>
         <translation>Nouveau projet</translation>
     </message>
@@ -985,42 +786,34 @@ AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apo
         <translation type="vanished">Créer un diagramme intérprété</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Open project</source>
         <translation>Ouvrir le projet</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Recent projects</source>
         <translation>Projets récents</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Create </source>
         <translation>Créer</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Editor: </source>
         <translation>Editeur :</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>; Diagram: </source>
         <translation>; Diagramme :</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select file with metamodel to open</source>
         <translation>Chosir un fichier avec le metamodèle pour l&apos;ouvrir</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Enter the diagram name:</source>
         <translation>Entrez le nom du diagramme :</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>diagram name:</source>
         <translation>Nom du diagramme :</translation>
     </message>
@@ -1028,79 +821,58 @@ AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apo
 <context>
     <name>qReal::gui::DraggableElement</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="+89"/>
         <source>Mouse gesture</source>
         <translation>Geste souris</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Deleting an element: </source>
         <translation>Supression d&apos;un élément :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete this item and all its graphicalrepresentation from the scene and from the palette?</source>
         <translation>Est-ce que vous voulez vraiment supprimer cet élément ainsi que toutes ses représentations graphiques de la scene et de la palette ?</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+40"/>
-        <location line="+38"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+40"/>
-        <location line="+38"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location line="-48"/>
-        <location line="+33"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <location line="+33"/>
         <source>The deleted element </source>
         <translation>L&apos;élément supprimé</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source> is the element of root digram. Continue to delete?</source>
         <translation>est l&apos;élément racine du diagramme. Continuer la suppression ?</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source> has inheritors:</source>
         <translation>a des héritiers :</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If you delete it, its properties will be removed fromthe elements-inheritors. Continue to delete?</source>
         <translation>Si vous le supprimer, ses propriétés seront supprimées de la liste des éléments héritiers. Continuer la supprssion ?</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+29"/>
         <source>Change Properties</source>
         <translation>Modifier les propriétés</translation>
     </message>
     <message>
-        <location line="-24"/>
         <source>Change Appearance</source>
         <translation>Modifier l&apos;apparence</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Delete Element</source>
         <translation>Supprimer l&apos;élément</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -1108,22 +880,18 @@ AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apo
 <context>
     <name>qReal::gui::ErrorReporter</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="+215"/>
         <source>INFORMATION:</source>
         <translation>INFORMATION :</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>WARNING:</source>
         <translation>ATTENTION :</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>ERROR:</source>
         <translation>ERREUR :</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>CRITICAL:</source>
         <translation>CRITIQUE :</translation>
     </message>
@@ -1131,7 +899,6 @@ AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apo
 <context>
     <name>qReal::gui::ModelExplorer</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/modelExplorer.cpp" line="+35"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -1143,12 +910,10 @@ AVERTISSEMENT : Les paramètres seront rétablis après le redémarrage de l&apo
         <translation type="obsolete">Ajouter un élément</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="+157"/>
         <source>Add Entity</source>
         <translation>Ajouter une entité</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Relastionship</source>
         <translation>Ajouter une relation</translation>
     </message>

--- a/qrtranslations/fr/qrgui/models_fr.ts
+++ b/qrtranslations/fr/qrgui/models_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>qReal::gui::RenameDialog</name>
     <message>
-        <location filename="../../../qrgui/models/details/renameDialog.cpp" line="+26"/>
         <source>Enter new name</source>
         <translation>Entrer un nouveau nom</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>qReal::models::details::modelsImplementation::AbstractModel</name>
     <message>
-        <location filename="../../../qrgui/models/details/modelsImplementation/abstractModel.cpp" line="+45"/>
         <source>name</source>
         <translation>nom</translation>
     </message>

--- a/qrtranslations/fr/qrgui/mouseGestures_fr.ts
+++ b/qrtranslations/fr/qrgui/mouseGestures_fr.ts
@@ -4,17 +4,14 @@
 <context>
     <name>GesturesWidget</name>
     <message>
-        <location filename="../../../qrgui/mouseGestures/gesturesWidget.ui" line="+20"/>
         <source>Form</source>
         <translation>Forme</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List of mouse gestures</source>
         <translation>Liste des gestes souris</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Click to see how to draw it:</source>
         <translation>Cliquez pour voir comment le dessiner : </translation>
     </message>

--- a/qrtranslations/fr/qrgui/plugins/metaMetaModel_fr.ts
+++ b/qrtranslations/fr/qrgui/plugins/metaMetaModel_fr.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/metaMetaModel/src/metamodel.cpp" line="+74"/>
         <source>Unknown element %1</source>
         <translation>Élément inconnu %1</translation>
     </message>

--- a/qrtranslations/fr/qrgui/plugins/pluginManager_fr.ts
+++ b/qrtranslations/fr/qrgui/plugins/pluginManager_fr.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="+598"/>
         <source>Root node for diagram %1 (which is %2) does not exist!</source>
         <translation>Le nœud racine du diagramme %1 (qui est %2) n&apos;existe pas !</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Name should contain only latin letters, digits, spaces and underscores and should start with latin letter or underscore</source>
         <translation>Le nom ne doit contenir que des lettres latines, des chiffres, des espaces et des traits de soulignement, et doit commencer par une lettre latine ou un trait de soulignement</translation>
     </message>
@@ -32,32 +30,26 @@
 <context>
     <name>qReal::QrsMetamodelLoader</name>
     <message>
-        <location line="-438"/>
         <source>Incorrect label type</source>
         <translation>Type d&apos;étiquette incorrect</translation>
     </message>
     <message>
-        <location line="+433"/>
         <source>Name should not be empty</source>
         <translation>Le nom ne doit pas être vide</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Port type %1 not declared in metamodel</source>
         <translation>Le type de port %1 n&apos;est pas déclaré dans le métamodèle</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Unknown link style type %1</source>
         <translation>Type de style de lien inconnu : %1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unknown link shape type %1</source>
         <translation>Type de forme de lien inconnu : %1</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 is not a valid integer number</source>
         <translation>%1 n&apos;est pas un nombre entier valide</translation>
     </message>
@@ -65,12 +57,10 @@
 <context>
     <name>qReal::QrsMetamodelSaver</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelSaver.cpp" line="+389"/>
         <source>Unknown link style type %1</source>
         <translation>Type de style de lien inconnu : %1</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Unknown link shape type %1</source>
         <translation>Type de forme de lien inconnu : %1</translation>
     </message>

--- a/qrtranslations/fr/qrgui/preferencesDialog_fr.ts
+++ b/qrtranslations/fr/qrgui/preferencesDialog_fr.ts
@@ -4,72 +4,58 @@
 <context>
     <name>PreferencesBehaviourPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="+23"/>
         <source>User Interface</source>
         <translation>Interface utilisateur</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Language</source>
         <translation>Langage</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Automatics</source>
         <translation>Automatique</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Palette tab switching</source>
         <translation>Commutation d&apos;onglets de la palette</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>msec</source>
         <translation>msec</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Autosave</source>
         <translation>Sauvegarde automatique</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>sec</source>
         <translation>sec</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Delay after gesture</source>
         <translation>Délai après un geste</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Gestures</source>
         <translation>Gestes</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Touch</source>
         <translation>Touche</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Touch Mode</source>
         <translation>Mode tactile</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Widgets</source>
         <translation>Widgets</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Dockable mode</source>
         <translation>Mode fenêtres ancrables</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.cpp" line="+117"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Langage système&gt;</translation>
     </message>
@@ -77,17 +63,14 @@
 <context>
     <name>PreferencesDebuggerPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/debuggerPage.ui" line="+9"/>
         <source>Presentation</source>
         <translation>Présentation</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Debug timeout (ms):</source>
         <translation>Temps expiré de débogage (ms) :</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Color of highlighting:</source>
         <translation>Couleur de surlignage :</translation>
     </message>
@@ -95,32 +78,26 @@
 <context>
     <name>PreferencesDialog</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="+32"/>
         <source>Preferences</source>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Apply</source>
         <translation>Appliquer</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Import</source>
         <translation>Importer</translation>
     </message>
@@ -128,107 +105,86 @@
 <context>
     <name>PreferencesEditorPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="+24"/>
         <source>Font</source>
         <translation>Police</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Use some of system fonts</source>
         <translation>Utiliser les polices système</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose Font</source>
         <translation>Choisir la police</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Grid</source>
         <translation>Grille</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show grid</source>
         <translation>Afficher la grille</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Activate grid</source>
         <translation>Activer la grille</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show alignment</source>
         <translation>Afficher l&apos;alignement</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Activate alignment</source>
         <translation>Activer l&apos;alignement</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Cell size</source>
         <translation>Taille de cellule</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Node Elements</source>
         <translation>Éléments</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Drag area</source>
         <translation>Surface de traînée</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edge</source>
         <translation>Bord</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>broken</source>
         <translation>cassé</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>square</source>
         <translation>carré</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>curve</source>
         <translation>courbe</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line mode</source>
         <translation>type de lien</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Loop edges indent</source>
         <translation>Indentation de liens en boucle</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Embedded Linkers</source>
         <translation>Linkers embarqués</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Indent</source>
         <translation>Indentation</translation>
     </message>
@@ -245,27 +201,22 @@
         <translation type="vanished">Permettre le redimensionnement</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Palette</source>
         <translation>Palette</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>   Representation   </source>
         <translation>   Représentation </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>   Count of items in a row </source>
         <translation>   Nombre d&apos;éléments en ligne </translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Icons  and names</source>
         <translation>Icônes et les noms</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Icons</source>
         <translation>icônes</translation>
     </message>
@@ -273,33 +224,26 @@
 <context>
     <name>PreferencesFeaturesPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="+23"/>
         <source>Element controls</source>
         <translation>Éléments de commande</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Gestures</source>
         <translation>Gestes</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+7"/>
         <source>fast linking with mouse</source>
         <translation>Liaison rapide avec la souris</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Embedded Linkers</source>
         <translation>Linkers embarqués</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>fast property editing</source>
         <translation>Édition rapide de la propriété</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Embedded Controls</source>
         <translation>Éléments de commande embarqués</translation>
     </message>
@@ -307,52 +251,42 @@
 <context>
     <name>PreferencesMiscellaneousPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="+109"/>
         <source>Graphics</source>
         <translation>Graphes</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Antialiasing</source>
         <translation>Anticrénelage</translation>
     </message>
     <message>
-        <location line="+127"/>
         <source>Other</source>
         <translation>Autre</translation>
     </message>
     <message>
-        <location line="-108"/>
         <source>Show splashscreen</source>
         <translation>Afficher l&apos;écran de démarrage</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Limit recent projects list</source>
         <translation>Longueur maximale de la liste des projets récents</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Images</source>
         <translation>Images</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Browse</source>
         <translation>Explorer</translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Toolbars</source>
         <translation>Barres d&apos;outils</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.cpp" line="+57"/>
         <source>Open Directory</source>
         <translation>Ouvrir le répertoire</translation>
     </message>
@@ -360,43 +294,34 @@
 <context>
     <name>qReal::gui::PreferencesDialog</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="+58"/>
         <source>Behaviour</source>
         <translation>Comportement</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Miscellaneous</source>
         <translation>Divers</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Editor</source>
         <translation>Editeur</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You should restart the program to apply changes</source>
         <translation>Le programme doit être redemarré pour appliquer les modifications</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Save File</source>
         <translation>Enregister le fichier</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+11"/>
         <source>*.ini</source>
         <translation>*.ini</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Open File</source>
         <translation>Ouvrir le fichier</translation>
     </message>

--- a/qrtranslations/fr/qrgui/systemFacade_fr.ts
+++ b/qrtranslations/fr/qrgui/systemFacade_fr.ts
@@ -4,62 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="+26"/>
         <source>Information:</source>
         <translation>Informations :</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning:</source>
         <translation>Avertissement :</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error:</source>
         <translation>Erreur :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Critical:</source>
         <translation>Critique :</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bubble:</source>
         <translation>Bulle :</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="+256"/>
         <source>Can`t open project file</source>
         <translation>Impossible d&apos;ouvrir le fichier du projet</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="+114"/>
         <source>Project was automaticly converted from version %1 to version %2. Please check its contents.</source>
         <translation>Le projet a été automatiquement converti de la version %1 à la version %2. Veuillez en vérifier le contenu.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>The attempt to automaticly convert this project to the current enviroment version failed and thus save file can`t be opened. </source>
         <translation>La conversion automatique du projet en version d&apos;environnement courant a échoué, le fichier de sauvgarde ne peut pas être ouvert.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This project was created by version %1 of the editor.</source>
         <translation>Le projet a été crée par la version %1 de l&apos;editeur.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This project was created by too old version of the editor.</source>
         <translation>Ce projet a été crée par une version trop ancienne de l&apos;editeur.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source> It is now considered outdated and cannot be opened.</source>
         <translation> Il est considéré comme obsolet et ne peut pas être ouvert.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The save you are trying to open is made by version %1 of editor, whitch is newer than currently installed enviroment. Update your version before opening this save.</source>
         <translation>Le projet a été crée par une version %1 de l&apos;editeur, elle est plus moderne que l&apos;environnement courant, il faut effectuer une mise à jour.</translation>
     </message>
@@ -67,18 +55,14 @@
 <context>
     <name>qReal::Autosaver</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="+145"/>
-        <location line="+14"/>
         <source>Question</source>
         <translation>Question</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>More recent autosaved version of this file was found. Do you wish to open it instead?</source>
         <translation>Une version plus récente de sauvegarde automatique a été trouvée. Est-ce que vous voulez l&apos;ouvrir à la place ?</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>It seems like the last application session was terminated in an unusual way. Do you wish to recover unsaved project?</source>
         <translation>Il paraît que la dernière session a été terminée de façon anormale. Est-ce que vous voulez récupérer le projet non sauvegardé ?</translation>
     </message>
@@ -90,60 +74,47 @@
         <translation type="vanished">Ouvrir un projet existant</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="-180"/>
-        <location line="+14"/>
         <source>Open project</source>
         <translation>Ouvrir le projet</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+7"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Cannot open file, please try with another one.</source>
         <translation>Impossible d&apos;ouvrir le fichier, veuillez en essayer un autre.</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Select file with a save to import</source>
         <translation>Choisir le fichier avec la sauvegarde pour importer</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>There are missing plugins</source>
         <translation>Manque d&apos;extensions</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>These plugins are not present, but needed to load the save:
 </source>
         <translation>Ces extensions ne sont pas présents, mais sont necessaires pour charger et enregister :</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>This project contains unknown element %1 and thus can`t be opened. Probably it was created by old or incorrectly working version of QReal.</source>
         <translation>Ce projet contient un élément inconnue %1 et donc ne peut pas être ouvert. Peut être, il a été créeé avec une version trop ancienne (ou corrompue) de QReal.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Can`t open project file</source>
         <translation>Le fichier du projet ne peut pas être ouvert</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Select file to save current model to</source>
         <translation>Choisissez le ficher pour enregister le modèle</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>File not found</source>
         <translation>Fichier introuvable</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>File %1 not found. Try again</source>
         <translation>Fichier %1 introuvable. Réessayez de nouveau</translation>
     </message>

--- a/qrtranslations/fr/qrgui/textEditor_fr.ts
+++ b/qrtranslations/fr/qrgui/textEditor_fr.ts
@@ -4,47 +4,38 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="+91"/>
         <source>Text File</source>
         <translation>Fichier texte</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>C Language Source File</source>
         <translation>Fichier source en langage C</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Russian Algorithmic Language Source File</source>
         <translation>Fichier source en langage algorithmique russe</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Python Source File</source>
         <translation>Fichier source Python</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Java Script Language Source File</source>
         <translation>Fichier source en langage JavaScript</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>QtScript Language Source File</source>
         <translation>Fichier source en langage QtScript</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>F# Language Source File</source>
         <translation>Fichier source en langage F#</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>PascalABC Language Source File</source>
         <translation>Fichier source en langage PascalABC</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Lua Language Source File</source>
         <translation>Fichier source en langage Lua</translation>
     </message>
@@ -52,22 +43,18 @@
 <context>
     <name>qReal::text::TextManager</name>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="+86"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save before closing?</source>
         <translation>Enregistrer avant de fermer ?</translation>
     </message>
     <message>
-        <location line="+193"/>
         <source>All files (*)</source>
         <translation>Tous les fichiers (*)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Save generated code</source>
         <translation>Enregister le code généré</translation>
     </message>

--- a/qrtranslations/fr/qrgui/thirdparty_fr.ts
+++ b/qrtranslations/fr/qrgui/thirdparty_fr.ts
@@ -12,15 +12,10 @@
         <translation type="vanished">Faux</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="+233"/>
-        <location line="+10"/>
-        <location line="+25"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location line="-25"/>
-        <location line="+25"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
@@ -36,12 +31,10 @@
         <translation type="vanished">Faux</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="+1696"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
@@ -49,7 +42,6 @@
 <context>
     <name>QtCharEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="+1700"/>
         <source>Clear Char</source>
         <translation>Effacer</translation>
     </message>
@@ -57,7 +49,6 @@
 <context>
     <name>QtColorEditWidget</name>
     <message>
-        <location line="+668"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -65,22 +56,18 @@
 <context>
     <name>QtColorPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="+4799"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Blue</source>
         <translation>Bleu</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Alpha</source>
         <translation>Alpha</translation>
     </message>
@@ -88,97 +75,78 @@
 <context>
     <name>QtCursorDatabase</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="-210"/>
         <source>Arrow</source>
         <translation>Pointe</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Up Arrow</source>
         <translation>Flèche vers le haut</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Cross</source>
         <translation>Croix</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wait</source>
         <translation>Attendre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>IBeam</source>
         <translation>IBeam</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size Vertical</source>
         <translation>Hauteur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size Horizontal</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size Backslash</source>
         <translation>Taille barre oblique inverse</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size Slash</source>
         <translation>Taille barre oblique</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size All</source>
         <translation>Taille tout</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Blank</source>
         <translation>Vide</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Split Vertical</source>
         <translation>Fractionner verticalement</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Split Horizontal</source>
         <translation>Fractionner horizontalement</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pointing Hand</source>
         <translation>Main pointant</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Forbidden</source>
         <translation>Interdit</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Open Hand</source>
         <translation>Main ouverte</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Closed Hand</source>
         <translation>Main fermée</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>What&apos;s This</source>
         <translation>Qu&apos;est-ce que c&apos;est</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Busy</source>
         <translation>Occupé</translation>
     </message>
@@ -186,12 +154,10 @@
 <context>
     <name>QtFontEditWidget</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="+209"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Select Font</source>
         <translation>Choisir la police</translation>
     </message>
@@ -199,37 +165,30 @@
 <context>
     <name>QtFontPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="-350"/>
         <source>Family</source>
         <translation>Famille</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Point Size</source>
         <translation>Taille de point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Bold</source>
         <translation>Gras</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Italic</source>
         <translation>Italique</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Underline</source>
         <translation>Souligné</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Strikeout</source>
         <translation>Barré</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Kerning</source>
         <translation>Crénage</translation>
     </message>
@@ -237,7 +196,6 @@
 <context>
     <name>QtKeySequenceEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="+234"/>
         <source>Clear Shortcut</source>
         <translation>Effacer</translation>
     </message>
@@ -245,17 +203,14 @@
 <context>
     <name>QtLocalePropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="-3608"/>
         <source>%1, %2</source>
         <translation>%1, %2</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Language</source>
         <translation>Langage</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Country</source>
         <translation>Pays</translation>
     </message>
@@ -263,17 +218,14 @@
 <context>
     <name>QtPointFPropertyManager</name>
     <message>
-        <location line="+409"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -281,17 +233,14 @@
 <context>
     <name>QtPointPropertyManager</name>
     <message>
-        <location line="-319"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -299,12 +248,10 @@
 <context>
     <name>QtPropertyBrowserUtils</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="-141"/>
         <source>[%1, %2, %3] (%4)</source>
         <translation>[%1, %2, %3] (%4)</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>[%1, %2]</source>
         <translation>[%1, %2]</translation>
     </message>
@@ -312,27 +259,22 @@
 <context>
     <name>QtRectFPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="+1701"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
@@ -340,27 +282,22 @@
 <context>
     <name>QtRectPropertyManager</name>
     <message>
-        <location line="-611"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
@@ -368,17 +305,14 @@
 <context>
     <name>QtSizeFPropertyManager</name>
     <message>
-        <location line="-534"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
@@ -386,33 +320,26 @@
 <context>
     <name>QtSizePolicyPropertyManager</name>
     <message>
-        <location line="+1779"/>
-        <location line="+1"/>
         <source>&lt;Invalid&gt;</source>
         <translation>&lt;valeur incorrecte&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[%1, %2, %3, %4]</source>
         <translation>[%1, %2, %3, %4]</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Horizontal Policy</source>
         <translation>Politique horizontale</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Vertical Policy</source>
         <translation>Politique verticale</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Horizontal Stretch</source>
         <translation>Étirement horizontal</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Vertical Stretch</source>
         <translation>Étirement vertical</translation>
     </message>
@@ -420,17 +347,14 @@
 <context>
     <name>QtSizePropertyManager</name>
     <message>
-        <location line="-2355"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
@@ -438,12 +362,10 @@
 <context>
     <name>QtTreePropertyBrowser</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="+478"/>
         <source>Property</source>
         <translation>Propriété</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>

--- a/qrtranslations/fr/qrmc_fr.ts
+++ b/qrtranslations/fr/qrmc_fr.ts
@@ -4,19 +4,16 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrmc/main.cpp" line="26"/>
         <source>QReal Metamodel Compiler. It takes .qrs file with QReal metamodel created by metaeditor and generates Qt project with editor plugin for that metamodel. Project is ready to be built with qmake, but it actively uses QReal sources and build system, so it can not be built alone. Example of command line:
 </source>
         <translation>Compilateur de métamodèle QReal. Il prend un fichier .qrs contenant un métamodèle QReal créé par metaeditor et génère un projet Qt avec un plugin d&apos;éditeur pour ce métamodèle. Le projet est prêt à être compilé avec qmake, mais utilise activement les sources et le système de compilation de QReal, il ne peut donc pas être compilé indépendamment. Exemple de ligne de commande :
 </translation>
     </message>
     <message>
-        <location filename="../../qrmc/main.cpp" line="75"/>
         <source>Metamodel file to be processed.</source>
         <translation>Fichier de métamodèle à traiter.</translation>
     </message>
     <message>
-        <location filename="../../qrmc/main.cpp" line="77"/>
         <source>Directory to which source code of the editor plugin shall be generated.</source>
         <translation>Répertoire dans lequel le code source du plugin d&apos;éditeur sera généré.</translation>
     </message>

--- a/qrtranslations/fr/qrtext_fr.ts
+++ b/qrtranslations/fr/qrtext_fr.ts
@@ -4,269 +4,206 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/lexer/lexer.h" line="+60"/>
         <source>Invalid regexp: </source>
         <translation>Expression régulière invalide :</translation>
     </message>
     <message>
-        <location line="+111"/>
         <source>Unknown sequence of symbols: </source>
         <translation>Séquence de symboles inconnue :</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="+40"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/concatenationParser.h" line="+43"/>
         <source>Unexpected end of input</source>
         <translation>Fin de l&apos;entrée inattendue</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Parser can not decide which alternative to use on </source>
         <translation>Le parser ne peut pas décider quelle alternative à utiliser </translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/parser.h" line="+54"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="+11"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/concatenationParser.h" line="+29"/>
         <source>Unexpected token</source>
         <translation>Token inattendu</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/expressionParser.h" line="+94"/>
         <source>Binary operator in expression is of the wrong type</source>
         <translation>Opérateur binaire dans l&apos;expression est du mauvais type</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Right operand required</source>
         <translation>Opérande droite obligatoire</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/simpleParser.h" line="+51"/>
         <source>Semantic action incorrectly discarded node in SimpleParser</source>
         <translation>L&apos;action sémantique a incorrectement rejeté un noeud dans SimpleParser</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/tokenParser.h" line="+52"/>
         <source>Semantic action incorrectly discarded node in TokenParser</source>
         <translation>L&apos;action sémantique a incorrectement rejeté un noeud dans TokenParser</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/tokenStream.h" line="+62"/>
         <source>Expected &quot;%1&quot;, got &quot;%2&quot;</source>
         <translation>Attendu &quot;%1&quot;, obtenu &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/types/any.h" line="+28"/>
         <source>any</source>
         <translation>tout</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/nil.h" line="+28"/>
         <source>nil</source>
         <translation>nil</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="+68"/>
         <source>Type mismatch</source>
         <translation>Incompatibilité de type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Can not deduce type, expression can be of following types: %1</source>
         <translation>Le type ne peut pas être déduit, l&apos;expression peut être de types suivants : %1</translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="+193"/>
         <source>This construction is not supported by semantic analysis</source>
         <translation>Cette construction n&apos;est pas supportée par l&apos;analyse sémantique</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Type mismatch.</source>
         <translation>Incompatibilité de type.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="+107"/>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="+194"/>
         <source>Variable %1 is read-only</source>
         <translation>Variable %1 est en lecture seule</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+39"/>
         <source>This construction is not supported by interpreter</source>
         <translation>Cette construction n&apos;est pas supportée par l&apos;interpréteur</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Seems like accessing an uninitialized variable %1</source>
         <translation>Il semble que l&apos;on accède à une variable non initialisée %1</translation>
     </message>
     <message>
-        <location line="+133"/>
-        <location line="+10"/>
-        <location line="+13"/>
         <source>Division by zero</source>
         <translation>Division par zéro</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Currently interpreter allows only tables denoted by identifier and by integer expression index, as in &apos;a[1 + 2][3]&apos;</source>
         <translation>En ce moment l&apos;interpréteur ne supporte que les tables désignées par un identifiant et une indice entière, comme dans &apos;a[1 + 2][3]&apos;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Tables denoted by something other than identifier (like f(x)[0]) are not allowed</source>
         <translation>Tables designées autrement que par un idéntificateur (comme f(x)[0]) ne sont pas autorisées</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Explicit table indexes of non-integer type are not supported</source>
         <translation>Indices de table explicites de type non entier ne sont pas supportés</translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location line="+17"/>
-        <location line="+54"/>
-        <location line="+14"/>
         <source>Negative index for a table</source>
         <translation>Indice négatif pour une table</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="+30"/>
         <source>whitespace</source>
         <translation>espace</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>newline</source>
         <translation>nouvelle ligne</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>identifier</source>
         <translation>identificateur</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/string.h" line="+28"/>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="+66"/>
         <source>string</source>
         <translation>chaîne</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="+5"/>
         <source>integer literal</source>
         <translation>littéral entier</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>float literal</source>
         <translation>littéral flottant</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>comment</source>
         <translation>commentaire</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="+158"/>
         <source>node in &apos;stat&apos; semantic action is of unexpected type</source>
         <translation>Le nœud d&apos;une action sémantique &apos;stat&apos; est de type inattendu</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Number of variables in assignment shall be equal to the number of assigned values</source>
         <translation>Le nombre de variables dans l&apos;assignation doit être égal au nombre de valeurs affectées</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Assignment to function call is impossible</source>
         <translation>Affectation à l&apos;appel de fonction est impossible</translation>
     </message>
     <message>
-        <location line="+127"/>
         <source>In &apos;args&apos; semantic action node is of incorrect type</source>
         <translation>Le nœud d&apos;une action sémantique &apos;args&apos; est de type inattendu</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>In &apos;table constructor&apos; semantic action fieldList is of incorrect type</source>
         <translation>fieldList d&apos;une action sémantique &apos;table constructor&apos; est de type inattendu</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>In &apos;field&apos; semantic action node is of incorrect type</source>
         <translation>Le nœud d&apos;une action sémantique &apos;field&apos; est de type inattendu</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="-274"/>
         <source>Intrinsic function used as an identifier</source>
         <translation>Une fonction intrinsèque ne peut pas être utilisée comme identificateur</translation>
     </message>
     <message>
-        <location line="+167"/>
         <source>Incorrect assignment, only variables and tables can be assigned to.</source>
         <translation>Affectation erronée, seules les variables et les tableaux peuvent être affectés.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Left and right operand have mismatched types.</source>
         <translation>Les operandes gauche et droite ont des types incompatibles.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>An attempt will be made to implicitly cast the right operand to the type &apos;%1&apos;</source>
         <translation>Une tentative de conversion implicite du membre droit vers le type &apos;%1&apos; sera effectuée</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Indirect function calls are not supported</source>
         <translation>Appels de fonction indirects ne sont pas supportés</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unknown function</source>
         <translation>Fonction inconnue</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Too many parameters, %1 expected</source>
         <translation>Trop de paramètres , %1 attendu(s)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Not enough parameters, %1 expected</source>
         <translation>Pas assez de paramètres , %1 attendu(s)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Undeclared identifier: %1</source>
         <translation>Identificateur non déclaré : %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/boolean.h" line="+28"/>
         <source>boolean</source>
         <translation>booléen</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/float.h" line="+28"/>
         <source>float</source>
         <translation>flottant</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/integer.h" line="+28"/>
         <source>integer</source>
         <translation>entier</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/number.h" line="+28"/>
         <source>number</source>
         <translation>nombre</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/table.h" line="+44"/>
         <source>table[%1]</source>
         <translation>tableau[%1]</translation>
     </message>

--- a/qrtranslations/fr/qrutils_fr.ts
+++ b/qrtranslations/fr/qrutils_fr.ts
@@ -23,72 +23,58 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="+642"/>
         <source>Unexpected end of stream at %1. Mb you forget &apos;;&apos;?</source>
         <translation>La fin du flux inattendue sur %1. Peut-être vous avez oublié &apos;;&apos; ?</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unexpected symbol at %1 : expected %2, got %3</source>
         <translation>Un symbole intattendu sur %1 : attendu %2, obtenu %3</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Types mismatch at %1: %2 = %3. Possible loss of data</source>
         <translation>Incompatibilité de types sur %1 : %2 = %3. Perte de données possible</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unknown identifier at %1 &apos; %2 &apos;</source>
         <translation>Identifiant Inconnu sur %1 &apos; %2 &apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Empty process is unnecessary</source>
         <translation>Le processus vide n&apos;est pas necessaire</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Condition can&apos;t be empty</source>
         <translation>La condition ne peut pas être vide</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Using reserved variable %1</source>
         <translation>Utilisation d&apos;une variable reservée %1</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No value of expression</source>
         <translation>Aucune valeur de l&apos;expression</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Incorrect variable declaration: use function block for it</source>
         <translation>Mauvaise déclaration de variable : utiliser le bloc de fonction pour ça</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unexpected symbol after the end of expression</source>
         <translation>Symbole inattendu après la fin d&apos;expression</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown element property used</source>
         <translation>Utilisation de la propriété d&apos;élément inconnue</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown element name used</source>
         <translation>Utilisation du nom de l&apos;élément inconnu</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Integer division by zero</source>
         <translation>Division entière par zéro</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphicsUtils/abstractItem.cpp" line="+696"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
@@ -103,23 +89,18 @@
 <context>
     <name>qReal::BaseGraphTransformationUnit</name>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="+48"/>
         <source>no current diagram</source>
         <translation>Ouvrez un diagramme</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+48"/>
         <source>Rule &apos;</source>
         <translation>Règle &apos;</translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>&apos; has not any appropriate nodes</source>
         <translation>&apos; n&apos;a pas de nœuds appropriés</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>&apos; has unconnected link</source>
         <translation>&apos; a un lien non connecté</translation>
     </message>
@@ -127,28 +108,22 @@
 <context>
     <name>qReal::interpretation::Block</name>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="+60"/>
         <source>Control flow break detected, stopping</source>
         <translation>Une pause de flux de contrôle détecté, arrêt en cours</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+93"/>
         <source>Block has disappeared!</source>
         <translation>Le bloc a disparu!</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Too many outgoing links</source>
         <translation>Trop de liens sortants</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>No outgoing links, please connect this block to something or use Final Node to end program</source>
         <translation>Aucun lien sortant, s&apos;il vous plait connectez ce bloc à un autre ou bien utilisez un nœud final pour terminer le programme</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Outgoing link is not connected</source>
         <translation>Le lien sortant n&apos;est pas connecté</translation>
     </message>
@@ -156,22 +131,18 @@
 <context>
     <name>qReal::interpretation::Interpreter</name>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="+55"/>
         <source>Interpreter is already running</source>
         <translation>Interpréteur est déjà en cours d&apos;exécution</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Cannot create new thread with already occupied id %1</source>
         <translation>Vous ne pouvez pas créer un nouveau thread avec id déjà occupée %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Threads limit exceeded. Maximum threads count is %1</source>
         <translation>Le nombre limite de threads est dépassé. Le max est de %1</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Killing non-existent thread %1</source>
         <translation>Terminaison du thread non-existant %1</translation>
     </message>
@@ -179,17 +150,14 @@
 <context>
     <name>qReal::interpretation::Thread</name>
     <message>
-        <location filename="../../qrutils/interpreter/thread.cpp" line="+117"/>
         <source>No entry point found, please add Initial Node to a diagram</source>
         <translation>Aucun point d&apos;entrée n&apos;est trouvé, ajoutez un nœud initial à un diagramme</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Stack overflow</source>
         <translation>Débordement de pile</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Block has disappeared!</source>
         <translation>Le bloc a disparu!</translation>
     </message>
@@ -197,7 +165,6 @@
 <context>
     <name>qReal::interpretation::blocks::CommentBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/commentBlock.cpp" line="+28"/>
         <source>The comment block with incoming links detected!</source>
         <translation>Le bloc de commentaires avec des liens entrants est détecté !</translation>
     </message>
@@ -205,22 +172,18 @@
 <context>
     <name>qReal::interpretation::blocks::ForkBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="+36"/>
         <source>There must be at least two outgoing links</source>
         <translation>Il doit y être au moins deux liens sortants</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Outgoing link is not connected</source>
         <translation>Le lien sortant n&apos;est pas connecté</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Cannot create two threads with the same id %1</source>
         <translation>Impossible à créer deux threads avec le même id %1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>There must be a link that has its &apos;Guard&apos; property set to the current thread id %1</source>
         <translation>Il doit y être un lien avec une propriété &apos;Guard&apos; avec l&apos;id du thread courant %1</translation>
     </message>
@@ -228,27 +191,22 @@
 <context>
     <name>qReal::interpretation::blocks::IfBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="+36"/>
         <source>There must be exactly TWO links outgoing from if block</source>
         <translation>Il doit y être exactement deux liens sortants du bloc conditionnel</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Outgoing link is not connected</source>
         <translation>Le lien sortant n&apos;est pas connecté</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Two links marked with &apos;true&apos; found</source>
         <translation>Deux liens marqués comme &apos;true&apos; sont détectés</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Two links marked with &apos;false&apos; found</source>
         <translation>Deux liens marqués comme &apos;false&apos; sont détectés</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>There must be at least one link with &quot;true&quot; or &quot;false&quot; marker on it</source>
         <translation>Il doit y exister au moins un lien marqué comme &quot;vrai&quot; ou &quot;faux&quot;</translation>
     </message>
@@ -256,27 +214,22 @@
 <context>
     <name>qReal::interpretation::blocks::InputBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="+27"/>
         <source>Input</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Input value for %1:</source>
         <translation>Saisir la valeur pour %1 :</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Only one link with &quot;%1&quot; is allowed</source>
         <translation>Un seul lien avec &quot;%1&quot; est autorisé</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>One of the outgoing links must be marked with &quot;%1&quot;</source>
         <translation>L&apos;un des liens sortants doit être marqué avec &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Link to the next statement is missing</source>
         <translation>Le lien vers l&apos;instruction suivante est manquant</translation>
     </message>
@@ -285,24 +238,18 @@
         <translation type="obsolete">Une pause de flux de contrôle détecté, arrêt en cours</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>No outgoing links, please connect this block to something or use Final Node to end program</source>
         <translation>Aucun lien sortant, veuillez connecter ce bloc à autre chose ou utiliser le nœud Final pour terminer le programme</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>There should be a maximum of TWO links outgoing from input block</source>
         <translation>Il doit y avoir au maximum DEUX liens sortants depuis le bloc d&apos;entrée</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Outgoing link is not connected</source>
         <translation>Le lien sortant n&apos;est pas connecté</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+4"/>
-        <location line="+7"/>
         <source>cancel</source>
         <translation>annuler</translation>
     </message>
@@ -311,7 +258,6 @@
         <translation type="obsolete">Deux liens marqués comme &apos;false&apos; sont détectés</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>You must input some value!</source>
         <translation>Vous devez saisir une valeur !</translation>
     </message>
@@ -319,7 +265,6 @@
 <context>
     <name>qReal::interpretation::blocks::JoinBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/joinBlock.cpp" line="+32"/>
         <source>Link outgoing from join block must have surviving thread id in its &apos;Guard&apos; property</source>
         <translation>Le lien sortant du bloc join doit avoir sa propriété &apos;Guard&apos; avec l&apos;idéntificateur du thread qui va continuer son travail</translation>
     </message>
@@ -327,7 +272,6 @@
 <context>
     <name>qReal::interpretation::blocks::KillThreadBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/killThreadBlock.cpp" line="+24"/>
         <source>Need to specify a thread to be stopped</source>
         <translation>Besoin de spécifier le fil à arrêter</translation>
     </message>
@@ -335,22 +279,18 @@
 <context>
     <name>qReal::interpretation::blocks::LoopBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="+43"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Il doit y être un lien avec un marqueur &quot;body&quot;</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Outgoing link is not connected</source>
         <translation>Le lien sortant n&apos;est pas connecté</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Two links marked as &quot;body&quot; found</source>
         <translation>Deux liens marqués comme &quot;body&quot; sont trouvés</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>There must be a non-marked outgoing link</source>
         <translation>Il doit y exister un lien sortant non marqué</translation>
     </message>
@@ -358,23 +298,18 @@
 <context>
     <name>qReal::interpretation::blocks::PreconditionalLoopBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="+41"/>
         <source>Outgoing link is not connected</source>
         <translation>Le lien sortant n&apos;est pas connecté</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two links marked as &quot;body&quot; found</source>
         <translation>Deux liens marqués comme &quot;body&quot; sont trouvés</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+7"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Il doit y être un lien avec un marqueur &quot;body&quot;</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>There must be a non-marked outgoing link</source>
         <translation>Il doit y exister un lien sortant non marqué</translation>
     </message>
@@ -382,7 +317,6 @@
 <context>
     <name>qReal::interpretation::blocks::ReceiveThreadMessageBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/receiveThreadMessageBlock.cpp" line="+25"/>
         <source>Need to specify variable which will contain received message</source>
         <translation>On doit spécifier la variable qui contiendra le message reçu</translation>
     </message>
@@ -390,7 +324,6 @@
 <context>
     <name>qReal::interpretation::blocks::SendThreadMessageBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/sendThreadMessageBlock.cpp" line="+23"/>
         <source>Need to specify a receiving thread in &apos;Thread&apos; property</source>
         <translation>On doit spécifier le thread recepteur dans la propriété &apos;Thread&apos;</translation>
     </message>
@@ -398,7 +331,6 @@
 <context>
     <name>qReal::interpretation::blocks::SubprogramBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/subprogramBlock.cpp" line="+35"/>
         <source>Please enter valid c-style name for subprogram &quot;</source>
         <translation>Entrez un nom valide (style C) pour le sousprogramme &quot;</translation>
     </message>
@@ -406,27 +338,22 @@
 <context>
     <name>qReal::interpretation::blocks::SwitchBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="+36"/>
         <source>There must be at list TWO links outgoing from switch block</source>
         <translation>Il doit y être au moins deux liens sortants pour le bloc de choix multiples</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Outgoing link is not connected</source>
         <translation>Le lien sortant n&apos;est pas connecté</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>There must be exactly one link without marker on it (default branch)</source>
         <translation>Il doit y exister exactement un lien sans marquer associé (branche par défaut)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Duplicate case branch: &apos;%1&apos;</source>
         <translation>Un doublon de choix multiple : &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>There must be a link without marker on it (default branch)</source>
         <translation>Il doit y exister un lien sans marquer associé (branche par défaut)</translation>
     </message>
@@ -434,7 +361,6 @@
 <context>
     <name>qReal::interpretation::blocks::UnsupportedBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/unsupportedBlock.cpp" line="+21"/>
         <source>Block of a type which is unsupported by an interpreter</source>
         <translation>Le bloc de ce type n&apos;est pas supporté par l&apos;intérpréteur</translation>
     </message>
@@ -442,12 +368,10 @@
 <context>
     <name>qReal::ui::ColorDialog</name>
     <message>
-        <location filename="../../qrutils/widgets/colorDialog.cpp" line="+34"/>
         <source>Select background color in the 2D-model editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Select the background color of the scene</source>
         <translation type="unfinished"></translation>
     </message>
@@ -455,7 +379,6 @@
 <context>
     <name>qReal::ui::ConsoleDock</name>
     <message>
-        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+50"/>
         <source>Reset shell</source>
         <translation>Réinitialiser la console</translation>
     </message>
@@ -463,7 +386,6 @@
 <context>
     <name>qReal::ui::DirPicker</name>
     <message>
-        <location filename="../../qrutils/widgets/dirPicker.cpp" line="+33"/>
         <source>Browse...</source>
         <translation>Parcourir...</translation>
     </message>
@@ -475,17 +397,14 @@
 <context>
     <name>qReal::ui::ImagePicker</name>
     <message>
-        <location filename="../../qrutils/widgets/imagePicker.cpp" line="+35"/>
         <source>Browse...</source>
         <translation>Parcourir...</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Select image</source>
         <translation>Sélectionner une image</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Images (*.png *.svg *.jpg *.gif *.bmp);;All files (*.*)</source>
         <translation>Images (*.png *.svg *.jpg *.gif *.bmp);;Tous les fichiers (*.*)</translation>
     </message>
@@ -493,27 +412,22 @@
 <context>
     <name>qReal::ui::SearchLineEdit</name>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="+31"/>
         <source>Clear text</source>
         <translation>Effacer le texte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Case insensitive</source>
         <translation>Insensible à la casse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Case sensitive</source>
         <translation>Sensible à la casse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Regular expression</source>
         <translation>Expression régulière</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enter search text...</source>
         <translation>Tapez le texte à rechercher...</translation>
     </message>
@@ -521,13 +435,10 @@
 <context>
     <name>qReal::ui::SearchLinePanel</name>
     <message>
-        <location filename="../../qrutils/widgets/searchLinePanel.cpp" line="+134"/>
-        <location line="+10"/>
         <source>Enter search text...</source>
         <translation>Saisissez le texte de recherche...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&lt;line&gt;:&lt;column&gt;</source>
         <translation>&lt;ligne&gt;:&lt;colonne&gt;</translation>
     </message>
@@ -535,22 +446,18 @@
 <context>
     <name>utils::MetamodelGeneratorSupport</name>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="+72"/>
         <source>Please, fill compiler settings</source>
         <translation>Remplissez les paramètres du compilateur</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot unload plugin</source>
         <translation>Impossible à décharger le plugin</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Cannot load new editor</source>
         <translation>Impossible à charger le nouvel editeur</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Cannot build new editor</source>
         <translation>Impossible à créer un nouvel editeur</translation>
     </message>
@@ -558,97 +465,78 @@
 <context>
     <name>utils::QRealMessageBox</name>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="+30"/>
         <source>Ok</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discard</source>
         <translation>Ignorer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apply</source>
         <translation>Appliquer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Reset</source>
         <translation>Réinitialiser</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save All</source>
         <translation>Tout enregistrer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Yes To All</source>
         <translation>Oui pour tout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>No To All</source>
         <translation>Non pour tout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Abort</source>
         <translation>Abandonner</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ignore</source>
         <translation>Ignorer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>NoButton</source>
         <translation>Pas de bouton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Restore Defaults</source>
         <translation>Restaurer les valeurs par défaut</translation>
     </message>
@@ -698,17 +586,14 @@
 <context>
     <name>watchListWindow</name>
     <message>
-        <location filename="../../qrutils/watchListWindow.ui" line="+41"/>
         <source>Watch List</source>
         <translation>Watch list</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/checker/patcher_ru.ts
+++ b/qrtranslations/ru/plugins/robots/checker/patcher_ru.ts
@@ -4,37 +4,30 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="25"/>
         <source>Patcher for save files, replaces world model with contents of a given XML world model</source>
         <translation>Утилита для изменения файлов сохранений, заменяющая модель мира на содержимое указанной XML-модели мира</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="38"/>
         <source>TRIK Studio save file to be patched.</source>
         <translation>Файл сохранения TRIK Studio, который необходимо изменить.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="40"/>
         <source>XML file with prepared 2D model field. Both world and robot configurations (position + ports) will be patched.</source>
         <translation>XML-файл с подготовленным полем 2D-модели. Будут изменены конфигурации мира и робота (позиция и порты).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="43"/>
         <source>Script file to be patched into save file.</source>
         <translation>Файл скрипта, который будет встроен в файл сохранения.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="45"/>
         <source>XML file with prepared 2D model field. Only world configurations will be patched.</source>
         <translation>XML-файл с подготовленным полем 2D-модели. Будут изменены только конфигурации мира.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="49"/>
         <source>XML file with prepared 2D model field. Only world configurations and robot position will be patched.</source>
         <translation>XML-файл с подготовленным полем 2D-модели. Будут изменены только конфигурации мира и позиция робота.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="53"/>
         <source>Reset robot position to start position</source>
         <translation>Сбросить позицию робота до начальной</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/checker/twoDModelRunner_ru.ts
+++ b/qrtranslations/ru/plugins/robots/checker/twoDModelRunner_ru.ts
@@ -8,7 +8,6 @@
         <translation type="vanished">Эмулирует поведение робота на 2D модели TRIK Studio отдельно от редактора программ. Указанный файл сохранения .qrs будет исполнен, как в случае нажатия на кнопку &quot;Запуск&quot; в среде.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="+30"/>
         <source>Emulates robot`s behaviour on TRIK Studio 2D model separately from programming environment. Passed .qrs will be interpreted just like when &apos;Run&apos; button was pressed in TRIK Studio. 
 In background mode the session will be terminated just after the execution ended and return code will then contain binary information about program correctness.Example: 
 </source>
@@ -17,57 +16,46 @@ In background mode the session will be terminated just after the execution ended
 </translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Save file to be interpreted.</source>
         <translation>Файл сохранения, который будет исполнен.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Run emulation in background.</source>
         <translation>Произвести эмуляцию в фоне.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>A path to file where checker results will be written (JSON).</source>
         <translation>Путь к файлу, куда будут записаны результаты проверки (JSON).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Inputs for JavaScript solution.</source>
         <translation>Входные данные для JavaScript файла.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set to &quot;script&quot; for execution of js/py from the project or set to &quot;diagram&quot; for block diagram.</source>
         <translation>Установите &quot;script&quot; для выполнения js/py скрипта из проекта или установите &quot;diagram&quot; для выполнения диаграммы блоков.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Speed factor, try from 5 to 20, or even 1000 (at your own risk!).</source>
         <translation>Ускорение, попробуйте от 5 до 20, но можно пробовать и 1000.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Shows robot&apos;s display.</source>
         <translation>Отображает дисплей робота.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The complete file path, including the filename, to save the generated JavaScript or Python code.</source>
         <translation>Полный путь, включающий имя файла, для сохранения сгенерированного Javascript или Python кода.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The path to the Python or JavaScript file that will be used for interpretation.</source>
         <translation>Путь к Python или Javascript файлу, который будет использоваться для интерпретации.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do not run the interpretation in any mode, this is a parameter that is only used to generate a file.</source>
         <translation>Не запускайте интерпретацию ни в каком режиме, этот параметр используется только для создания файла.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add a delay in milliseconds after executing the script before closing the window</source>
         <translation>Добавить задержку в миллисекундах после выполнения скрипта перед закрытием окна</translation>
     </message>
@@ -76,27 +64,22 @@ In background mode the session will be terminated just after the execution ended
         <translation type="vanished">Не запускайте интерпретацию ни в каком режиме, этот параметр используется только для генерации файла.</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select &quot;python&quot; or &quot;javascript&quot;.</source>
         <translation>Выберите &quot;python&quot; или &quot;javascript&quot;.</translation>
     </message>
     <message>
-        <location line="-24"/>
         <source>A path to file where robot`s trajectory will be written. The writing will not be performed not immediately, each trajectory point will be written just when obtained by checker, so FIFOs are recommended to be targets for this option.</source>
         <translation>Путь к файлу, куда будет выводиться траектори робота. Запись не будет осуществлена единомоментно, каждый узел траектории будет записан по факту его просчета проверяющей системой. Поэтому разумно использования FIFO-файлов в качестве значения этого параметра.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Close the window and exit if the diagram/script finishes without errors.</source>
         <translation>Закрыть окно если диаграмма/скрипт были выполнены без ошибок.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Close the window and exit after diagram/script finishes.</source>
         <translation>Закрыть окно и выйти после завершения диаграммы/скрипта.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Shows robot&apos;s console.</source>
         <translation>Отображает консоль робота.</translation>
     </message>
@@ -108,7 +91,6 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="+241"/>
         <source>Robot console</source>
         <translation>Консоль робота</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/common/ev3Kit_ru.ts
+++ b/qrtranslations/ru/plugins/robots/common/ev3Kit_ru.ts
@@ -4,17 +4,14 @@
 <context>
     <name>ev3::blocks::details::Ev3ReadRGBBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/blocks/details/ev3ReadRGBBlock.cpp" line="+43"/>
         <source>Sensor reading should consist of three components</source>
         <translation>Показания датчика должны состоять из трех компонентов</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Sensor reading failed</source>
         <translation>Не удалось получить показания датчика</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Color raw sensor is not configured on port %2</source>
         <translation>Сырой датчик цвета не настроен на порту %2</translation>
     </message>
@@ -22,7 +19,6 @@
 <context>
     <name>ev3::communication::BluetoothRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/bluetoothRobotCommunicationThread.cpp" line="+82"/>
         <source>Cannot open port </source>
         <translation>Не удается открыть порт </translation>
     </message>
@@ -30,7 +26,6 @@
 <context>
     <name>ev3::communication::Ev3RobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/ev3RobotCommunicationThread.cpp" line="+55"/>
         <source>EV3 limits filename length to %1 characters, but you have %2, please, rename your project.</source>
         <translation>EV3 не загружает файлы длиннее %1 символов. Длина имени Вашего файла %2 символов. Пожалуйста, сократите имя программы.</translation>
     </message>
@@ -38,7 +33,6 @@
 <context>
     <name>ev3::communication::UsbRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/usbRobotCommunicationThread.cpp" line="+99"/>
         <source>Cannot find EV3 device. Check robot connected and turned on and try again.</source>
         <translation>Не могу найти устройство EV3. Проверьте, что робот включен и присоединен и попробуйте снова.</translation>
     </message>
@@ -62,7 +56,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3ACIRSeeker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3ACIRSeeker.h" line="+27"/>
         <source>NXT IRSeeker V2 (AC)</source>
         <translation>NXT IRSeeker V2 (AC)</translation>
     </message>
@@ -70,7 +63,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Compass</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Compass.h" line="+27"/>
         <source>Compass</source>
         <translation>Компас</translation>
     </message>
@@ -78,7 +70,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3DCIRSeeker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3DCIRSeeker.h" line="+27"/>
         <source>NXT IRSeeker V2 (DC)</source>
         <translation>NXT IRSeeker V2 (DC)</translation>
     </message>
@@ -93,7 +84,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Led</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Led.h" line="+53"/>
         <source>LED</source>
         <translation>Диод</translation>
     </message>
@@ -101,7 +91,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Motor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Motor.h" line="+27"/>
         <source>Motor</source>
         <translation>Мотор</translation>
     </message>
@@ -109,7 +98,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Color</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Color.h" line="+27"/>
         <source>NXT color sensor V2 (color)</source>
         <translation>Датчик цвета NXT V2 (цвет)</translation>
     </message>
@@ -117,7 +105,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Passive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Passive.h" line="+27"/>
         <source>NXT color sensor V2 (passive)</source>
         <translation>Датчик цвета NXT V2 (пассивный)</translation>
     </message>
@@ -125,7 +112,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2RGB</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2RGB.h" line="+27"/>
         <source>NXT color sensor V2 (RGB)</source>
         <translation>Датчик цвета NXT V2 (RGB)</translation>
     </message>
@@ -133,7 +119,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Raw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Raw.h" line="+27"/>
         <source>NXT color sensor V2 (raw)</source>
         <translation>Датчик цвета NXT V2 (raw)</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/common/kitBase_ru.ts
+++ b/qrtranslations/ru/plugins/robots/common/kitBase_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/blocksBase/common/deviceBlock.h" line="+47"/>
         <source>%1 is not configured.</source>
         <translation>%1 не сконфигурирован.</translation>
     </message>
@@ -12,17 +11,14 @@
 <context>
     <name>kitBase::DevicesConfigurationWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/devicesConfigurationWidget.cpp" line="+103"/>
         <source>%1:</source>
         <translation>%1:</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Port %1:</source>
         <translation>Порт %1:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unused</source>
         <translation>Не используется</translation>
     </message>
@@ -30,7 +26,6 @@
 <context>
     <name>kitBase::blocksBase::common::WaitForButtonBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/blocksBase/common/waitForButtonBlock.cpp" line="+37"/>
         <source>Incorrect button port %1</source>
         <translation>Неправильная кнопка %1</translation>
     </message>
@@ -65,7 +60,6 @@
 <context>
     <name>kitBase::blocksBase::common::WaitForSensorBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/blocksBase/common/waitForSensorBlock.cpp" line="+46"/>
         <source>%1 is not configured on port %2</source>
         <translation>%1 не сконфигурирован на порту %2</translation>
     </message>
@@ -73,7 +67,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::AccelerometerSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/accelerometerSensor.h" line="+29"/>
         <source>Accelerometer</source>
         <translation>Акселерометр</translation>
     </message>
@@ -81,7 +74,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Button</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/button.h" line="+29"/>
         <source>Button</source>
         <translation>Кнопка</translation>
     </message>
@@ -89,7 +81,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensor.h" line="+32"/>
         <source>Color sensor</source>
         <translation>Датчик цвета</translation>
     </message>
@@ -97,7 +88,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorAmbient</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorAmbient.h" line="+29"/>
         <source>EV3 color sensor (ambient)</source>
         <translation>Датчик цвета EV3 (рассеянный)</translation>
     </message>
@@ -105,7 +95,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorBlue</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorBlue.h" line="+30"/>
         <source>NXT color sensor (blue)</source>
         <translation>Датчик цвета NXT (синий)</translation>
     </message>
@@ -113,7 +102,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorFull</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorFull.h" line="+33"/>
         <source>NXT / EV3 color sensor (full)</source>
         <translation>Датчик цвета EV3 / NXT (цвет)</translation>
     </message>
@@ -121,7 +109,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorGreen</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorGreen.h" line="+30"/>
         <source>NXT color sensor (green)</source>
         <translation>Датчик цвета NXT (зеленый)</translation>
     </message>
@@ -129,7 +116,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorPassive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorPassive.h" line="+33"/>
         <source>NXT color sensor (passive)</source>
         <translation>Датчик цвета NXT (пассивный)</translation>
     </message>
@@ -137,7 +123,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorRaw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorRaw.h" line="+29"/>
         <source>EV3 color sensor (raw)</source>
         <translation>Датчик цвета EV3 (сырой)</translation>
     </message>
@@ -145,7 +130,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorRed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorRed.h" line="+30"/>
         <source>NXT color sensor (red)</source>
         <translation>Датчик цвета NXT (красный)</translation>
     </message>
@@ -153,7 +137,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorReflected</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorReflected.h" line="+29"/>
         <source>EV3 color sensor (reflected)</source>
         <translation>Датчик цвета EV3 (отраженный)</translation>
     </message>
@@ -161,7 +144,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Communicator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h" line="+29"/>
         <source>Communicator</source>
         <translation>Коммуникатор</translation>
     </message>
@@ -169,7 +151,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Display</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/display.h" line="+29"/>
         <source>Display</source>
         <translation>Дисплей</translation>
     </message>
@@ -177,7 +158,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::EncoderSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/encoderSensor.h" line="+29"/>
         <source>Encoder</source>
         <translation>Энкодер</translation>
     </message>
@@ -185,7 +165,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::GyroscopeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/gyroscopeSensor.h" line="+29"/>
         <source>Gyroscope</source>
         <translation>Гиродатчик</translation>
     </message>
@@ -193,7 +172,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::LidarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lidarSensor.h" line="+29"/>
         <source>Lidar</source>
         <translation>Лидар</translation>
     </message>
@@ -201,7 +179,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::LightSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lightSensor.h" line="+29"/>
         <source>Light sensor</source>
         <translation>Датчик света</translation>
     </message>
@@ -209,7 +186,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Motor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/motor.h" line="+29"/>
         <source>Motor</source>
         <translation>Мотор</translation>
     </message>
@@ -217,7 +193,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::MotorsAggregator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/motorsAggregator.h" line="+29"/>
         <source>Motors aggregator</source>
         <translation>Агрегатор моторов</translation>
     </message>
@@ -225,7 +200,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Random</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/random.h" line="+30"/>
         <source>Random</source>
         <translation>Случайное число</translation>
     </message>
@@ -233,7 +207,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::RangeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/rangeSensor.h" line="+30"/>
         <source>Range sensor</source>
         <translation>Датчик расстояния</translation>
     </message>
@@ -241,7 +214,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Shell</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/shell.h" line="+28"/>
         <source>Shell</source>
         <translation>Консоль</translation>
     </message>
@@ -249,7 +221,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::SoundSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/soundSensor.h" line="+30"/>
         <source>Sound sensor</source>
         <translation>Датчик звука</translation>
     </message>
@@ -257,7 +228,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Speaker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/speaker.h" line="+29"/>
         <source>Speaker</source>
         <translation>Динамик</translation>
     </message>
@@ -265,7 +235,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::TouchSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/touchSensor.h" line="+30"/>
         <source>Touch sensor</source>
         <translation>Датчик касания</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/common/nxtKit_ru.ts
+++ b/qrtranslations/ru/plugins/robots/common/nxtKit_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>nxt::communication::BluetoothRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/bluetoothRobotCommunicationThread.cpp" line="+86"/>
         <source>Cannot open port </source>
         <translation>Не удается открыть порт </translation>
     </message>
@@ -12,32 +11,26 @@
 <context>
     <name>nxt::communication::NxtUsbDriverInstaller</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="+54"/>
         <source>Driver for NXT is not installed. An attempt to attach TRIK Studio driver also failed (probably NXT tools package was not installer). No panic! Driver can still be installed manually, see documentation, chapter &quot;Installing NXT driver manually.&quot;. Also TRIK Studio supports &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>Драйвер для Lego NXT не установлен на компьютер. Попытка установить драйвера TRIK Studio также не удалась (возможно, пакет &quot;Инструменты NXT&quot; был отключен при установке). Без паники! Драйвер все еще может быть установлен вручную, см. документацию, раздер &quot;установка драйвера NXT вручную&quot;. Также TRIK Studio совместима с &lt;a href=&apos;%1&apos;&gt;драйвером Lego Fantom&lt;/a&gt;, Вы можете скачать и установить его.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Driver installation cancelled. Please note that TRIK Studio also supports official &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>Установка драйвера TRIK Studio отменета. Пожалуйста, имейте в виду, что TRIK Studio также поддерживает официальный &lt;a href=&apos;%1&apos;&gt;драйвер Lego Fantom&lt;/a&gt;, Вы можете скачать и установить его.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>An attempt to attach TRIK Studio driver failed. No panic! Driver can be still installed manually, see documentation, chapter &quot;Installing NXT driver manually.&quot;. Also TRIK Studio supports &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>Попытка установить драйвера TRIK Studio не удалась. Без паники! Драйвер все еще может быть установлен вручную, см. документацию, раздер &quot;установка драйвера NXT вручную&quot;. Также TRIK Studio совместима с &lt;a href=&apos;%1&apos;&gt;драйвером Lego Fantom&lt;/a&gt;, Вы можете скачать и установить его.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>NXT drivers not found</source>
         <translation>Драйвер NXT не найден</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Drivers for LEGO NXT brick are not installed. TRIK Studio can install own drivers to communicate with NXT. Do you want to do it?</source>
         <translation>Драйвер для Lego NXT не установлен. TRIK Studio может попытаться установить свой драйвер для взаимодействия с NXT. Вы хотите продолжить?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>TRIK Studio drivers are not officially registered, so two red warning messages will be shown by Windows. Confirm them to proceed installation.</source>
         <translation>Драйвер TRIK Studio не зарегистрирован в Microsoft, поэтому сейчас Windows покажет два красных окна. Подтвердите в них согласие, чтобы продолжить установку.</translation>
     </message>
@@ -45,33 +38,26 @@
 <context>
     <name>nxt::communication::UsbRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="+169"/>
         <source>USB Device configuration problem. Try to restart TRIK Studio and re-plug NXT.</source>
         <translation>Проблема конфигурации USB-устройства. Попробуйте перезапустить TRIK Studio и перевоткнуть NXT в компьютер.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>NXT device is already used by another software.</source>
         <translation>Устройство NXT уже чем-то используется. Попробуйте перезапустить среду и перевоткнуть NXT.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>NXT handshake procedure failed. Please contact developers.</source>
         <translation>Процедура рукопожатия с NXT не была успешной. Пожалуйста, попробуйте еще раз, если эта ошибка снова появится, обратитесь к разработчикам.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot find NXT device. Check robot connected and turned on and try again.</source>
         <translation>Устройство NXT не найдено. Проверьте, что робот включен и подключен к компьютеру и попробуйте еще раз.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+19"/>
         <source>Connection to NXT lost</source>
         <translation>Связь с NXT потеряна</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Cannot find NXT device in resetted mode. Check robot resetted, connected and ticking and try again.</source>
         <translation>Не могу найти устройство NXT в режиме перепрошивки. Проверьте, что прошивка робота стерта, робот подключен к компьютеру и издает повторяющиеся звуковые сигналы (тикает).</translation>
     </message>
@@ -79,7 +65,6 @@
 <context>
     <name>nxt::robotModel::parts::NxtMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/include/nxtKit/robotModel/parts/nxtMotor.h" line="+27"/>
         <source>Motor</source>
         <translation>Мотор</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/common/trikKit_ru.ts
+++ b/qrtranslations/ru/plugins/robots/common/trikKit_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::blocks::details::WaitForMessageBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="+46"/>
         <source>Device not found for port name CommunicatorPort</source>
         <translation>Устройство не найдено для имени порта CommunicatorPort</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>trik::blocks::details::WaitGamepadButtonBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/blocks/details/waitGamepadButtonBlock.cpp" line="+41"/>
         <source>Incorrect port for gamepad button %1</source>
         <translation>Неверная кнопка Android-пульта %1</translation>
     </message>
@@ -20,13 +18,10 @@
 <context>
     <name>trik::robotModel::TrikRobotModelBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="+93"/>
-        <location line="+212"/>
         <source>Video 2</source>
         <translation>Видео 2</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Lidar</source>
         <translation>Лидар</translation>
     </message>
@@ -34,7 +29,6 @@
 <context>
     <name>trik::robotModel::parts::TrikColorSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikColorSensor.h" line="+29"/>
         <source>Color Sensor</source>
         <translation>Сенсор цвета</translation>
     </message>
@@ -42,7 +36,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadButton</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadButton.h" line="+28"/>
         <source>Android Gamepad Button</source>
         <translation>Кнопка Android-пульта</translation>
     </message>
@@ -50,7 +43,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadConnectionIndicator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadConnectionIndicator.h" line="+28"/>
         <source>Android Gamepad Connection Indicator</source>
         <translation>Индикатор подключения Android-пульта</translation>
     </message>
@@ -58,7 +50,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadPad</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadPad.h" line="+29"/>
         <source>Android Gamepad Pad</source>
         <translation>Активная область Android-пульта</translation>
     </message>
@@ -66,7 +57,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadPadPressSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadPadPressSensor.h" line="+28"/>
         <source>Android Gamepad Pad as Button</source>
         <translation>Активная область Android-пульта как кнопка</translation>
     </message>
@@ -74,7 +64,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadWheel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadWheel.h" line="+29"/>
         <source>Android Gamepad Wheel</source>
         <translation>&quot;Руль&quot; Android-пульта</translation>
     </message>
@@ -82,7 +71,6 @@
 <context>
     <name>trik::robotModel::parts::TrikInfraredSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikInfraredSensor.h" line="+27"/>
         <source>Infrared Sensor</source>
         <translation>Датчик расстояния ИК</translation>
     </message>
@@ -90,7 +78,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLed.h" line="+27"/>
         <source>Led</source>
         <translation>Светодиод</translation>
     </message>
@@ -98,7 +85,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLightSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLightSensor.h" line="+28"/>
         <source>Light sensor</source>
         <translation>Датчик освещенности</translation>
     </message>
@@ -106,7 +92,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLineSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLineSensor.h" line="+28"/>
         <source>Line Sensor</source>
         <translation>Сенсор линии</translation>
     </message>
@@ -114,7 +99,6 @@
 <context>
     <name>trik::robotModel::parts::TrikMotionSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikMotionSensor.h" line="+27"/>
         <source>Motion Sensor</source>
         <translation>Сенсор движения</translation>
     </message>
@@ -122,7 +106,6 @@
 <context>
     <name>trik::robotModel::parts::TrikMotorsAggregator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikMotorsAggregator.h" line="+27"/>
         <source>Trik Motors Aggregator</source>
         <translation>Агрегатор моторов Trik</translation>
     </message>
@@ -130,7 +113,6 @@
 <context>
     <name>trik::robotModel::parts::TrikObjectSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikObjectSensor.h" line="+28"/>
         <source>Object Sensor</source>
         <translation>Сенсор объекта</translation>
     </message>
@@ -138,7 +120,6 @@
 <context>
     <name>trik::robotModel::parts::TrikPowerMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikPowerMotor.h" line="+27"/>
         <source>Power Motor</source>
         <translation>Силовой мотор</translation>
     </message>
@@ -146,7 +127,6 @@
 <context>
     <name>trik::robotModel::parts::TrikServoMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikServoMotor.h" line="+27"/>
         <source>Servo Motor</source>
         <translation>Сервомотор</translation>
     </message>
@@ -154,7 +134,6 @@
 <context>
     <name>trik::robotModel::parts::TrikSonarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikSonarSensor.h" line="+27"/>
         <source>Sonic Sensor</source>
         <translation>Датчик расстояния УЗ</translation>
     </message>
@@ -162,7 +141,6 @@
 <context>
     <name>trik::robotModel::parts::TrikTouchSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikTouchSensor.h" line="+28"/>
         <source>Touch sensor</source>
         <translation>Датчик касания</translation>
     </message>
@@ -170,7 +148,6 @@
 <context>
     <name>trik::robotModel::parts::TrikVideoCamera</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikVideoCamera.h" line="+27"/>
         <source>Video Camera</source>
         <translation>Видеокамера</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/common/twoDModel_ru.ts
+++ b/qrtranslations/ru/plugins/robots/common/twoDModel_ru.ts
@@ -202,123 +202,98 @@
         <translation type="vanished">2D модель</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="+65"/>
         <source>Root element must be &quot;constraints&quot; tag</source>
         <translation>Корневой элемент должен быть тэгом &quot;constraints&quot;</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>There must be a &quot;timelimit&quot; constraint.</source>
         <translation>Должен иметься тэг &quot;timelimit&quot;.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>There must be only one &quot;timelimit&quot; tag.</source>
         <translation>Тэг &quot;timelimit&quot; может быть только один.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Event tag must have &quot;condition&quot; or &quot;conditions&quot; child tag. &quot;%1&quot; found instead.</source>
         <translation>Тег &quot;event&quot; должен иметь дочерний тэг &quot;condition&quot; или &quot;conditions&quot;. Вместо этого найдено &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Event tag must have &quot;trigger&quot; or &quot;triggers&quot; child tag. &quot;%1&quot; found instead.</source>
         <translation>Тег &quot;event&quot; должен иметь дочерний тэг &quot;trigger&quot; или &quot;triggers&quot;. Вместо этого найдено &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Program worked for too long time</source>
         <translation>Программа работала слишком долго</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>&quot;Glue&quot; attribute must have value &quot;and&quot; or &quot;or&quot;.</source>
         <translation>Аттрибут &quot;glue&quot; должен иметь значение &quot;and&quot; или &quot;or&quot;.</translation>
     </message>
     <message>
-        <location line="+59"/>
-        <location line="+212"/>
         <source>Unknown tag &quot;%1&quot;.</source>
         <translation>Неизвестный тэг &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>There must be only one tag &quot;return&quot; in &quot;using&quot; expression.</source>
         <translation>Тэг &quot;return&quot; может быть только один.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>There must be &quot;return&quot; tag in &quot;using&quot; expression.</source>
         <translation>В выражении &quot;using&quot; должен иметься тэг &quot;return&quot;.</translation>
     </message>
     <message>
-        <location line="+334"/>
         <source>Unknown value &quot;%1&quot;.</source>
         <translation>Неизвестное значение &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Invalid integer value &quot;%1&quot;</source>
         <translation>&quot;%1&quot; - не целое число</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Invalid floating point value &quot;%1&quot;</source>
         <translation>&quot;%1&quot; - не число</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Invalid boolean value &quot;%1&quot; (expected &quot;true&quot; or &quot;false&quot;)</source>
         <translation>&quot;%1&quot; - не логическое значение (ожидалось &quot;true&quot; или &quot;false&quot;)</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Duplicate id: &quot;%1&quot;</source>
         <translation>Переобъявление события &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>When using the extended form for the %1 tag, the number of arguments starting with _ must be %2, %3 was provided</source>
         <translation>При использовании расширенной формы для тега %1 ожидаемое количество аргументов, начинающихся с _, — %2, было предоставлено %3</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>%1 tag must have exactly %2 child tag(s)</source>
         <translation>У тэга &quot;%1&quot; должно быть ровно %2 дочерних(ий) тэг(а)</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 tag must have at least %2 child tag(s)</source>
         <translation>У тэга &quot;%1&quot; должно быть как минимум %2 дочерних(ий) тэг(а)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&quot;%1&quot; tag must have &quot;%2&quot; attribute.</source>
         <translation>У тэга &quot;%1&quot; должен быть аттрибут &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Expected &quot;%1&quot; tag, got &quot;%2&quot;.</source>
         <translation>Ожидался тэг &quot;%1&quot;, найден - &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Attribute &quot;%1&quot; of the tag &quot;%2&quot; must not be empty.</source>
         <translation>Атрибут &quot;%1&quot; тэга &quot;%2&quot; не может быть пустым.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="+105"/>
         <source>No such region: %1</source>
         <translation>Нет такого региона: %1</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 is not a region</source>
         <translation>%1 - не регион</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>%1 has incorrect type for matching it with region</source>
         <translation>%1 не сопоставить с регионом (не тот тип)</translation>
     </message>
@@ -327,16 +302,10 @@
         <translation type="vanished">%1 не сопоставить с регионом (не тот тип)</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+12"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="+112"/>
-        <location line="+12"/>
         <source>No such event: %1</source>
         <translation>Нет такого события: %1</translation>
     </message>
     <message>
-        <location line="-90"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="+125"/>
         <source>No such object: %1</source>
         <translation>Нет такого объекта: %1</translation>
     </message>
@@ -345,235 +314,186 @@
         <translation type="vanished">У объекта &quot;%1&quot; нет свойства &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="-61"/>
         <source>Using special syntax with an empty variable name</source>
         <translation>Использование специального синтаксиса с пустым именем переменной</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The name %1 is not a valid variable name or property chain for an object</source>
         <translation>Имя %1 не является валидным именем переменной или цепочкой свойств объекта</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Requesting variable value with empty name</source>
         <translation>Запрашивается переменная с пустым именем</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Object path is empty!</source>
         <translation>Путь до объекта пуст!</translation>
     </message>
     <message>
-        <location line="+131"/>
         <source>Unknown type of object &quot;%1&quot;</source>
         <translation>Неизвестный тип объекта &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Object &quot;%1&quot; has no property &quot;%2&quot;</source>
         <translation>У объекта &quot;%1&quot; нет свойства &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/speedPopup.cpp" line="+25"/>
         <source>Speed:&amp;nbsp;&amp;nbsp;&lt;b&gt;%1%&lt;/b&gt;</source>
         <translation>Скорость:&amp;nbsp;&amp;nbsp;&lt;b&gt;%1%&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="-30"/>
         <source>Invalid &lt;setState&gt; object type %1</source>
         <translation>Неверный тип объекта %1 в элементе &lt;setState&gt;</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Object %1 has no property %2</source>
         <translation>Объект %1 не имеет свойства %2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/colorFieldItem.cpp" line="+52"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="+181"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp" line="+261"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Convert to region</source>
         <translation>Сконвертировать в регион</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bind to region</source>
         <translation>Привязать к региону</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="+1"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Edit</source>
         <translation>Изменить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="+119"/>
         <source>cm</source>
         <translation>см</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>m</source>
         <translation>м</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>px</source>
         <translation>пикс</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Pixels</source>
         <translation>Пиксели</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Centimeters</source>
         <translation>Сантиметры</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Meters</source>
         <translation>Метры</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Миллиметры</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="+35"/>
         <source>The &amp;lt;template&amp;gt; tag was provided, but the required &quot;name&quot; attribute was missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Redefinition a template %1 that already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>the &amp;lt;templates&amp;gt; tag can only contain the &amp;lt;template&amp;gt; tag as a child tag, actual %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="+31"/>
         <source>The &amp;lt;use&amp;gt; tag must contain a &quot;template&quot; attribute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Recursive template expansion detected: %1 -&gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The &amp;lt;use&amp;gt; tag contains a template=%1 attribute that is not the name of a declared template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>After substituting the parameters for the template %1, it did not become a valid xml node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="+78"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="+100"/>
         <source>line %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>template %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="+3"/>
         <source>relative the beginning of the &amp;lt;constraints&amp;gt; tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>relative to the beginning of the %1 template body</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Substitution chain: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="+29"/>
         <source>Currently, this method of setting &amp;lt;content&amp;gt; tag for the template %1 is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>When defining the template %1, the syntax %2 was used to substitute an offset %3 for an undeclared parameter %4.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>the &amp;lt;params&amp;gt; tag can only contain the &amp;lt;param&amp;gt; tag as a child tag for template %1, actual tag is &amp;lt;%2&amp;gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The &amp;lt;param&amp;gt; tag of template %1 was provided, but the required &quot;name&quot; attribute was missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>The &amp;lt;template&amp;gt; of template %1 tag was provided, but the required child tag &amp;lt;content&amp;gt; was missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The using an undeclared parameter %1 for template %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>The &amp;lt;use&amp;gt; tag can only contain a child tag &amp;lt;with&amp;gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>The parameter %1 of template %2 has no default value and was not explicitly specified by the user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/templateParserApi.cpp" line="+101"/>
         <source>Error while template substitution: %1</source>
         <translation type="unfinished">Ошибка при раскрытии шаблона: %1</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Error while parsing template: %1</source>
         <translation type="unfinished">Ошибка при разборе шаблона: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp" line="+1"/>
         <source>Change visibility</source>
         <translation>Изменить видимость</translation>
     </message>
@@ -581,7 +501,6 @@
 <context>
     <name>TwoDModelWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="+14"/>
         <source>2D Robot Model</source>
         <translation>Двумерная модель</translation>
     </message>
@@ -598,70 +517,54 @@
         <translation type="vanished">Вернуть робота в исходное положение</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Run program</source>
         <translation>Запустить программу</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Stop program</source>
         <translation>Остановить программу</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>Grid size:</source>
         <translation>Шаг сетки:</translation>
     </message>
     <message>
-        <location line="+230"/>
-        <location line="+7"/>
-        <location line="+7"/>
-        <location line="+14"/>
         <source>cm</source>
         <translation>см</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>kg</source>
         <translation>кг</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Decrease speed</source>
         <translation>Уменьшить скорость</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Time in 2D model</source>
         <translation>Время в 2D модели</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source> sec.</source>
         <translation> сек.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Increase speed</source>
         <translation>Увеличить скорость</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>px</source>
         <translation>пикс</translation>
     </message>
     <message>
-        <location line="-555"/>
         <source>Left wheel:</source>
         <translation>Левое колесо:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Right wheel:</source>
         <translation>Правое колесо:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Metric system units:</source>
         <translation>Единицы измерения</translation>
     </message>
@@ -670,52 +573,42 @@
         <translation type="vanished">Кол-во пикселей в см</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Realistic physics</source>
         <translation>Реалистичная физика</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Realistic sensors</source>
         <translation>Реалистичные сенсоры</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Realistic engines</source>
         <translation>Реалистичные моторы</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Wheel diameter:</source>
         <translation>Диаметр колеса:</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Robot height:</source>
         <translation>Высота робота:</translation>
     </message>
     <message>
-        <location line="-344"/>
         <source>Edit Regions</source>
         <translation>Редактировать регионы</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Reset World</source>
         <translation>Сбросить мир</translation>
     </message>
     <message>
-        <location line="+397"/>
         <source>Robot mass:</source>
         <translation>Масса робота:</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Robot width:</source>
         <translation>Ширина робота:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Robot track:</source>
         <translation>Колея робота:</translation>
     </message>
@@ -793,17 +686,14 @@
         <translation type="vanished">Ошибка при разборе шаблона: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="+127"/>
         <source>Error while parsing constraints: %1</source>
         <translation>Ошибка чтения ограничений: %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Warning while parsing constraints: %1</source>
         <translation>Предупреждение при чтении ограничений: %1</translation>
     </message>
     <message>
-        <location line="+232"/>
         <source>Program has finished, but the task is not accomplished.</source>
         <translation>Программа отработала, но задание не выполнено.</translation>
     </message>
@@ -811,7 +701,6 @@
 <context>
     <name>twoDModel::engine::TwoDModelEngineFacade</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="+207"/>
         <source>Realistic physics&apos; must be turned on to enjoy skittles, cubes and balls</source>
         <translation>Реалистичная физика должна быть включена для взаимодействия с кеглями, кубами и мячами</translation>
     </message>
@@ -819,7 +708,6 @@
 <context>
     <name>twoDModel::items::BallItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/ballItem.cpp" line="+54"/>
         <source>Ball (B)</source>
         <translation>Мяч (B)</translation>
     </message>
@@ -827,7 +715,6 @@
 <context>
     <name>twoDModel::items::CommentItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="-141"/>
         <source>Text (T)</source>
         <translation>Текст (Т)</translation>
     </message>
@@ -835,7 +722,6 @@
 <context>
     <name>twoDModel::items::CubeItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="+62"/>
         <source>Cube (X)</source>
         <translation>Куб (X)</translation>
     </message>
@@ -847,7 +733,6 @@
         <translation type="vanished">Кривая Безье (B)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/curveItem.cpp" line="+64"/>
         <source>Bezier Curve (Z)</source>
         <translation>Кривая Безье (Z)</translation>
     </message>
@@ -855,7 +740,6 @@
 <context>
     <name>twoDModel::items::EllipseItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/ellipseItem.cpp" line="+44"/>
         <source>Ellipse (E)</source>
         <translation>Эллипс (E)</translation>
     </message>
@@ -863,7 +747,6 @@
 <context>
     <name>twoDModel::items::ImageItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/imageItem.cpp" line="+80"/>
         <source>Image (I)</source>
         <translation>Картинка (I)</translation>
     </message>
@@ -871,7 +754,6 @@
 <context>
     <name>twoDModel::items::LineItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/lineItem.cpp" line="+49"/>
         <source>Line (L)</source>
         <translation>Линия (L)</translation>
     </message>
@@ -879,7 +761,6 @@
 <context>
     <name>twoDModel::items::RectangleItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/rectangleItem.cpp" line="+44"/>
         <source>Rectangle (R)</source>
         <translation>Прямоугольник (R)</translation>
     </message>
@@ -887,7 +768,6 @@
 <context>
     <name>twoDModel::items::SkittleItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/skittleItem.cpp" line="+54"/>
         <source>Can (C)</source>
         <translation>Банка (C)</translation>
     </message>
@@ -895,7 +775,6 @@
 <context>
     <name>twoDModel::items::StylusItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/stylusItem.cpp" line="+62"/>
         <source>Stylus (S)</source>
         <translation>Стилус (S)</translation>
     </message>
@@ -903,7 +782,6 @@
 <context>
     <name>twoDModel::items::WallItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="+69"/>
         <source>Wall (W)</source>
         <translation>Стена (W)</translation>
     </message>
@@ -911,27 +789,22 @@
 <context>
     <name>twoDModel::model::Model</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="+74"/>
         <source>The task was accomplished in %1 sec!</source>
         <translation>Задание выполнено за %1 сек!</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Error in checker: %1</source>
         <translation>Ошибка в проверяющей программе: %1</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>The &quot;version&quot; field of the &quot;root&quot; tag must not be empty.</source>
         <translation>Поле &quot;version&quot; тега &quot;root&quot; не должно быть пустым.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The world model has version %1. The current version is %2. Please check that the world model behaves as expected.</source>
         <translation>Модель мира имеет версию %1. Текущая версия %2. Пожалуйста, убедитесь, что модель мира ведет себя ожидаемым образом.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>This robot model already exists</source>
         <translation>Эта модель робота уже существует</translation>
     </message>
@@ -974,24 +847,14 @@
 <context>
     <name>twoDModel::model::WorldModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="+195"/>
-        <location line="+20"/>
-        <location line="+19"/>
-        <location line="+19"/>
-        <location line="+19"/>
-        <location line="+19"/>
-        <location line="+44"/>
-        <location line="+20"/>
         <source>Trying to add an item with a duplicate id: %1</source>
         <translation>Попытка добавить элемент с существующим идентификатором: %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Incorrect image, please try anouther one</source>
         <translation>Некорректное изображение, попробуйте другое</translation>
     </message>
     <message>
-        <location line="+543"/>
         <source>Unknown image with imageId %1</source>
         <translation>Неизвестное изображение с imageId %1</translation>
     </message>
@@ -999,8 +862,6 @@
 <context>
     <name>twoDModel::robotModel::TwoDRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/robotModel/twoDRobotModel.cpp" line="+74"/>
-        <location line="+3"/>
         <source>2D Model</source>
         <translation>2D модель</translation>
     </message>
@@ -1008,7 +869,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorAmbient</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorAmbient.h" line="+33"/>
         <source>EV3 color sensor (ambient)</source>
         <translation>Датчик цвета EV3 (рассеянный)</translation>
     </message>
@@ -1016,7 +876,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorBlue</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorBlue.h" line="+36"/>
         <source>Color sensor (blue)</source>
         <translation>Сенсор цвета (синий)</translation>
     </message>
@@ -1024,7 +883,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorFull</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorFull.h" line="+37"/>
         <source>Color sensor (full)</source>
         <translation>Сенсор цвета (распознавание цветов)</translation>
     </message>
@@ -1032,7 +890,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorGreen</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorGreen.h" line="+36"/>
         <source>Color sensor (green)</source>
         <translation>Сенсор цвета (зеленый)</translation>
     </message>
@@ -1040,7 +897,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorPassive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorPassive.h" line="+37"/>
         <source>Color sensor (passive)</source>
         <translation>Сенсор цвета (пассивный)</translation>
     </message>
@@ -1048,7 +904,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorRaw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorRaw.h" line="+35"/>
         <source>Color sensor (raw)</source>
         <translation>Датчик цвета (сырой)</translation>
     </message>
@@ -1056,7 +911,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorRed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorRed.h" line="+36"/>
         <source>Color sensor (red)</source>
         <translation>Сенсор цвета (красный)</translation>
     </message>
@@ -1064,7 +918,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorReflected</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorReflected.h" line="+33"/>
         <source>EV3 color sensor (reflected)</source>
         <translation>Датчик цвета EV3 (отраженный)</translation>
     </message>
@@ -1072,7 +925,6 @@
 <context>
     <name>twoDModel::robotModel::parts::Marker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/marker.h" line="+37"/>
         <source>Marker</source>
         <translation>Маркер</translation>
     </message>
@@ -1080,32 +932,26 @@
 <context>
     <name>twoDModel::view::ActionsBox</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="+26"/>
         <source>Hand dragging mode</source>
         <translation>Режим таскания сцены</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Multiselection mode</source>
         <translation>Режим выделения</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Save world model...</source>
         <translation>Сохранить модель мира...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Load world model...</source>
         <translation>Загрузить модель мира...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Load templates...</source>
         <translation>Загрузить шаблоны...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Load world model without robot configuration...</source>
         <translation>Загрузить модель мира без конфигурации робота...</translation>
     </message>
@@ -1114,12 +960,10 @@
         <translation type="vanished">Установить фон...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear items</source>
         <translation>Очистить всё</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Clear floor</source>
         <translation>Очистить пол от следов робота</translation>
     </message>
@@ -1127,22 +971,18 @@
 <context>
     <name>twoDModel::view::ColorItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="+104"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Disable filling</source>
         <translation>Не заливать</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enable filling</source>
         <translation>Заливать</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Thickness</source>
         <translation>Толщина</translation>
     </message>
@@ -1209,32 +1049,26 @@
 <context>
     <name>twoDModel::view::DetailsTab</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="+38"/>
         <source>Display</source>
         <translation>Дисплей</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ports configuration</source>
         <translation>Порты</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Motors</source>
         <translation>Моторы</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Physics</source>
         <translation>Физика</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Model parameters</source>
         <translation>Параметры модели</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Metric system</source>
         <translation>Метрическая система</translation>
     </message>
@@ -1242,7 +1076,6 @@
 <context>
     <name>twoDModel::view::GridParameters</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/gridParameters.cpp" line="+34"/>
         <source>Grid</source>
         <translation>Сетка</translation>
     </message>
@@ -1250,37 +1083,30 @@
 <context>
     <name>twoDModel::view::ImageItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="+58"/>
         <source>Image will be packed into save file. Warning: this will increase save file size.</source>
         <translation>Картинка будет запакована в проект. Внимание: это значительно увеличит размер файла сохранения.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Image will not be packed into a save file. Warning: if will use save file on other machine or rename file this image will disappear from 2D model.</source>
         <translation>Картинка не будет включена в файл сохранения. Внимание: при открытии текущего проекта на другой машине или переименовании файла с картинкой изображение в 2D модели пропадет.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The image will be in the background. Warning: the robot does not see this image.</source>
         <translation>Изображение будет на заднем плане. Предупреждение: робот не видит это изображение.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The image will be in the foreground. Warning: robot sees this image with sensors.</source>
         <translation>Изображение будет на переднем плане. Предупреждение: робот видит это изображение с помощью сенсоров.</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Change image...</source>
         <translation>Изменить картинку...</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select image</source>
         <translation>Выберите картинку</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Graphics (*.*)</source>
         <translation>Графика (*.*)</translation>
     </message>
@@ -1288,7 +1114,6 @@
 <context>
     <name>twoDModel::view::Palette</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/palette.cpp" line="+25"/>
         <source>Cursor (N)</source>
         <translation>Курсор (N)</translation>
     </message>
@@ -1296,32 +1121,26 @@
 <context>
     <name>twoDModel::view::RobotItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="+78"/>
         <source>Camera folowing robot: %1</source>
         <translation>Следовать за роботом: %1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>enabled</source>
         <translation>включено</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>disabled</source>
         <translation>отключено</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Return robot to the initial position</source>
         <translation>Вернуть робота в исходное положение</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Move start position here</source>
         <translation>Передвинуть стартовое положение робота сюда</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Marker thickness</source>
         <translation>Толщина маркера</translation>
     </message>
@@ -1329,7 +1148,6 @@
 <context>
     <name>twoDModel::view::SpeedPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/speedPopup.cpp" line="+5"/>
         <source>Reset to default</source>
         <translation>По умолчанию</translation>
     </message>
@@ -1341,32 +1159,26 @@
         <translation type="vanished">Выберите картинку</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="+897"/>
         <source>Select images</source>
         <translation>Выберите картинки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Graphics (*.*)</source>
         <translation>Графика (*.*)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You are trying to load to big image, it may freeze execution for some time. Continue?</source>
         <translation>Попытка загрузить слишком большое изображение может заморозить выполнение на некоторое время. Продолжить?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot load %1. Try another file.</source>
         <translation>Невозможно загрузить %1. Попробуйте другой файл.</translation>
     </message>
@@ -1374,12 +1186,10 @@
 <context>
     <name>twoDModel::view::TwoDModelWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="+385"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to clear scene?</source>
         <translation>Вы действительно хотите очистить сцену?</translation>
     </message>
@@ -1396,34 +1206,26 @@
         <translation type="vanished">см</translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>kg</source>
         <translation>кг</translation>
     </message>
     <message>
-        <location line="+303"/>
         <source>Training mode: solution will not be checked</source>
         <translation>Режим тренировки: решение не будет проверяться</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Checking mode: solution will be checked, errors will be reported</source>
         <translation>Режим проверки: проверка решения будет осуществляться, об ошибках будет сообщаться</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Saving world and robot model</source>
         <translation>Сохранение модели мира</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+20"/>
-        <location line="+25"/>
         <source>2D model saves (*.xml)</source>
         <translation>Файлы 2D модели (*.xml)</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Loading world and robot model</source>
         <translation>Загрузка модели мира</translation>
     </message>
@@ -1432,7 +1234,6 @@
         <translation type="vanished">Выберите каталог шаблонов</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Loading world without robot model</source>
         <translation>Загрузка модели мира без модели робота</translation>
     </message>
@@ -1449,23 +1250,18 @@
         <translation type="vanished">Попытка загрузить слишком большое изображение может заморозить выполнение на некоторое время. Продолжить?</translation>
     </message>
     <message>
-        <location line="+336"/>
         <source>Hide details</source>
         <translation>Скрыть детали</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Show details</source>
         <translation>Показать детали</translation>
     </message>
     <message>
-        <location line="+211"/>
-        <location line="+1"/>
         <source>No wheel</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 (port %2)</source>
         <translation>%1 (порт %2)</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/editor/common_ru.ts
+++ b/qrtranslations/ru/plugins/robots/editor/common_ru.ts
@@ -8,13 +8,10 @@
         <translation type="vanished">Функция:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="+486"/>
-        <location line="+354"/>
         <source>Condition:</source>
         <translation>Условие:</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Iterations:</source>
         <translation>Итераций:</translation>
     </message>
@@ -115,7 +112,6 @@
         <translation type="vanished">Порт:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
@@ -148,8 +144,6 @@
         <translation type="vanished">Громкость:</translation>
     </message>
     <message>
-        <location line="-373"/>
-        <location line="+885"/>
         <source>Expression:</source>
         <translation>Выражение:</translation>
     </message>
@@ -182,11 +176,6 @@
         <translation type="vanished">Датчик линии в переменную</translation>
     </message>
     <message>
-        <location line="-840"/>
-        <location line="+141"/>
-        <location line="+374"/>
-        <location line="+62"/>
-        <location line="+361"/>
         <source>Variable:</source>
         <translation>Переменная:</translation>
     </message>
@@ -195,13 +184,10 @@
         <translation type="vanished">Имя файла:</translation>
     </message>
     <message>
-        <location line="-781"/>
-        <location line="+310"/>
         <source>Text:</source>
         <translation>Текст:</translation>
     </message>
     <message>
-        <location line="+229"/>
         <source>Message:</source>
         <translation>Сообщение:</translation>
     </message>
@@ -286,12 +272,10 @@
         <translation type="vanished">Кнопка:</translation>
     </message>
     <message>
-        <location line="-245"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
@@ -344,7 +328,6 @@
         <translation type="vanished">Длительность</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>ms</source>
         <translation>мс</translation>
     </message>
@@ -353,38 +336,30 @@
         <translation type="vanished">см</translation>
     </message>
     <message>
-        <location line="-877"/>
         <source>Wait:</source>
         <translation>Дождаться нажатия:</translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Reads a value into variable from an input dialog.</source>
         <translation>Ввести с клавиатуры значение в переменную.</translation>
     </message>
     <message>
-        <location line="+104"/>
-        <location line="+450"/>
         <source>Thread:</source>
         <translation>Задача:</translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>From:</source>
         <translation>От:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>To:</source>
         <translation>До:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Synchronized:</source>
         <translation>Дождаться сообщения:</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Delay:</source>
         <translation>Задержка:</translation>
     </message>
@@ -445,69 +420,54 @@
         <translation type="vanished">Пульт:</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Value:</source>
         <translation>Значение:</translation>
     </message>
     <message>
-        <location line="-1353"/>
         <source>AbstractNode</source>
         <translation>Базовый блок</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Clear Screen</source>
         <translation>Очистить экран</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Clears everything drawn on the robot`s screen.</source>
         <translation>Стереть всё, что нарисовано на экране робота.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+840"/>
         <source>Redraw</source>
         <translation>Обновить картинку</translation>
     </message>
     <message>
-        <location line="-829"/>
-        <location line="+37"/>
         <source>Comment</source>
         <translation>Комментарий</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>This block can hold text notes that are ignored by generators and interpreters. Use it for improving the diagram readability.</source>
         <translation>Блок с текстовыми заметками, которые игнорируются при генерации и интерпретации. Используйте его для повышения наглядности диаграммы.</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Enter some text here...</source>
         <translation>Введите текст...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Link</source>
         <translation>Линия соединения</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>For creating a link between two elements A and B you can just hover a mouse above A, press the right mouse button and (without releasing it) draw a line to the element B. Alternatively you can just &apos;pull&apos; a link from a small blue circle next to the element.</source>
         <translation>Для того, чтобы создать связь между двумя элементами A и B, можно навести курсор на элемент A, нажать правую кнопку мыши и, не отпуская ее, провести линию до элемента B, либо &apos;вытащить&apos; связь из кружочка справа от элемента.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Guard</source>
         <translation>Условие</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>EngineCommand</source>
         <translation>Базовый блок моторов</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>EngineMovementCommand</source>
         <translation>Базовый блок включения моторов</translation>
     </message>
@@ -564,12 +524,10 @@
         <translation type="vanished">Заполнен</translation>
     </message>
     <message>
-        <location line="+688"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -634,7 +592,6 @@
         <translation type="vanished">Включить моторы в режиме реверса по заданным портам с заданной мощностью. Порты задаются буквами A, B или C, разделенными запятыми. Мощность задается в процентах числом от -100 до 100, если задано отрицательное значение, мотор включается в обычном режиме.</translation>
     </message>
     <message>
-        <location line="-665"/>
         <source>Power (%)</source>
         <translation>Мощность (%)</translation>
     </message>
@@ -643,7 +600,6 @@
         <translation type="vanished">B, C</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>100</source>
         <translation>100</translation>
     </message>
@@ -672,7 +628,6 @@
         <translation type="vanished">Установить цвет светодиода на передней панели робота.</translation>
     </message>
     <message>
-        <location line="+522"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
@@ -685,7 +640,6 @@
         <translation type="vanished">Проиграть на роботе звук с заданной частотой и длительностью. Аналогичен блоку &apos;Гудок&apos;, но позволяет задавать параметры звука. Имеется параметр, определяющий, ждать ли завершения проигрывания звука или сразу же перейти к следующему блоку.</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
@@ -734,8 +688,6 @@
         <translation type="vanished">Считанное значение</translation>
     </message>
     <message>
-        <location line="-363"/>
-        <location line="+415"/>
         <source>0</source>
         <translation>0</translation>
     </message>
@@ -792,32 +744,26 @@
         <translation type="vanished">Ждать, пока не сработает датчик касания. Параметром указывается номер порта, к которому подключен датчик. Допустимые значения: 1, 2, 3, 4.</translation>
     </message>
     <message>
-        <location line="-1129"/>
         <source>End if</source>
         <translation>Конец условия</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Unites control flow from different condition branches.</source>
         <translation>Соединяет ветви блока &quot;Условие&quot;.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Final Node</source>
         <translation>Конец</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The final node of the program. If the program consists of some parallel execution lines the reachment of this block terminates the corresponding execution line. This block can`t have outgoing links.</source>
         <translation>Конец программы. Если программа состоит из нескольких параллельных участков выполнения, достижение этого блока завершает соответствующий участок выполнения. У данного блока не может быть исходящих связей.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Fork</source>
         <translation>Параллельные задачи</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Separates program execution into a number of threads that will be executed concurrently from the programmers`s point of view. For example in such way signal from sensor and some time interval can be waited synchroniously. This block must have at least two outgoing links. &apos;Guard&apos; property of every link must contain unique thread identifiers, and one of those identifiers must be the same as the identifier of a thread where fork is placed (it must be &apos;main&apos; if it is the first fork in a program.</source>
         <translation>Разделяет исполнение программы на несколько задач, которые будут исполняться параллельно с точки зрения программиста. К примеру, в этом случае ожидание сигнала от датчика или истечения некоторого промежутка времени могут происходить одновременно. Этот блок должен иметь как минимум две исходящие связи. Свойство &quot;Условие&quot; всех исходящих связей должно содержать уникальные идентификаторы задач, и один из этих идентификаторов должен совпадать с идентификатором задачи, из которой вызван этот блок (считается, что первый блок в программе вызывается из задачи с идентификатором &apos;main&apos;).</translation>
     </message>
@@ -826,7 +772,6 @@
         <translation type="vanished">Функция</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Evaluates a value of the given expression. Also new variables can be defined in this block. See the &apos;Expressions Syntax&apos; chapter in help for more information about &apos;Function&apos; block syntax.</source>
         <translation>Посчитать значение заданного выражения. Также в данном блоке допускается определение переменных. Подробнее про синтаксис допустимых выражений параметра &apos;Функция&apos; см. в документации в разделе &apos;Синтаксис выражений&apos;.</translation>
     </message>
@@ -835,71 +780,46 @@
         <translation type="vanished">Тело функции</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Get Button Code</source>
         <translation>Получить код кнопки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Assigns a given variable a value of pressed button. If no button is pressed at the moment and &apos;Wait&apos; property is false when variable is set to -1.</source>
         <translation>Присваивает заданной переменной код нажатой кнопки. Если в данный момент нет нажатых кнопок и свойство &apos;Дождаться нажатия&apos; ложно, переменная будет иметь значение -1.</translation>
     </message>
     <message>
-        <location line="+39"/>
-        <location line="+151"/>
-        <location line="+374"/>
-        <location line="+414"/>
         <source>Variable</source>
         <translation>Переменная</translation>
     </message>
     <message>
-        <location line="-938"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="+137"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Wait</source>
         <translation>Ожидание</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+151"/>
-        <location line="+374"/>
-        <location line="+307"/>
-        <location line="+107"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+34"/>
-        <location line="+353"/>
         <source>Condition</source>
         <translation>Условие</translation>
     </message>
     <message>
-        <location line="-385"/>
         <source>Separates program execution in correspondece with the given condition. The &apos;Condition&apos; parameter value must be some boolean expression that will determine subsequent program execution line. This block must have two outgoing links, at least one of them must have &apos;Guard&apos; parameter set to &apos;true&apos; or &apos;false&apos;. The execution will be proceed trough the link marked with the guard corresponding to &apos;Condition&apos; parameter of the block.</source>
         <translation>Разделить выполнение программы в соответствии с заданным условием. Значением параметра &apos;Условие&apos; является некое логическое выражение, на основе значения которого будет осуществлен выбор дальнейшего пути выполнения диаграммы. У данного блока должны быть две исходящие связи, у одной из которых должно быть задано значение параметра &apos;Условие&apos; (возможные варианты — &apos;истина&apos; и &apos;ложь&apos;). При невыполнении данного условия выполнение передается по другой связи.</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location line="+353"/>
         <source>x &gt; 0</source>
         <translation>x &gt; 0</translation>
     </message>
     <message>
-        <location line="-342"/>
         <source>Initial Node</source>
         <translation>Начало</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The entry point of the program execution. Each diagram should have only one such block, it must not have incomming links and it must have only one outgoing link. The interpretation process starts from exactly this block.</source>
         <translation>Начальная точка выполнения программы. На каждой диаграмме такой блок должен быть только один, в него не должно быть входящих связей, исходящая связь из этого элемента должна быть только одна. Процесс интерпретации диаграммы начинается именно с этого блока.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>User Input</source>
         <translation>Пользовательский ввод</translation>
     </message>
@@ -908,83 +828,66 @@
         <translation type="vanished">Устанавливает значение переменной в значение из окна пользовательского ввода</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Default:</source>
         <translation>По умолчанию:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Join</source>
         <translation>Слияние задач</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Joins a number of threads into one. &apos;Guard&apos; property of the single outgoing link must contain an identifier of one of threads being joined. The specified thread would wait until the rest of them finish execution, and then proceed in a normal way.</source>
         <translation>Сливает несколько параллельных задач в одну. Свойство &quot;Условие&quot; единственной исходящей связи должно содержать идентификатор одной из сливаемых задач. Выполнение указанной задачи приостановится до того момента, как остальные задачи подойдут к этому блоку (закончат выполнение). Затем выполнение продолжается в обычном порядке.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Kill Thread</source>
         <translation>Завершить задачу</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Terminates execution of a specified thread.</source>
         <translation>Заканчивает выполнение указанной задачи.</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Thread</source>
         <translation>Задача</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>main</source>
         <translation>main</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loop</source>
         <translation>Цикл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This block executes a sequence of blocks for a given number of times. The number of repetitions is specified by the &apos;Iterations&apos; parameter. This block must have two outgoing links. One of them must be marked with the &apos;body&apos; guard (that means that the property &apos;Guard&apos; of the link must be set to &apos;body&apos; value). Another outgoing link must be unmarked: the program execution will be proceeded through this link when it will go through our &apos;Loop&apos; block for the given number of times.</source>
         <translation>Блок, организующий выполнение последовательности блоков несколько раз. Число повторений задается значением параметра &apos;Итераций&apos;. Блок должен иметь две исходящие связи, одна из которых должна быть помечена значением &apos;тело цикла&apos; (то есть значение параметра &apos;Условие&apos; должно быть &apos;тело цикла&apos;). Другая связь, исходящая из блока &apos;Цикл&apos;, должна оставаться непомеченной: по ней будет осуществляться переход, когда программа пройдет через блок &apos;Цикл&apos; указанное число раз.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Iterations</source>
         <translation>Итерации</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+248"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Marker Down</source>
         <translation>Опустить маркер</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Moves the marker of the 2D model robot down to the floor: the robot will draw its trace on the floor after that. If the marker of another color is already drawing at the moment it will be replaced.</source>
         <translation>Опускает маркер робота в 2D модели на пол так, что тот начинает рисовать на полу свою траекторию Если маркер другого цвета уже опущен, то он будет замещен.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Marker Up</source>
         <translation>Поднять маркер</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Lifts the marker of the 2D model robot up: the robot stops drawing its trace on the floor after that.</source>
         <translation>Поднимает маркер робота в 2D модели так, что тот перестает рисовать свою траекторию на полу.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Pre-conditional Loop</source>
         <translation>Цикл с предусловием</translation>
     </message>
@@ -1017,79 +920,62 @@
         <translation type="vanished">Ждать, пока расстояние, возвращаемое ультразвуковым датчиком расстояния, не будет сравнимо с указанным в значении параметра &apos;Расстояние&apos; (расстояние задается в сантиметрах, от 0 до 255). Еще один парамер — номер порта, к которому подключен датчик расстояния. Также параметром указывается операция, которая будет использоваться для сравнения с введенным расстоянием.</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Print Text</source>
         <translation>Напечатать текст</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Prints a given line in the specified coordinates on the robot`s screen. The value of &apos;Text&apos; property is interpreted as a plain text unless &apos;Evaluate&apos; property is set to true, then it will be interpreted as an expression (that may be useful for example when debugging variables values).</source>
         <translation>Печатает заданную строку в заданном месте на экране робота. Значение свойства &quot;Текст&quot; по умолчанию трактуется как строка в чистом виде, оно так и будет выведено на экран. Чтобы система считала, что это выражение на текстовом языке (это может быть полезно, например, при отладке значения переменных), поставьте галочку &quot;Вычислять&quot; в редакторе свойств.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Evaluate</source>
         <translation>Вычислять</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enter some text here</source>
         <translation>Введите текст</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+1"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Random Initialization</source>
         <translation>Случайное число</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets a variable value to a random value inside given interval.</source>
         <translation>Присваивает переменной случайное число из заданного интервала.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>From</source>
         <translation>От</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>To</source>
         <translation>До</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Receive Message From Thread</source>
         <translation>Получить сообщение из другой задачи</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Receive a message sent to a thread from which this block is called.</source>
         <translation>Получить сообщение, посланное другой задачей той задаче, из которой вызван этот блок.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Synchronized</source>
         <translation>Дождаться сообщения</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>RobotsDiagramGroup</source>
         <translation>Диаграмма поведения роботов</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="-29"/>
         <source>Robot`s Behaviour Diagram</source>
         <translation>Диаграмма поведения робота</translation>
     </message>
@@ -1098,12 +984,10 @@
         <translation type="vanished">Конфигурация устройств</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Send Message To Thread</source>
         <translation>Отправить сообщение в задачу</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sends a message to a specified thread.</source>
         <translation>Посылает сообщение в указанную задачу.</translation>
     </message>
@@ -1112,58 +996,46 @@
         <translation type="vanished">Сообщение</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Subprogram</source>
         <translation>Подпрограмма</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Subprogram call. Subprograms are used for splitting repetitive program parts into a separate diagram and then calling it from main diagram or other subprograms. When this block is added into a diagram it will be suggested to enter subprogram name. The double click on subprogram call block may open the corresponding subprogram diagram. Moreover user palette will appear containing existing subrpograms, they can be dragged into a diagram like the usual blocks.</source>
         <translation>Вызов подпрограммы. Подпрограммы используются для того, чтобы вынести повторяющиеся фрагменты программы на отдельную диаграмму, а потом вызывать фрагмент программы с этой диаграммы в нескольких местах основной программы или других подпрограмм. При добавлении этого блока на диаграмму будет предложено ввести имя подпрограммы, после чего двойным кликом на блоке можно будет перейти на диаграмму, соответствующую данной подпрограмме. Кроме того, появится дополнительная палитра со всеми подпрограммами, подпрограммы из неё можно перетаскивать на сцену и использовать как обычные блоки.</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Subprogram Diagram</source>
         <translation>Подпрограмма</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>SubprogramDiagramGroup</source>
         <translation>Подпрограмма</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Switch</source>
         <translation>Выбор</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Selects the program execution branch in correspondence with some expression value. The value of the expression written in &apos;Expression&apos; property is compared to the values on the outgoing links. If equal value is found then execution will be proceeded by that branch. Else branch without a marker will be selected.</source>
         <translation>Выбирает ветку, по которой будет продолжено исполнение программы. Значение выражения, указанного в свойстве &apos;Выражение&apos; сравнивается со значениями на исходящих связях. Если среди них найдено равное, исполнение будет продолжено по этой ветке. В противном случае будет выбрана ветка без маркера.</translation>
     </message>
     <message>
-        <location line="-887"/>
-        <location line="+918"/>
         <source>Expression</source>
         <translation>Выражение</translation>
     </message>
     <message>
-        <location line="-464"/>
         <source>This block executes a sequence of blocks while condition in &apos;Condition&apos; is true. This block must have two outgoing links. One of them must be marked with the &apos;body&apos; guard (that means that the property &apos;Guard&apos; of the link must be set to &apos;body&apos; value). Another outgoing link must be unmarked: the program execution will be proceeded through this link when condition becomes false.</source>
         <translation>Блок позволяет выполнить последовательность блоков, пока указанное в свойстве &apos;Условие&apos; условие является верным. Блок должен иметь две исходящие связи, одна из которых должна быть помечена значением &apos;тело цикла&apos; (то есть значение параметра &apos;Условие&apos; должно быть &apos;тело цикла&apos;). Другая связь, исходящая из блока &apos;Цикл с предусловием&apos;, должна оставаться непомеченной: по ней будет осуществляться переход, когда &apos;Условие&apos; станет ложным.</translation>
     </message>
     <message>
-        <location line="+475"/>
         <source>Timer</source>
         <translation>Таймер</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for a given time in milliseconds.</source>
         <translation>Ждать заданное количество времени в миллисекундах.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Delay (ms)</source>
         <translation>Задержка (мс)</translation>
     </message>
@@ -1488,53 +1360,26 @@
         <translation type="vanished">Записывает заданное значение в файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Variable Initialization</source>
         <translation>Инициализация переменной</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Assigns a given value to a given variable.</source>
         <translation>Присвоить данное значение данной переменной.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Algorithms</source>
         <translation>Алгоритмы</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Действия</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Drawing</source>
         <translation>Рисование</translation>
     </message>
@@ -1546,37 +1391,30 @@
         <translation type="vanished">Тело функции</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="-990"/>
         <source>Expression</source>
         <translation>Выражение</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Variable</source>
         <translation>Переменная</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Devices configuration</source>
         <translation>Конфигурация устройств</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Message</source>
         <translation>Сообщение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thread</source>
         <translation>Задача</translation>
     </message>
@@ -2416,17 +2254,14 @@
         <translation type="vanished">Присвоить указанной переменной указанное значение.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="+16"/>
         <source>Composite</source>
         <translation>Композиция</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Общая</translation>
     </message>
@@ -2439,27 +2274,22 @@
         <translation type="vanished">Истина</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>greater</source>
         <translation>больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>меньше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>не больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>не меньше</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Concurrent</source>
         <translation>Параллельный</translation>
     </message>
@@ -2540,12 +2370,10 @@
         <translation type="vanished">Ждёт нажатия на одну из активных областей Android-пульта. Левая область имеет номер 1, правая - номер 2.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Защищенный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Последовательный</translation>
     </message>
@@ -2594,7 +2422,6 @@
         <translation type="vanished">F1</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>black</source>
         <translation>черный</translation>
     </message>
@@ -2935,7 +2762,6 @@
         <translation type="vanished">красный пульсирующий</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>body</source>
         <translation>тело цикла</translation>
     </message>
@@ -2976,7 +2802,6 @@
         <translation type="vanished">Вверх</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>blue</source>
         <translation>синий</translation>
     </message>
@@ -3041,7 +2866,6 @@
         <translation type="vanished">серый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>green</source>
         <translation>зелёный</translation>
     </message>
@@ -3054,17 +2878,14 @@
         <translation type="vanished">пурпурный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red</source>
         <translation>красный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>white</source>
         <translation>белый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yellow</source>
         <translation>жёлтый</translation>
     </message>
@@ -3137,53 +2958,42 @@
         <translation type="vanished">4</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>In</source>
         <translation>Входной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Входной-выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Возвращается</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>norm</source>
         <translation>норма</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>ось x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>ось y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>ось z</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>brake</source>
         <translation>торможение</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+6"/>
         <source>false</source>
         <translation>ложь</translation>
     </message>
@@ -3192,8 +3002,6 @@
         <translation type="vanished">итерация</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
         <source>true</source>
         <translation>истина</translation>
     </message>
@@ -3234,22 +3042,18 @@
         <translation type="vanished">JF1</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>Package</source>
         <translation>Пакет</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Приватный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Защищенный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Публичный</translation>
     </message>
@@ -3258,7 +3062,6 @@
         <translation type="vanished">тормозить</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>float</source>
         <translation>скольжение</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/editor/ev3_ru.ts
+++ b/qrtranslations/ru/plugins/robots/editor/ev3_ru.ts
@@ -4,169 +4,134 @@
 <context>
     <name>Ev3MetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="+204"/>
         <source>In</source>
         <translation>Входной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Входной-выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Возвращаемое значение</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>black</source>
         <translation>черный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>blue</source>
         <translation>синий</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+6"/>
         <source>green</source>
         <translation>зеленый</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
         <source>red</source>
         <translation>красный</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>white</source>
         <translation>белый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yellow</source>
         <translation>желтый</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>bool</source>
         <translation>Логическое значение</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>int</source>
         <translation>Целое число</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>string</source>
         <translation>Строка</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>norm</source>
         <translation>нормаль</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>ось x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>ось y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>ось z</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>brake</source>
         <translation>торможение</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Concurrent</source>
         <translation>Параллельно</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Со стражником</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Последовательно</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>greater</source>
         <translation>больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>меньше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>не больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>не меньше</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Package</source>
         <translation>Пакетная</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Приватная</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Защищенная</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Открытая</translation>
     </message>
@@ -175,130 +140,102 @@
         <translation type="vanished">тормозить</translation>
     </message>
     <message>
-        <location line="-22"/>
-        <location line="+14"/>
         <source>float</source>
         <translation>Значение с плавающей точкой</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Down</source>
         <translation>Вниз</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enter</source>
         <translation>Вперед</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Left</source>
         <translation>Влево</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Right</source>
         <translation>Вправо</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Up</source>
         <translation>Вверх</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>green flash</source>
         <translation>зеленый моргающий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>green pulse</source>
         <translation>зеленый плавный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>off</source>
         <translation>выключить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>orange</source>
         <translation>оранжевый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>orange flash</source>
         <translation>оранжевый моргающий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>orange pulse</source>
         <translation>оранжевый плавный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red flash</source>
         <translation>красный моргающий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red pulse</source>
         <translation>красный плавный</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+6"/>
         <source>false</source>
         <translation>ложь</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>body</source>
         <translation>тело цикла</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+6"/>
         <source>true</source>
         <translation>истина</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Composite</source>
         <translation>Композиция</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Агрегация</translation>
     </message>
@@ -306,1017 +243,706 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="+26"/>
         <source>Beep</source>
         <translation>Гудок</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.</source>
         <translation>Проигрывает на роботе звук с заданной частотой. Принимает два параметра: первый – громкость звука, второй – ждать ли окончания проигрывания звука перед тем, как продолжить.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+876"/>
-        <location line="+1061"/>
         <source>Volume:</source>
         <translation>Громкость:</translation>
     </message>
     <message>
-        <location line="-1929"/>
-        <location line="+886"/>
         <source>Wait for Completion:</source>
         <translation>Ожидать завершения:</translation>
     </message>
     <message>
-        <location line="-853"/>
-        <location line="+880"/>
         <source>50</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-880"/>
-        <location line="+880"/>
-        <location line="+1051"/>
         <source>Volume</source>
         <translation>Громкость</translation>
     </message>
     <message>
-        <location line="-1930"/>
-        <location line="+880"/>
         <source>Wait for Completion</source>
         <translation>Ожидать завершения</translation>
     </message>
     <message>
-        <location line="-869"/>
         <source>Calibrate Black</source>
         <translation>Калибровка черного</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Calibrates the black threshold for each sensor in the array. Place the array over the black surface with all sensors on the black area.</source>
         <translation>Калибрует порог черного для сенсора. Должен находиться на черном.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Calibrate gyroscope</source>
         <translation>Калибровка  гироскопа</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets gyroscope&apos;s angle to zero in current position.</source>
         <translation>Устанавливает гироскоп в 0 в текущей позиции.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Calibrate PID</source>
         <translation>Калибровка ПИД-регулятора</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets set point, P, I, D value of PID control and P factor, I factor, D factor for P, I, D value of PID control.</source>
         <translation>Устанавливает уставку сенсора (середина сенсора над линией), П/(П фактор), И/(И фактор), Д/(Д фактор).</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Set point:</source>
         <translation>Уставка сенсора:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>P:</source>
         <translation>П:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>P factor:</source>
         <translation>П фактор:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>I:</source>
         <translation>И:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>I factor:</source>
         <translation>И фактор:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>D:</source>
         <translation>Д:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>D factor:</source>
         <translation>Д фактор:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>D</source>
         <translation>Д</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>D factor</source>
         <translation>Д фактор</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I</source>
         <translation>И</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I factor</source>
         <translation>И фактор</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P</source>
         <translation>П</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P factor</source>
         <translation>П фактор</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set point</source>
         <translation>Середина сенсора</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Calibrate White</source>
         <translation>Калибровка белого</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Calibrates the white threshold for each sensor in the array. Place the array over the white surface with all sensors on the white area.</source>
         <translation>Калибрует порог белого для сенсора. Должен находиться на белом.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Clear Encoder</source>
         <translation>Сбросить энкодеры</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Сбросить показания количества оборотов моторов по заданным портам.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+360"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>Ports:</source>
         <translation>Порты:</translation>
     </message>
     <message>
-        <location line="-443"/>
-        <location line="+476"/>
         <source>A, B, C, D</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-476"/>
-        <location line="+314"/>
-        <location line="+54"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>Ports</source>
         <translation>Порты</translation>
     </message>
     <message>
-        <location line="-465"/>
         <source>Draw Circle</source>
         <translation>Нарисовать круг</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws on the robot screen a circle with the given center and radius.</source>
         <translation>Нарисовать на экране круг с заданным центром и заданным радиусом.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+144"/>
-        <location line="+54"/>
         <source>X:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-190"/>
-        <location line="+144"/>
-        <location line="+54"/>
         <source>Y:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-190"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+206"/>
         <source>Filled:</source>
         <translation>Закрашенный:</translation>
     </message>
     <message>
-        <location line="-182"/>
         <source>Radius</source>
         <translation>Радиус</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+205"/>
         <source>Filled</source>
         <translation>Закрашенный</translation>
     </message>
     <message>
-        <location line="-204"/>
-        <location line="+70"/>
-        <location line="+56"/>
-        <location line="+80"/>
         <source>Redraw</source>
         <translation>Обновить картинку</translation>
     </message>
     <message>
-        <location line="-205"/>
-        <location line="+126"/>
-        <location line="+81"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-206"/>
-        <location line="+126"/>
-        <location line="+81"/>
         <source>Y</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Draw Line</source>
         <translation>Нарисовать линию</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Нарисовать на экране отрезок. В качестве параметров блоку указываются концы отрезка.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>X1:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y1:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>X2:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y2:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>X1</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>X2</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y1</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y2</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Draw Pixel</source>
         <translation>Нарисовать точку</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Нарисовать на экране точку в указанных координатах.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Draw Rectangle</source>
         <translation>Нарисовать прямоугольник</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Нарисовать на экране прямоугольник. В качестве параметров указываются координаты левого верхнего угла, ширина и высота прямоугольника.</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Height</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Ev3EngineMovementCommand</source>
         <translation>Базовый блок моторов EV3</translation>
     </message>
     <message>
-        <location line="+185"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location line="-161"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>B, C</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-107"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>100</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-108"/>
-        <location line="+54"/>
-        <location line="+54"/>
         <source>Power (%)</source>
         <translation>Мощность (%)</translation>
     </message>
     <message>
-        <location line="-97"/>
         <source>Motors Backward</source>
         <translation>Моторы назад</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Включить моторы в режиме реверса по заданным портам с заданной мощностью. Порты задаются буквами A, B или C, разделенными запятыми. Мощность задается в процентах числом от -100 до 100, если задано отрицательное значение, мотор включается в обычном режиме.</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+54"/>
         <source>Power:</source>
         <translation>Мощность:</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Motors Forward</source>
         <translation>Моторы вперёд</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Включить моторы по заданным портам с заданной мощностью. Порты задаются буквами A, B или C, разделенными запятыми. Мощность задается в процентах числом от -100 до 100, если задано отрицательное значение, мотор включается в режиме реверса.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Stop Motors</source>
         <translation>Моторы стоп</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Disables motors on the given ports.</source>
         <translation>Выключить моторы по заданным портам.</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Led</source>
         <translation>Светодиод</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the color of the LED on the robot`s front panel.</source>
         <translation>Устанавливает цвет светодида на передней панели робота.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+649"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-624"/>
-        <location line="+649"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location line="-638"/>
         <source>Play Tone</source>
         <translation>Воспроизвести</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Plays on the robot a sound with the given frequency and duration. This block is similar to the &apos;Beep&apos; block wuth the only difference that here you can specify sound parameters.</source>
         <translation>Проигрывает на роботе звук с заданной частотой и продолжительностью. Этот блок похож на &apos;Гудок&apos;, единственное отличие заключается в возможности регулировать параметры звука.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Frequency:</source>
         <translation>Частота:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hz</source>
         <translation>Гц</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+34"/>
         <source>Duration</source>
         <translation>Продолжительность</translation>
     </message>
     <message>
-        <location line="-33"/>
         <source>ms</source>
         <translation>мс</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+1"/>
         <source>1000</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Frequency</source>
         <translation>Частота</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Read Sensor to Array</source>
         <translation>Считать сенсор в массив</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Read the values from the Line Leader.  Amount of light or dark each sensor sees.  Typically between 0-20.  0=black, 100=white.</source>
         <translation>Считать значения с сенсора (восемь значений). Значения от 0 до 100. 0 - черный, 100 - белый.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Array:</source>
         <translation>Массив:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>a</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Array Variable</source>
         <translation>Переменная массив</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Read Average to Variable</source>
         <translation>Средневзвешенное значение в переменную</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Read the Weighted Average value from the sensor.  This value is calculated internally by the sensor where each of the eight sensors is either triggered or not and multiplied by a factor to help determine if the line is left, right or on center of the line (according to the set point). EXPECTED VALUES: 0-80 (-1=ERROR)</source>
         <translation>Считывает средневзвешенное значение в переменную. Значение высчитывается внутри сенсора, где каждый из восьми сенсоров берется с коэффициентом, и вычисляется срееднее. Ожидается значение от 0 до 80 (-1 = ошибка)</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+124"/>
         <source>x</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-124"/>
-        <location line="+124"/>
         <source>Variable</source>
         <translation>Переменная</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Read RGB into Variables</source>
         <translation>Считать цвета в переменные</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reads R, G, B channels values into given variables</source>
         <translation>Считать значения красного, зеленого, синего канала в переменные</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>R Variable:</source>
         <translation>Значение красного:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>G Variable:</source>
         <translation>Значение зеленого:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>B Variable:</source>
         <translation>Значение синего:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>b</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B Variable</source>
         <translation>Значение синего</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>g</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G Variable</source>
         <translation>Знаечние зеленого</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>r</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R Variable</source>
         <translation>Значение красного</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Read Steering to Variable</source>
         <translation>Управляющее значение в переменную</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Read the Steering value from the sensor.  This value is calculated internally and can directly be used to set turning values for the robot&apos;s motors. EXPECTED VALUES: -100 to 100 (-101=ERROR)</source>
         <translation>Считывает управляющее значение в переменную. Значение высчитывается внутри сенсора и может быть использовано сразу для моторов. Ожидается значение от -100 до 100 (-101 = ошибка)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Send Mail</source>
         <translation>Отправить письмо роботу</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sends mail (message) to another robot. If Receiver name left empty, message will be sent to all connected robots</source>
         <translation>Отправляет письмо другому роботу. Если имя получателя пусто, сообщение будет отослано всем соединенным роботам</translation>
     </message>
     <message>
-        <location line="+863"/>
         <source>Wake Up Line Leader</source>
         <translation>Пробудить датчик линии</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wakes the line leader to prepare for use.</source>
         <translation>Включает датчик линии для работы.</translation>
     </message>
     <message>
-        <location line="-858"/>
-        <location line="+621"/>
         <source>Message type:</source>
         <translation>Тип сообщения:</translation>
     </message>
     <message>
-        <location line="-613"/>
         <source>Message:</source>
         <translation>Сообщение:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Receiver name:</source>
         <translation>Имя получателя:</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+605"/>
         <source>Mailbox name:</source>
         <translation>Имя почтового ящика:</translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>42</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Сообщение</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+621"/>
         <source>Message type</source>
         <translation>Тип сообщения</translation>
     </message>
     <message>
-        <location line="-620"/>
-        <location line="+619"/>
         <source>EV3MailBox</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-619"/>
-        <location line="+619"/>
         <source>Mailbox name</source>
         <translation>Имя почтового ящика</translation>
     </message>
     <message>
-        <location line="-607"/>
         <source>Ev3SensorBlock</source>
         <translation>Базовый сенсорный блок EV3</translation>
     </message>
     <message>
-        <location line="-1148"/>
-        <location line="+44"/>
-        <location line="+106"/>
-        <location line="+45"/>
-        <location line="+693"/>
-        <location line="+53"/>
-        <location line="+71"/>
-        <location line="+53"/>
-        <location line="+107"/>
-        <location line="+44"/>
-        <location line="+44"/>
-        <location line="+52"/>
-        <location line="+99"/>
-        <location line="+78"/>
-        <location line="+62"/>
-        <location line="+64"/>
-        <location line="+71"/>
-        <location line="+136"/>
-        <location line="+62"/>
-        <location line="+47"/>
-        <location line="+44"/>
         <source>Port</source>
         <translation>Порт</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>Wait for button</source>
         <translation>Ждать нажатия кнопки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Ждать нажатия на кнопку на корпусе робота.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Button:</source>
         <translation>Кнопка:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Button</source>
         <translation>Кнопка</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Wait for Color</source>
         <translation>Ждать цвет</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the color sensor on the given port will recognize the given color.</source>
         <translation>Ждать, пока датчик цвета в режиме распознавания цветов не вернет указанный цвет.</translation>
     </message>
     <message>
-        <location line="-1394"/>
-        <location line="+44"/>
-        <location line="+44"/>
-        <location line="+107"/>
-        <location line="+685"/>
-        <location line="+53"/>
-        <location line="+53"/>
-        <location line="+71"/>
-        <location line="+159"/>
-        <location line="+44"/>
-        <location line="+44"/>
-        <location line="+97"/>
-        <location line="+54"/>
-        <location line="+79"/>
-        <location line="+63"/>
-        <location line="+63"/>
-        <location line="+142"/>
-        <location line="+65"/>
-        <location line="+63"/>
-        <location line="+45"/>
         <source>Port:</source>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location line="-768"/>
         <source>Sleep Line Leader</source>
         <translation>Датчик линии в спящий режим</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Puts the line leader to sleep conserve power</source>
         <translation>Отправляет датчик линии в режим энергосбережения</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Start Compass Calibration</source>
         <translation>Начать калибровку компаса</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Starts compass calibration under program control. To calibrate, robot needs to spin &gt;=540 clockwise and counterclockwise with minimum 20 seconds duration for each direction. Atfer robot rotation add Stop Compass Сalibration block.</source>
         <translation>Начинает калибровку компаса программно. Чтобы откалибровать компас, робот должен повернуться на месте больше чем на 540 градусов в одну, а затем в обратную сторону. После поворотов необходимо добавить блок &quot;Закончить калибровку компаса&quot;.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Stop Compass Calibration</source>
         <translation>Закончить калибровку компаса</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Ends compass calibration process. Stores result of calibration into the given variable. Not zero means success.</source>
         <translation>Заканчивает калибровку компаса Результат калибровки возвращается в переменной. Ненулевой результат означает успешную калибровку.</translation>
     </message>
     <message>
-        <location line="+149"/>
         <source>Wait for Color Intensity</source>
         <translation>Ждать интенсивность цвета</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the color sensor on the given port will be greater or less than the given in the &apos;Intensity&apos; parameter value (the intensity is specified in percents, 0 to 100).</source>
         <translation>Ждать, пока значение, возвращаемое датчиком цвета на указанном порту, не будет сравнимо с указанным в значении параметра &apos;Интенсивность&apos; (задается в процентах). Еще один парамер — номер порта, к которому подключен датчик цвета. Также параметром указывается операция, которая будет использоваться для сравнения с введенной интенсивностью.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Intensity:</source>
         <translation>Интенсивность:</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+79"/>
-        <location line="+63"/>
-        <location line="+63"/>
-        <location line="+143"/>
-        <location line="+64"/>
         <source>Sign:</source>
         <translation>Знак:</translation>
     </message>
     <message>
-        <location line="-371"/>
-        <location line="+197"/>
-        <location line="+136"/>
-        <location line="+65"/>
         <source>0</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-398"/>
         <source>Intensity</source>
         <translation>Интенсивность</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+62"/>
-        <location line="+64"/>
-        <location line="+71"/>
-        <location line="+136"/>
-        <location line="+62"/>
         <source>Sign</source>
         <translation>Знак</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Wait for Encoder</source>
         <translation>Ждать энкодер</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Ждать, пока показания счетчика количества оборотов на заданном моторе не достинут указанного в значении параметра &apos;Предел оборотов&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tacho Limit:</source>
         <translation>Предел оборотов:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Wait for Gyroscope</source>
         <translation>Ждать гироскоп</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given.</source>
         <translation>Ждать, пока значение, возвращаемое гироскопом на указанном порте, не будет сравнимо с указанным в значении параметра &apos;Значение&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Value:</source>
         <translation>Значение:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>90</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Light</source>
         <translation>Ждать свет</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Ждать, пока значение, возвращаемое датчиком света на указанном порту, не будет сравнимо с указанным в значении параметра &apos;Проценты&apos;. Еще один парамер — номер порта, к которому подключен датчик цвета. Также параметром указывается операция, которая будет использоваться для сравнения со значением параметра &apos;Проценты&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Percents:</source>
         <translation>Проценты:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Percents</source>
         <translation>Проценты</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Mail Receiving</source>
         <translation>Ждать приема сообщения</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Stores a message from another robot (fom mailbox) into a given variable. When no incoming messages are present at the moment, a robot will wait for incoming message if &apos;Synchronized&apos; property is true, and doing nothing otherwise.</source>
         <translation>Сохраняет сообщение от другого робота в заданную переменную. Если сообщения нет, то робот ждет приход сообщения, если установлен флаг. Иначе в переменную установится значение по умолчанию.</translation>
     </message>
     <message>
-        <location line="-783"/>
-        <location line="+124"/>
-        <location line="+247"/>
-        <location line="+435"/>
         <source>Variable:</source>
         <translation>Переменная:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Synchronized:</source>
         <translation>Дождаться сообщения:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Synchronized</source>
         <translation>Дождаться сообщения</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Range Sensor</source>
         <translation>Ждать датчик расстояния</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the ultrasonic or infrared range sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, 0 to 255).</source>
         <translation>Ждать, пока расстояние, возвращаемое ультразвуковым датчиком расстояния, не будет сравнимо с указанным в значении параметра &apos;Расстояние&apos; (расстояние задается в сантиметрах, от 0 до 255). Еще один парамер — номер порта, к которому подключен датчик расстояния. Также параметром указывается операция, которая будет использоваться для сравнения с введенным расстоянием.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Distance:</source>
         <translation>Расстояние:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cm</source>
         <translation>см</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Distance</source>
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Sound Sensor</source>
         <translation>Ждать датчик звука</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the loudness obtained by the sound sensor on the given port will be greater or less than the given value.</source>
         <translation>Ждать, пока громкость, считанная микрофоном на заданном порту, не будет выше или ниже заданного значения.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Wait for Touch Sensor</source>
         <translation>Ждать датчик касания</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Ждать, пока не сработает датчик касания. Параметром указывается номер порта, к которому подключен датчик. Допустимые значения: 1, 2, 3, 4.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="-60"/>
         <source>RobotsDiagram</source>
         <translation>Диаграмма поведения робота</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Действия</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Line Leader</source>
         <translation>Датчик линии</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Wait</source>
         <translation>Ожидание</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Drawing</source>
         <translation>Рисование</translation>
     </message>
@@ -1324,18 +950,14 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="-762"/>
         <source>Receiver name</source>
         <translation>Имя получателя</translation>
     </message>
     <message>
-        <location line="+416"/>
         <source>Tacho Limit</source>
         <translation>Предел оборотов</translation>
     </message>
     <message>
-        <location line="-240"/>
-        <location line="+445"/>
         <source>Variable</source>
         <translation>Переменная</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/editor/nxt_ru.ts
+++ b/qrtranslations/ru/plugins/robots/editor/nxt_ru.ts
@@ -4,59 +4,46 @@
 <context>
     <name>NxtMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="+138"/>
         <source>In</source>
         <translation>Входной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Входной-выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Возвращаемое значение</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+10"/>
         <source>false</source>
         <translation>ложь</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>body</source>
         <translation>тело цикла</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+10"/>
         <source>true</source>
         <translation>истина</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>4</source>
         <translation>4</translation>
     </message>
@@ -69,127 +56,102 @@
         <translation type="vanished">Истина</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>Enter</source>
         <translation>Enter</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Escape</source>
         <translation>Escape</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Left</source>
         <translation>Left</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Right</source>
         <translation>Right</translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>Concurrent</source>
         <translation>Параллельно</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Со стражником</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Последовательно</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>black</source>
         <translation>чёрный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>blue</source>
         <translation>синий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>green</source>
         <translation>зелёный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red</source>
         <translation>красный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>white</source>
         <translation>белый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yellow</source>
         <translation>жёлтый</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Composite</source>
         <translation>Композиция</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Агрегация</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>brake</source>
         <translation>торможение</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>greater</source>
         <translation>больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>меньше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>не больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>не меньше</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Package</source>
         <translation>Пакетная</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Приватная</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Защищённая</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Открытая</translation>
     </message>
@@ -198,27 +160,22 @@
         <translation type="vanished">тормозить</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>float</source>
         <translation>скольжение</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>norm</source>
         <translation>нормаль</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>ось x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>ось y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>ось z</translation>
     </message>
@@ -226,12 +183,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="+26"/>
         <source>Beep</source>
         <translation>Гудок</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.</source>
         <translation variants="yes">
             <lengthvariant>Проигрывает на роботе звук с заданной частотой. Принимает два параметра: первый – громкость звука, второй – ждать ли окончания проигрывания звука перед тем, как продолжить.</lengthvariant>
@@ -240,568 +195,390 @@
         </translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+578"/>
-        <location line="+485"/>
         <source>Volume:</source>
         <translation>Громкость:</translation>
     </message>
     <message>
-        <location line="-1055"/>
-        <location line="+588"/>
         <source>Wait for Completion:</source>
         <translation>Ожидать завершения:</translation>
     </message>
     <message>
-        <location line="-555"/>
-        <location line="+582"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location line="-582"/>
-        <location line="+582"/>
-        <location line="+475"/>
         <source>Volume</source>
         <translation>Громкость</translation>
     </message>
     <message>
-        <location line="-1056"/>
-        <location line="+582"/>
         <source>Wait for Completion</source>
         <translation>Ожидать завершения</translation>
     </message>
     <message>
-        <location line="-571"/>
         <source>Clear Encoder</source>
         <translation>Сбросить энкодеры</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Сбросить показания количества оборотов моторов по заданным портам.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+343"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>Ports:</source>
         <translation>Порты:</translation>
     </message>
     <message>
-        <location line="-430"/>
-        <location line="+462"/>
         <source>A, B, C</source>
         <translation>A, B, C</translation>
     </message>
     <message>
-        <location line="-462"/>
-        <location line="+297"/>
-        <location line="+56"/>
-        <location line="+56"/>
-        <location line="+53"/>
         <source>Ports</source>
         <translation>Порты</translation>
     </message>
     <message>
-        <location line="-451"/>
         <source>Draw Circle</source>
         <translation>Нарисовать круг</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws on the robot screen a circle with the given center and radius.</source>
         <translation>Нарисовать на экране круг с заданным центром и заданным радиусом.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+135"/>
-        <location line="+54"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location line="-181"/>
-        <location line="+135"/>
-        <location line="+54"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location line="-181"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Radius</source>
         <translation>Радиус</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+70"/>
-        <location line="+56"/>
-        <location line="+71"/>
         <source>Redraw</source>
         <translation>Обновить картинку</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+126"/>
-        <location line="+72"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+126"/>
-        <location line="+72"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="-187"/>
         <source>Draw Line</source>
         <translation>Нарисовать линию</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Нарисовать на экране отрезок. В качестве параметров блоку указываются концы отрезка.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>X1:</source>
         <translation>X1:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y1:</source>
         <translation>Y1:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>X2:</source>
         <translation>X2:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y2:</source>
         <translation>Y2:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Draw Pixel</source>
         <translation>Нарисовать точку</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Нарисовать на экране точку в указанных координатах.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Draw Rectangle</source>
         <translation>Нарисовать прямоугольник</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Нарисовать на экране прямоугольник. В качестве параметров указываются координаты левого верхнего угла, ширина и высота прямоугольника.</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Height</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>NxtEngineMovementCommand</source>
         <translation>Базовый блок моторов NXT</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location line="-111"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>B, C</source>
         <translation>B, C</translation>
     </message>
     <message>
-        <location line="-111"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location line="-112"/>
-        <location line="+56"/>
-        <location line="+56"/>
         <source>Power (%)</source>
         <translation>Мощность (%)</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Motors Backward</source>
         <translation>Моторы назад</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Включить моторы в режиме реверса по заданным портам с заданной мощностью. Порты задаются буквами A, B или C, разделенными запятыми. Мощность задается в процентах числом от -100 до 100, если задано отрицательное значение, мотор включается в обычном режиме.</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+56"/>
         <source>Power:</source>
         <translation>Мощность:</translation>
     </message>
     <message>
-        <location line="-55"/>
-        <location line="+56"/>
-        <location line="+109"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location line="-127"/>
         <source>Motors Forward</source>
         <translation>Моторы вперёд</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Включить моторы по заданным портам с заданной мощностью. Порты задаются буквами A, B или C, разделенными запятыми. Мощность задается в процентах числом от -100 до 100, если задано отрицательное значение, мотор включается в режиме реверса.</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Stop Motors</source>
         <translation>Моторы стоп</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Disables motors on the given ports.</source>
         <translation>Выключить моторы по заданным портам.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Play Tone</source>
         <translation>Играть звук</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Plays on the robot a sound with the given frequency and duration. This block is similar to the &apos;Beep&apos; block wuth the only difference that here you can specify sound parameters.</source>
         <translation>Проиграть на роботе звук с заданной частотой и длительностью. Аналогичен блоку &apos;Гудок&apos;, но позволяет задавать параметры звука. Имеется параметр, определяющий, ждать ли завершения проигрывания звука или сразу же перейти к следующему блоку.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Frequency:</source>
         <translation>Частота:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hz</source>
         <translation>Гц</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+34"/>
         <source>Duration</source>
         <translation>Длительность</translation>
     </message>
     <message>
-        <location line="-33"/>
         <source>ms</source>
         <translation>мс</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+1"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Frequency</source>
         <translation>Частота</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>NxtSensorBlock</source>
         <translation>Базовый сенсорный блок NXT</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+98"/>
-        <location line="+78"/>
-        <location line="+62"/>
-        <location line="+72"/>
-        <location line="+65"/>
-        <location line="+62"/>
-        <location line="+47"/>
         <source>Port</source>
         <translation>Порт</translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Wait for Button</source>
         <translation>Ждать нажатия кнопки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Ждать нажатия на кнопку на корпусе робота.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Button:</source>
         <translation>Кнопка:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Button</source>
         <translation>Кнопка</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Wait for Color</source>
         <translation>Ждать цвет</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the color sensor on the given port will recognize the given color.</source>
         <translation>Ждать, пока датчик цвета в режиме распознавания цветов не вернет указанный цвет.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+54"/>
-        <location line="+79"/>
-        <location line="+63"/>
-        <location line="+71"/>
-        <location line="+65"/>
-        <location line="+63"/>
         <source>Port:</source>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Color Intensity</source>
         <translation>Ждать интенсивность цвета</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the color sensor on the given port will be greater or less than the given in the &apos;Intensity&apos; parameter value (the intensity is specified in percents, 0 to 100).</source>
         <translation>Ждать, пока значение, возвращаемое датчиком цвета на указанном порту, не будет сравнимо с указанным в значении параметра &apos;Интенсивность&apos; (задается в процентах). Еще один парамер — номер порта, к которому подключен датчик цвета. Также параметром указывается операция, которая будет использоваться для сравнения с введенной интенсивностью.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Intensity:</source>
         <translation>Интенсивность:</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+79"/>
-        <location line="+63"/>
-        <location line="+72"/>
-        <location line="+64"/>
         <source>Sign:</source>
         <translation>Считанное значение:</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+134"/>
-        <location line="+65"/>
-        <location line="+65"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location line="-264"/>
         <source>Intensity</source>
         <translation>Интенсивность</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+62"/>
-        <location line="+72"/>
-        <location line="+65"/>
-        <location line="+62"/>
         <source>Sign</source>
         <translation>Считанное значение</translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Wait for Encoder</source>
         <translation>Ждать энкодер</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Ждать, пока показания счетчика количества оборотов на заданном моторе не достинут указанного в значении параметра &apos;Предел оборотов&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tacho Limit:</source>
         <translation>Предел оборотов:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Light</source>
         <translation>Ждать свет</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Ждать, пока значение, возвращаемое датчиком света на указанном порту, не будет сравнимо с указанным в значении параметра &apos;Проценты&apos;. Еще один парамер — номер порта, к которому подключен датчик цвета. Также параметром указывается операция, которая будет использоваться для сравнения со значением параметра &apos;Проценты&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Percents:</source>
         <translation>Проценты:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Percents</source>
         <translation>Проценты</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Sonar Distance</source>
         <translation>Ждать сонар</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the ultrasonic sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, 0 to 255).</source>
         <translation>Ждать, пока расстояние, возвращаемое ультразвуковым датчиком расстояния, не будет сравнимо с указанным в значении параметра &apos;Расстояние&apos; (расстояние задается в сантиметрах, от 0 до 255). Еще один парамер — номер порта, к которому подключен датчик расстояния. Также параметром указывается операция, которая будет использоваться для сравнения с введенным расстоянием.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Distance:</source>
         <translation>Расстояние:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cm</source>
         <translation>см</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Distance</source>
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Sound Sensor</source>
         <translation>Ждать датчик звука</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the loudness obtained by the sound sensor on the given port will be greater or less than the given value.</source>
         <translation>Ждать, пока громкость, считанная микрофоном на заданном порту, не будет выше или ниже заданного значения.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Wait for Touch Sensor</source>
         <translation>Ждать датчик касания</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Ждать, пока не сработает датчик касания. Параметром указывается номер порта, к которому подключен датчик. Допустимые значения: 1, 2, 3, 4.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="-41"/>
         <source>RobotsDiagram</source>
         <translation>Диаграмма поведения робота</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Действия</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Wait</source>
         <translation>Ожидание</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Drawing</source>
         <translation>Рисование</translation>
     </message>
@@ -809,7 +586,6 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="-212"/>
         <source>Tacho Limit</source>
         <translation>Предел оборотов</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/editor/pioneer_ru.ts
+++ b/qrtranslations/ru/plugins/robots/editor/pioneer_ru.ts
@@ -4,204 +4,162 @@
 <context>
     <name>PioneerMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="+132"/>
         <source>Concurrent</source>
         <translation>Параллельно</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Со стражником</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Последовательно</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>black</source>
         <translation>чёрный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>blue</source>
         <translation>синий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>green</source>
         <translation>зелёный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>red</source>
         <translation>красный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>white</source>
         <translation>белый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yellow</source>
         <translation>жёлтый</translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>norm</source>
         <translation>нормальное</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>по оси x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>по оси y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>по оси z</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>brake</source>
         <translation>торможение</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Altfu</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Input</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Output</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>A</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>D</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Package</source>
         <translation>Пакетный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Приватный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Защищённый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Публичный</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>greater</source>
         <translation>больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>меньше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>не больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>не меньше</translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>Composite</source>
         <translation>Композиция</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Агрегация</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>In</source>
         <translation>Входной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Входной-выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Возврат</translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+6"/>
         <source>false</source>
         <translation>ложь</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>body</source>
         <translation>тело цикла</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+6"/>
         <source>true</source>
         <translation>истина</translation>
     </message>
@@ -210,7 +168,6 @@
         <translation type="vanished">break</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>float</source>
         <translation>float</translation>
     </message>
@@ -218,616 +175,446 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="+26"/>
         <source>Landing</source>
         <translation>Посадка</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Orders quadcopter to land.</source>
         <translation>Указывает квадрокоптеру приземлиться.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Takeoff</source>
         <translation>Взлёт</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Orders quadcopter to takeoff.</source>
         <translation>Указывает квадрокоптеру взлететь.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Go to point</source>
         <translation>Лететь в точку</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Orders quadcopter to fly to given coordinates.</source>
         <translation>Указывает квадрокоптеру лететь в указанные координаты.</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Latitude:</source>
         <translation>Широта:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Longitude:</source>
         <translation>Долгота:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Altitude:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="+96"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+496"/>
         <source>0</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-570"/>
         <source>Altitude</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Latitude</source>
         <translation>Широта</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Longitude</source>
         <translation>Долгота</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Create GPIO in settings port.</source>
         <translation>Cоздает GPIO на порте с заданными настройками.</translation>
     </message>
     <message>
-        <location line="+664"/>
         <source>dist</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Set GPIO state</source>
         <translation>Установить значение GPIO</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set GPIO value in &quot;true/false&quot;.</source>
         <translation>Устанавливает GPIO в состояние &quot;истина/ложь&quot;.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>System</source>
         <translation>Команда</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Executes given Lua script.</source>
         <translation>Исполняет заданную строку на языке Lua на квадрокоптере.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>print(&apos;Hello&apos;)</source>
         <translation>print(&apos;Hello&apos;)</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Command</source>
         <translation>Команда</translation>
     </message>
     <message>
-        <location line="-189"/>
-        <location line="+190"/>
         <source>Evaluate</source>
         <translation>Вычислять</translation>
     </message>
     <message>
-        <location line="-888"/>
         <source>Orders quadcopter to fly to given GPS coordinates.</source>
         <translation>Указывает квадрокоптеру лететь в указанные координаты.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>50</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>600859810</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>304206500</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Go to local point</source>
         <translation>Лететь в точку (ЛК)</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+143"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>X:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-321"/>
-        <location line="+143"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>Y:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-321"/>
-        <location line="+143"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>Z:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Time:</source>
         <translation>Время:</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+133"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+133"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>Y</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+133"/>
-        <location line="+62"/>
-        <location line="+62"/>
-        <location line="+62"/>
         <source>Z</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-308"/>
         <source>GPIO Initialization</source>
         <translation>Инициализация GPIO</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+578"/>
-        <location line="+99"/>
         <source>Pin name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location line="-669"/>
         <source>Port:</source>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Pin:</source>
         <translation>Пин:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pin</source>
         <translation>Номер пина</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+560"/>
-        <location line="+91"/>
         <source>pin_name</source>
         <translation>pin_name</translation>
     </message>
     <message>
-        <location line="-651"/>
-        <location line="+560"/>
-        <location line="+91"/>
         <source>Pin name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="-650"/>
         <source>Port</source>
         <translation>Порт</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get Accelerometer</source>
         <translation>Прочитать акселерометр</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns accelerometer.</source>
         <translation>Возвращает данные с акселерометра квадрокоптера по трём осям.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>aX</source>
         <translation>aX</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>aY</source>
         <translation>aY</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>aZ</source>
         <translation>aZ</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get Gyroscope</source>
         <translation>Прочитать гироскоп</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns gyroscope.</source>
         <translation>Возвращает данные с гироскопа квадрокоптера по трём осям.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>gX</source>
         <translation>gX</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>gY</source>
         <translation>gY</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>gZ</source>
         <translation>gZ</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get LPS Position</source>
         <translation>Получить точку (ЛК)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns position (local positioning system).</source>
         <translation>Возвращает текущую позицию в локальной системе координат.</translation>
     </message>
     <message>
-        <location line="+47"/>
-        <location line="+376"/>
         <source>x</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-375"/>
         <source>y</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>z</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get LPS Velocity</source>
         <translation>Прочитать вектор скорости (ЛК)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns velocity (local position system).</source>
         <translation>Возвращает текущие значения скоростей в локальной системе координат.</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>velX</source>
         <translation>velX</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>velY</source>
         <translation>velY</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>velZ</source>
         <translation>velZ</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get LPS Yaw</source>
         <translation>Прочитать угол рысканья (ЛК)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns yaw (local position system).</source>
         <translation>Возвращает текущий угол рысканья в локальной системе координат.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Yaw:</source>
         <translation>Yaw:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>yaw</source>
         <translation>yaw</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Get Orientation</source>
         <translation>Прочитать данные положения</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns orientation.</source>
         <translation>Возвращает данные положения квадрокоптера в пространстве - крен, тангаж, рыскание.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Roll:</source>
         <translation>Крен:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Pitch:</source>
         <translation>Тангаж:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Azimuth:</source>
         <translation>Рысканье:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>azimuth</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Azimuth</source>
         <translation>Рысканье</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pitch</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Pitch</source>
         <translation>Тангаж</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>roll</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Roll</source>
         <translation>Крен</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Sets the color of the specified LED on a quadcopter.</source>
         <translation>Задаёт цвет светодиода на квадрокоптере.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Number:</source>
         <translation>Номер:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Red:</source>
         <translation>Красный:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Green:</source>
         <translation>Зелёный:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Blue:</source>
         <translation>Синий:</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1"/>
-        <location line="+2"/>
-        <location line="+314"/>
         <source>0.0</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-317"/>
         <source>Blue</source>
         <translation>Синий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green</source>
         <translation>Зелёный</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Number</source>
         <translation>Номер</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Red</source>
         <translation>Красный</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Magnet</source>
         <translation>Магнит</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Controls magnet on a quadcopter.</source>
         <translation>Управляет магнитом на квадрокоптере.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+189"/>
         <source>State on</source>
         <translation>Включён</translation>
     </message>
     <message>
-        <location line="-178"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Prints given string on a console.</source>
         <translation>Печатает переданную строку в консоли.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Text:</source>
         <translation>Текст:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Enter some text here</source>
         <translation>Введите текст</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Read GPIO</source>
         <translation>Прочитать значение GPIO</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Returns GPIO value.</source>
         <translation>Возвращает значение состояния GPIO.</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Read Range Sensor</source>
         <translation>Прочитать дальномер</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reads distance from rangefinder.</source>
         <translation>Считывает информацию с дальномера.</translation>
     </message>
     <message>
-        <location line="-38"/>
-        <location line="+45"/>
         <source>Variable:</source>
         <translation>Переменная:</translation>
     </message>
     <message>
-        <location line="-20"/>
-        <location line="+46"/>
         <source>Variable</source>
         <translation>Переменная</translation>
     </message>
     <message>
-        <location line="-314"/>
-        <location line="+415"/>
         <source>Yaw</source>
         <translation>Рыскание</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets yaw for quadcopter</source>
         <translation>Устанавливает рыскание коптера. Принимаемый параметр &quot;угол&quot; задаётся в градусах</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Angle (degrees)</source>
         <translation>Угол (градусы)</translation>
     </message>
     <message>
-        <location line="-375"/>
         <source>Led</source>
         <translation>Светодиод</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="-42"/>
         <source>RobotsDiagram</source>
         <translation>Диаграмма</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Действия</translation>
     </message>
@@ -835,7 +622,6 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="-439"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/editor/trik_ru.ts
+++ b/qrtranslations/ru/plugins/robots/editor/trik_ru.ts
@@ -4,1005 +4,686 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="+26"/>
         <source>TrikAnalogSensorBlock</source>
         <translation>Аналоговый Сенсор</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+226"/>
-        <location line="+512"/>
-        <location line="+944"/>
-        <location line="+413"/>
-        <location line="+119"/>
-        <location line="+71"/>
-        <location line="+158"/>
-        <location line="+46"/>
         <source>Port</source>
         <translation>Порт</translation>
     </message>
     <message>
-        <location line="-2478"/>
-        <location line="+1522"/>
         <source>Angular Servo</source>
         <translation>Угловой сервомотор</translation>
     </message>
     <message>
-        <location line="-1520"/>
-        <location line="+1522"/>
         <source>Manages angular servomotor. Sets up rotation angle on the given port in degrees. Values from 0 to 90 are correspond to a clockwise rotation and values from -90 to 0 correspond to counterclockwise rotation.</source>
         <translation>Управление угловым сервомотором. Устанавливает угол поворота вала мотора на данном порту (в градусах). Значения от 0 до 90 соотвествуют повороту по часовой, значения от -90 до 0 --- повороту против часовой.</translation>
     </message>
     <message>
-        <location line="-1515"/>
-        <location line="+1522"/>
-        <location line="+54"/>
-        <location line="+108"/>
-        <location line="+81"/>
-        <location line="+55"/>
-        <location line="+55"/>
         <source>Ports:</source>
         <translation>Порты:</translation>
     </message>
     <message>
-        <location line="-1867"/>
-        <location line="+1522"/>
-        <location line="+1101"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="-2622"/>
-        <location line="+1522"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location line="-1498"/>
         <source>E1</source>
         <translation>E1</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+1522"/>
-        <location line="+46"/>
-        <location line="+108"/>
-        <location line="+35"/>
-        <location line="+55"/>
-        <location line="+55"/>
-        <location line="+54"/>
         <source>Ports</source>
         <translation>Порты</translation>
     </message>
     <message>
-        <location line="-1874"/>
-        <location line="+261"/>
-        <location line="+1"/>
-        <location line="+72"/>
-        <location line="+1"/>
-        <location line="+69"/>
-        <location line="+2"/>
-        <location line="+127"/>
-        <location line="+1"/>
-        <location line="+988"/>
-        <location line="+412"/>
-        <location line="+162"/>
-        <location line="+63"/>
-        <location line="+71"/>
-        <location line="+158"/>
-        <location line="+241"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location line="-2629"/>
-        <location line="+1522"/>
         <source>Angle (degrees)</source>
         <translation>Угол (градусы)</translation>
     </message>
     <message>
-        <location line="-1476"/>
-        <location line="+11"/>
         <source>Detect by Videocamera</source>
         <translation>Детектировать по камере</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Initializes videocamera line or object detector with the color of the object in the middle of the camera`s sight.</source>
         <translation>Инициализировать датчик линии или объектов по видеокамере цветом объекта в центре поля зрения камеры.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+499"/>
-        <location line="+795"/>
         <source>Mode:</source>
         <translation>Режим:</translation>
     </message>
     <message>
-        <location line="-1263"/>
-        <location line="+500"/>
-        <location line="+794"/>
-        <location line="+493"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location line="-1776"/>
-        <location line="+3"/>
         <source>Line Detector into Variable</source>
         <translation>Датчик линии в переменную</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Stores videocamera line detector`s value into a given variable.</source>
         <translation>Сохранить текущее значение датчика линии по видеокамере в заданную переменную.</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+809"/>
-        <location line="+1330"/>
         <source>Variable:</source>
         <translation>Переменная:</translation>
     </message>
     <message>
-        <location line="-2115"/>
         <source>err</source>
         <translation>err</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+809"/>
         <source>Variable</source>
         <translation>Переменная</translation>
     </message>
     <message>
-        <location line="-798"/>
         <source>TrikDigitalSensorBlock</source>
         <translation>Базовый блок цифровых сенсоров TRIK</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Draw Arc</source>
         <translation>Нарисовать дугу</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws the arc defined by the rectangle beginning at (x, y) with the specified width and height, and the given startAngle and spanAngle.</source>
         <translation>Рисует на экране дугу, ограниченную прямоугольником с началом в (x, y) и заданными шириной и высотой, также задаётся начальный и конечный угол дуги.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+90"/>
-        <location line="+145"/>
-        <location line="+54"/>
-        <location line="+368"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location line="-649"/>
-        <location line="+90"/>
-        <location line="+145"/>
-        <location line="+54"/>
-        <location line="+368"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location line="-649"/>
-        <location line="+90"/>
-        <location line="+199"/>
-        <location line="+771"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="-1052"/>
-        <location line="+90"/>
-        <location line="+199"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="-281"/>
         <source>Start Angle:</source>
         <translation>Начальный угол:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Span Angle:</source>
         <translation>Размах:</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+4"/>
-        <location line="+71"/>
-        <location line="+2"/>
-        <location line="+127"/>
-        <location line="+1"/>
-        <location line="+69"/>
-        <location line="+2"/>
         <source>5</source>
         <translation>5</translation>
     </message>
     <message>
-        <location line="-276"/>
-        <location line="+75"/>
-        <location line="+199"/>
         <source>Height</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location line="-273"/>
-        <location line="+75"/>
-        <location line="+71"/>
-        <location line="+56"/>
-        <location line="+72"/>
-        <location line="+369"/>
-        <location line="+304"/>
         <source>Redraw</source>
         <translation>Обновить картинку</translation>
     </message>
     <message>
-        <location line="-946"/>
         <source>SpanAngle</source>
         <translation>Размах</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>StartAngle</source>
         <translation>Начальный угол</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+73"/>
-        <location line="+199"/>
-        <location line="+760"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="-1031"/>
-        <location line="+73"/>
-        <location line="+126"/>
-        <location line="+73"/>
-        <location line="+368"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="-639"/>
-        <location line="+73"/>
-        <location line="+126"/>
-        <location line="+73"/>
-        <location line="+368"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="-629"/>
         <source>Draw Ellipse</source>
         <translation>Нарисовать эллипс</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws the ellipse defined by the rectangle beginning at (x, y) with the given width and height.</source>
         <translation>Рисует на экране эллипс, ограниченный прямоугольником с началом в (x, y) и заданными шириной и высотой.</translation>
     </message>
     <message>
-        <location line="+55"/>
-        <location line="+199"/>
         <source>Filled</source>
         <translation>Заполнен</translation>
     </message>
     <message>
-        <location line="-183"/>
         <source>Draw Line</source>
         <translation>Нарисовать линию</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Нарисовать на экране отрезок. В качестве параметров блоку указываются концы отрезка.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>X1:</source>
         <translation>X1:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y1:</source>
         <translation>Y1:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>X2:</source>
         <translation>X2:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y2:</source>
         <translation>Y2:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+2"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Draw Pixel</source>
         <translation>Нарисовать точку</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Нарисовать на экране точку в указанных координатах.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Draw Rectangle</source>
         <translation>Нарисовать прямоугольник</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Нарисовать на экране прямоугольник. В качестве параметров указываются координаты левого верхнего угла, ширина и высота прямоугольника.</translation>
     </message>
     <message>
-        <location line="+71"/>
-        <location line="+11"/>
         <source>Initialize Videocamera</source>
         <translation>Включить видеокамеру</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Enables line or object or color detector by videocamera and draws videostream on the robot`s screen.</source>
         <translation>Включить датчик линии или объекта или цвета по видеокамере, вывести на экран картинку.</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
         <source>Enable Video Streaming</source>
         <translation>Запустить видеотрансляцию</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Enables video stream on robot. Video then can be watched on TRIK gamepad or in browser using URL http://ROBOT.IP.ADDRESS:8080/?action=stream</source>
         <translation>Включает видеотрансляцию на роботе. Видео может быть просмотрено, например, на пульте управления ТРИК или в браузере по адресу http://IP.АДРЕС.РОБОТА:8080/?action=stream</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Grayscaled</source>
         <translation>Чёрно-белое изображение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quality</source>
         <translation>Качество</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Join Network</source>
         <translation>Присоединиться к сети</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Address:</source>
         <translation>Адрес:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>192.168.77.1</source>
         <translation>192.168.77.1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hull Number</source>
         <translation>Бортномер</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Led</source>
         <translation>Светодиод</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the color of the LED on the robot`s front panel.</source>
         <translation>Установить цвет светодиода на передней панели робота.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+475"/>
-        <location line="+45"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-495"/>
-        <location line="+474"/>
-        <location line="+45"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location line="-463"/>
         <source>Play Tone</source>
         <translation>Играть звук</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Plays on the robot a sound file (.wav or .mp3) previously uploaded to it.</source>
         <translation>Проигрывает на роботе указанный звуковой файл (в формате .wav или .mp3), который должен быть на него предварительно загружен.</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>Play Sound</source>
         <translation>Играть звуковой файл</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File name:</source>
         <translation>Имя файла:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>media/beep.wav</source>
         <translation>media/beep.wav</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>File Name</source>
         <translation>Имя файла</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Plays on the robot a sound with the given frequency and duration.</source>
         <translation>Проигрывает на роботе звук с заданной частотой и длительностью.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Frequency:</source>
         <translation>Частота:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hz</source>
         <translation>Гц</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Duration</source>
         <translation>Длительность</translation>
     </message>
     <message>
-        <location line="-24"/>
         <source>ms</source>
         <translation>мс</translation>
     </message>
     <message>
-        <location line="-793"/>
         <source>Calibrate gyroscope</source>
         <translation>Калибровка  гироскопа</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets gyroscope&apos;s angle to zero in current position.</source>
         <translation>Устанавливает гироскоп в 0 в текущей позиции.</translation>
     </message>
     <message>
-        <location line="+572"/>
         <source>Draw stream</source>
         <translation>Вывести на экран</translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Duration:</source>
         <translation>Длительность:</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Frequency</source>
         <translation>Частота</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Remove File</source>
         <translation>Удалить файл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Removes a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
         <translation>Удаляет файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1735"/>
         <source>File:</source>
         <translation>Файл:</translation>
     </message>
     <message>
-        <location line="-1711"/>
-        <location line="+1743"/>
         <source>output.txt</source>
         <translation>output.txt</translation>
     </message>
     <message>
-        <location line="-1743"/>
-        <location line="+1743"/>
         <source>File</source>
         <translation>Файл</translation>
     </message>
     <message>
-        <location line="-1732"/>
         <source>Sad Smile</source>
         <translation>Грустный смайлик</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a sad smile on the robot`s screen :(</source>
         <translation>Рисует на экране грустный смайлик :(</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Say</source>
         <translation>Сказать</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Synthesizes the given phrase and plays it on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Text&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
         <translation>Воспроизводит заданную фразу на роботе. Если свойство &amp;quot;Вычислять&amp;quot; имеет значение &amp;quot;Истина&amp;quot;, значение свойства &amp;quot;Текст&amp;quot; будет вычислено как формула, иначе оно воспроизводится как есть.</translation>
     </message>
     <message>
-        <location line="-175"/>
-        <location line="+182"/>
-        <location line="+1662"/>
         <source>Text:</source>
         <translation>Текст:</translation>
     </message>
     <message>
-        <location line="-1812"/>
-        <location line="+174"/>
-        <location line="+397"/>
         <source>Evaluate</source>
         <translation>Вычислять</translation>
     </message>
     <message>
-        <location line="-396"/>
         <source>Hi!</source>
         <translation>Привет!</translation>
     </message>
     <message>
-        <location line="-173"/>
-        <location line="+173"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Send message</source>
         <translation>Послать сообщение</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sends message to another robot.</source>
         <translation>Посылает сообщение на другого робота.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message:</source>
         <translation>Сообщение:</translation>
     </message>
     <message>
-        <location line="-434"/>
-        <location line="+442"/>
         <source>Hull number:</source>
         <translation>Бортномер:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>TrikSensorBlock</source>
         <translation>Базовый блок сенсоров TRIK</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Background Color</source>
         <translation>Цвет фона</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the background color of the current picture on the robot`s screen.</source>
         <translation>Устанавливает цвет фона активной картинки на экране робота.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Painter Color</source>
         <translation>Цвет кисти</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the painter color.</source>
         <translation>Устанавливает цвет кисти.</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Painter Width</source>
         <translation>Толщина кисти</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the painter width.</source>
         <translation>Устанавливает толщину кисти.</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+1"/>
-        <location line="+390"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location line="-649"/>
         <source>Sets the hull number and connects with a peer by a (host)name or an IP-address. Target IP-port can be changed too if required.</source>
         <translation>Устанавливает бортовой номер и подключается по имени (хоста) или IP-адресу к другому роботу. При необходимости целевой IP-порт также может быть изменен.</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Print Text</source>
         <translation>Напечатать текст</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Prints a given line in the specified coordinates and font size on the robot`s screen. The value of &apos;Text&apos; property is interpreted as a plain text unless &apos;Evaluate&apos; property is set to true, then it will be interpreted as an expression (that may be useful for example when debugging variables values).</source>
         <translation>Печатает заданную строку в заданном месте и с заданным размером шрифта на экране робота. Значение свойства &quot;Текст&quot; по умолчанию трактуется как строка в чистом виде, оно так и будет выведено на экран. Чтобы система считала, что это выражение на текстовом языке (это может быть полезно, например, при отладке значения переменных), поставьте галочку &quot;Вычислять&quot; в редакторе свойств.</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Font size:</source>
         <translation>Размер шрифта:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>20</source>
         <translation>20</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Font size</source>
         <translation>Размер шрифта</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter some text here</source>
         <translation>Введите текст</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Read Lidar To Variable</source>
         <translation>Считать данные лидара в переменную</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Assigns a value from lidar to a given variable.</source>
         <translation>Присваивает значение из лидара указанной переменной.</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location line="+357"/>
         <source>Smile</source>
         <translation>Смайлик</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draws a smile on the robot`s screen :)</source>
         <translation>Рисует на экране смайлик :)</translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location line="+11"/>
         <source>Stop Videocamera</source>
         <translation>Выключить видеокамеру</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Stops line or object or color detector by videocamera.</source>
         <translation>Останавливает датчик линии или объектов по видеокамере цветом объекта в центре поля зрения камеры.</translation>
     </message>
     <message>
-        <location line="+49"/>
-        <location line="+3"/>
         <source>Disable Video Streaming</source>
         <translation>Отключить видеотрансляцию</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Disables video stream on robot.</source>
         <translation>Останавливает видеотрансляцию с камеры робота.</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>System Call</source>
         <translation>Системный вызов</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Invokes bash script-style command on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Command&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
         <translation>Выполняет заданную bash-команду на роботе. Если свойство &amp;quot;Вычислять&amp;quot; имеет значение &amp;quot;Истина&amp;quot;, значение свойства &amp;quot;Команда&amp;quot; будет вычислено как формула, иначе оно будет исполнено как есть.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Command:</source>
         <translation>Команда:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Code</source>
         <translation>Код</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>echo 123</source>
         <translation>echo 123</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Command</source>
         <translation>Команда</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>S1</source>
         <translation>S1</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+108"/>
         <source>Clear Encoder</source>
         <translation>Сбросить показания энкодера</translation>
     </message>
     <message>
-        <location line="-106"/>
-        <location line="+108"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Сбросить показания количества оборотов моторов по заданным портам.</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>E1, E2, E3, E4</source>
         <translation>E1, E2, E3, E4</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location line="+413"/>
         <source>Wait for Encoder</source>
         <translation>Ждать энкодер</translation>
     </message>
     <message>
-        <location line="-411"/>
-        <location line="+413"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Ждать, пока показания счетчика количества оборотов на заданном моторе не достинут указанного в значении параметра &apos;Предел оборотов&apos;.</translation>
     </message>
     <message>
-        <location line="-406"/>
-        <location line="+413"/>
-        <location line="+117"/>
-        <location line="+64"/>
-        <location line="+124"/>
-        <location line="+43"/>
-        <location line="+62"/>
         <source>Port:</source>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location line="-815"/>
-        <location line="+413"/>
         <source>Tacho Limit:</source>
         <translation>Предел оборотов:</translation>
     </message>
     <message>
-        <location line="-405"/>
-        <location line="+299"/>
-        <location line="+114"/>
-        <location line="+55"/>
-        <location line="+62"/>
-        <location line="+64"/>
-        <location line="+167"/>
-        <location line="+241"/>
         <source>Sign:</source>
         <translation>Считанное значение:</translation>
     </message>
     <message>
-        <location line="-976"/>
-        <location line="+307"/>
-        <location line="+106"/>
-        <location line="+55"/>
-        <location line="+64"/>
-        <location line="+71"/>
-        <location line="+158"/>
-        <location line="+240"/>
         <source>Sign</source>
         <translation>Считанное значение</translation>
     </message>
     <message>
-        <location line="-955"/>
         <source>B1, B2, B3, B4</source>
         <translation>B1, B2, B3, B4</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>TrikV6EngineMovementCommand</source>
         <translation>Базовый блок моторов TRIK v6</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+55"/>
-        <location line="+55"/>
         <source>M3, M4</source>
         <translation>M3, M4</translation>
     </message>
     <message>
-        <location line="-109"/>
-        <location line="+55"/>
-        <location line="+55"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location line="-110"/>
-        <location line="+55"/>
-        <location line="+55"/>
         <source>Power (%)</source>
         <translation>Скорость (%)</translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Motors Backward</source>
         <translation>Моторы назад</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified in accordance with TRIK controller notations (for example M1, E2) and divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Включить моторы в режиме реверса по заданным портам с заданной мощностью. Порты задаются так, как они обозначены на плате (например, M1, S2) и разделяются запятыми. Мощность задается в процентах числом от -100 до 100, если задано отрицательное значение, мотор включается в обычном режиме.</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+55"/>
         <source>Power:</source>
         <translation>Скорость:</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Motors Forward</source>
         <translation>Моторы вперёд</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enables motors on the given ports with the given power. Ports are specified in accordance with TRIK controller notations (for example M1, E2) and divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Включить моторы по заданным портам с заданной мощностью. Порты задаются так, как они обозначены на плате (например, M1, S2) и разделяются запятыми. Мощность задается в процентах числом от -100 до 100, если задано отрицательное значение, мотор включается в режиме реверса.</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Stop Motors</source>
         <translation>Моторы стоп</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Disables motors on the given ports.</source>
         <translation>Выключить моторы по заданным портам.</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>M1, M2, M3, M4</source>
         <translation>M1, M2, M3, M4</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Wait for Accelerometer</source>
         <translation>Ждать акселерометр</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Acceleration:</source>
         <translation>Ускорение:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Axis:</source>
         <translation>Ось:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Acceleration</source>
         <translation>Ускорение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Acceleration Axis</source>
         <translation>Ось</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Button</source>
         <translation>Ждать нажатия кнопки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Ждать нажатия на кнопку на корпусе робота.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+506"/>
         <source>Button:</source>
         <translation>Кнопка:</translation>
     </message>
     <message>
-        <location line="-482"/>
-        <location line="+506"/>
         <source>Button</source>
         <translation>Кнопка</translation>
     </message>
     <message>
-        <location line="-432"/>
         <source>Wait for Gyroscope</source>
         <translation>Ждать гиродатчик</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;Degrees&apos; parameter value.</source>
         <translation>Ждать, пока значение, возвращаемое гиродатчиком на указанном порту, не будет сравнимо с указанным в значении параметра &apos;Градусы&apos;.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Degrees:</source>
         <translation>Градусы:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Degrees</source>
         <translation>Градусы</translation>
     </message>
@@ -1031,256 +712,162 @@
         <translation type="vanished">Градусы/сек</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Infrared Distance</source>
         <translation>Ждать ИК датчик расстояния</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the infrared sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value. By default on ports A1 and A2 the distance is specified in centimeters (from 0 to 100). It is not recommended to plug IR sensor into other ports because its raw value will be processed by software on robot with expectation of another sensor type.</source>
         <translation>Ждать, пока расстояние, возвращаемое инфракрасным датчиком расстояния, не будет сравнимо с указанным в значении параметра &apos;Расстояние&apos;. Еще один парамер — номер порта, к которому подключен датчик. Также параметром указывается операция, которая будет использоваться для сравнения с введенным расстоянием. По умолчанию на портах A1 и A2 расстояние указывается в сантиметрах (от 0 до 100), к остальным подключение не рекомендуется, так как чистое значение с датчика будет обработано с ожиданием другого подключенного датчика.</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+231"/>
         <source>Distance:</source>
         <translation>Расстояние:</translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+229"/>
         <source>Distance</source>
         <translation>Расстояние</translation>
     </message>
     <message>
-        <location line="-216"/>
         <source>Wait for Light</source>
         <translation>Ждать свет</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Ждать, пока значение, возвращаемое датчиком света на указанном порту, не будет сравнимо с указанным в значении параметра &apos;Проценты&apos;. Еще один парамер — номер порта, к которому подключен датчик цвета. Также параметром указывается операция, которая будет использоваться для сравнения со значением параметра &apos;Проценты&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Percents:</source>
         <translation>Проценты:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Percents</source>
         <translation>Проценты</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Wait for Message</source>
         <translation>Получить сообщение</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Stores a message from another robot into a given variable. When no incoming messages are present at the moment, a robot will wait for incoming message if &apos;Synchronized&apos; property is true, and empty string will be assigned to a variable otherwise.</source>
         <translation>Сохраняет сообщение от другого робота в переменной. Если свойство &quot;Дождаться сообщения&quot; установлено, робот будет ждать, когда входящих сообщений нет, иначе переменной присваивается пустая строка.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Synchronized:</source>
         <translation>Дождаться сообщения:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Synchronized</source>
         <translation>Дождаться сообщения</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait for Motion</source>
         <translation>Ждать движения</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the motion sensor on the given port is triggered.</source>
         <translation>Ждет, пока не сработает датчик движения.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Wait for Ultrasonic Distance</source>
         <translation>Ждать УЗ датчик расстояния</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the value returned by the ultrasonic sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, from 0 to 300).</source>
         <translation>Ждать, пока расстояние, возвращаемое ультразвуковым датчиком расстояния, не будет сравнимо с указанным в значении параметра &apos;Расстояние&apos; (расстояние задается в сантиметрах, от 0 до 300). Еще один парамер — номер порта, к которому подключен датчик расстояния. Также параметром указывается операция, которая будет использоваться для сравнения с введенным расстоянием.</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Wait for Touch Sensor</source>
         <translation>Ждать датчик касания</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Ждать, пока не сработает датчик касания. Параметром указывается номер порта, к которому подключен датчик. Допустимые значения: 1, 2, 3, 4.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Wait Gamepad Button</source>
         <translation>Ждать кнопки на пульте</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for Android gamepad &apos;magic button&apos; press. Buttons are identified by numbers from 1 to 5 (from left to right)</source>
         <translation>Ждёт нажатия на одну из &apos;магических кнопок&apos; Android-пульта. Кнопки идентифицируются номерами с 1 по 5 (слева направо)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait gamepad button</source>
         <translation>Ждать кнопки на пульте</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+3"/>
         <source>Wait for Gamepad Connect</source>
         <translation>Ждать подключения пульта</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Waits until Android gamepad is connected.</source>
         <translation>Ждать, пока не будет подключен Android-пульт.</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
         <source>Wait for Gamepad Disconnect</source>
         <translation>Ждать отключения пульта</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Waits until Android gamepad is disconnected.</source>
         <translation>Ждать, пока Android-пульт не отключится.</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
         <source>Wait for Gamepad Wheel</source>
         <translation>Ждать &quot;руля&quot; на пульте</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Waits till the value returned by gamepad wheel be greater or less than the given in the &apos;Angle&apos; parameter value. Angle is measured from -100 (max left) to 100 (max right).</source>
         <translation>Ждёт, пока значение, возвращаемое &apos;рулём&apos; Android-пульта не будет больше (или меньше) заданного значения. Угол измеряется от -100 (максимально влево) до 100 (максимально вправо).</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Wait Pad Press</source>
         <translation>Ждать нажатия на пульт</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Waits for Android gamepad pad press (left pad has number 1, right pad - number 2).</source>
         <translation>Ждёт нажатия на одну из активных областей Android-пульта. Левая область имеет номер 1, правая - номер 2.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait pad press</source>
         <translation>Ждать нажатия пульта</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Pad:</source>
         <translation>Пульт:</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Pad</source>
         <translation>Пульт</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Write To File</source>
         <translation>Записать в файл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
         <translation>Записывает заданное значение в файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="+160"/>
         <source>RobotsDiagram</source>
         <translation>Диаграмма поведения робота</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Actions</source>
         <translation>Действия</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Wait</source>
         <translation>Ожидание</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
         <source>Drawing</source>
         <translation>Рисование</translation>
     </message>
@@ -1288,28 +875,22 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="-1570"/>
         <source>Hull Number</source>
         <translation>Бортномер</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Message</source>
         <translation>Сообщение</translation>
     </message>
     <message>
-        <location line="+505"/>
-        <location line="+413"/>
         <source>Tacho Limit</source>
         <translation>Предел оборотов</translation>
     </message>
     <message>
-        <location line="+242"/>
         <source>Variable</source>
         <translation>Переменная</translation>
     </message>
     <message>
-        <location line="+449"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
@@ -1317,97 +898,70 @@
 <context>
     <name>TrikMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="+40"/>
         <source>E1</source>
         <translation>E1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E2</source>
         <translation>E2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E3</source>
         <translation>E3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E4</source>
         <translation>E4</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>greater</source>
         <translation>больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>less</source>
         <translation>меньше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not greater</source>
         <translation>не больше</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>not less</source>
         <translation>не меньше</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+6"/>
         <source>black</source>
         <translation>черный</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
         <source>blue</source>
         <translation>синий</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
-        <location line="+14"/>
         <source>green</source>
         <translation>зеленый</translation>
     </message>
     <message>
-        <location line="-20"/>
-        <location line="+6"/>
-        <location line="+14"/>
         <source>red</source>
         <translation>красный</translation>
     </message>
     <message>
-        <location line="-20"/>
-        <location line="+6"/>
         <source>white</source>
         <translation>белый</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
         <source>yellow</source>
         <translation>желтый</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Color sensor</source>
         <translation>Сенсор цвета</translation>
     </message>
     <message>
-        <location line="-22"/>
-        <location line="+22"/>
         <source>Line sensor</source>
         <translation>Сенсор линии</translation>
     </message>
     <message>
-        <location line="-22"/>
-        <location line="+22"/>
         <source>Object sensor</source>
         <translation>Сенсор объекта</translation>
     </message>
@@ -1420,142 +974,114 @@
         <translation type="vanished">Истина</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>norm</source>
         <translation>норма</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>x-axis</source>
         <translation>ось x</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>y-axis</source>
         <translation>ось y</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>z-axis</source>
         <translation>ось z</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>In</source>
         <translation>Входной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Inout</source>
         <translation>Входной-выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Out</source>
         <translation>Выходной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Return</source>
         <translation>Возвращается</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Composite</source>
         <translation>Композиция</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shared</source>
         <translation>Общая</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Concurrent</source>
         <translation>Параллельный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Guarded</source>
         <translation>Защищенный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Sequential</source>
         <translation>Последовательный</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>B1</source>
         <translation>B1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B2</source>
         <translation>B2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B3</source>
         <translation>B3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>B4</source>
         <translation>B4</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A5</source>
         <translation>A5</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A6</source>
         <translation>A6</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>off</source>
         <translation>выключен</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>orange</source>
         <translation>оранжевый</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>D1</source>
         <translation>D1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>D2</source>
         <translation>D2</translation>
     </message>
@@ -1564,154 +1090,122 @@
         <translation type="vanished">тормозить</translation>
     </message>
     <message>
-        <location line="-24"/>
         <source>float</source>
         <translation>скольжение</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Package</source>
         <translation>Пакет</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Private</source>
         <translation>Приватный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Protected</source>
         <translation>Защищенный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Public</source>
         <translation>Публичный</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>15</source>
         <translation>15</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>30</source>
         <translation>30</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>80</source>
         <translation>80</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Down</source>
         <translation>Вниз</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enter</source>
         <translation>Ввод</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Esc</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Left</source>
         <translation>Влево</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Right</source>
         <translation>Вправо</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Up</source>
         <translation>Вверх</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>cyan</source>
         <translation>сине-зелёный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark blue</source>
         <translation>тёмно-синий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark cyan</source>
         <translation>тёмносине-зеленый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark gray</source>
         <translation>тёмно-серый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark green</source>
         <translation>тёмно-зелёный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark magenta</source>
         <translation>тёмно-пурпурный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark red</source>
         <translation>тёмно-красный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>dark yellow</source>
         <translation>тёмно-жёлтый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>gray</source>
         <translation>серый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>light gray</source>
         <translation>светло-серый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>magenta</source>
         <translation>пурпурный</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>brake</source>
         <translation>торможение</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+22"/>
         <source>false</source>
         <translation>ложь</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>body</source>
         <translation>тело цикла</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+22"/>
         <source>true</source>
         <translation>истина</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/ev3/ev3GeneratorBase_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/ev3/ev3GeneratorBase_ru.ts
@@ -4,13 +4,10 @@
 <context>
     <name>ev3::Ev3GeneratorFactory</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/sendMailGenerator.cpp" line="+35"/>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/receiveMailGenerator.cpp" line="+38"/>
         <source>There is already mailbox with same name, but different msg type</source>
         <translation>Уже существует почтовый ящик с таким именем, но другим типом данных</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/receiveMailGenerator.cpp" line="+4"/>
         <source>There are too many mailboxes, max size is 30</source>
         <translation></translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/ev3/ev3RbfGenerator_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/ev3/ev3RbfGenerator_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfMasterGenerator.cpp" line="+60"/>
         <source>There is no opened diagram</source>
         <translation>Сначала откройте диаграмму</translation>
     </message>
@@ -13,17 +12,14 @@
         <translation type="vanished">/* Внимание: преобразование типа из строки в целое число пока не поддерживается. Пожалуйста, обратитесь к разработчикам с запросом. */ 0</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="+821"/>
         <source>/* Warning: cast from string to numeric type is not supported */ 0</source>
         <translation>/* Внимание: преобразование типа из строки в числовой тип пока не поддерживается. Пожалуйста, обратитесь к разработчикам с запросом. */ 0</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>/* Warning: autocast from array to other type is not supported */ 0</source>
         <translation>/* Внимание: автоматическое преобразование типа из массива в другой тип не поддерживается. */ 0</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>/* Warning: autocast is supported only for numeric types */ 0</source>
         <translation>/* Внимание: автоматическое преобразование типов поддерживается только для числовых типов */ 0</translation>
     </message>
@@ -35,57 +31,46 @@
         <translation type="vanished">Генерация (Байткод)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="+34"/>
         <source>Autonomous mode (USB)</source>
         <translation>Автономный режим (USB)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Autonomous mode (Bluetooth)</source>
         <translation>Автономный режим (Bluetooth)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Generate to Ev3 Robot Byte Code File</source>
         <translation>Сгенерировать в байткод EV3</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Upload program</source>
         <translation>Загрузить программу</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Run program</source>
         <translation>Запустить программу</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Stop robot</source>
         <translation>Остановить программу</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>EV3 Source Code language</source>
         <translation>Файл с байткодом EV3</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Generate Ev3 Robot Byte Code File</source>
         <translation>Сгенерировать в байткод EV3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload EV3 Program</source>
         <translation>Загрузить программу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Run EV3 Program</source>
         <translation>Запустить программу на EV3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop EV3 Program</source>
         <translation>Остановить программу на EV3</translation>
     </message>
@@ -94,12 +79,10 @@
         <translation type="vanished">&lt;a href=&quot;https://java.com/ru/download/&quot;&gt;Java&lt;/a&gt; не установлена. Пожалуйста, скачайте и установите ее.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Can&apos;t write source code files to disk!</source>
         <translation>Не могу записать файлы с исходным кодом на диск!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Compilation error occured.</source>
         <translation>Ошибка компиляции.</translation>
     </message>
@@ -108,27 +91,22 @@
         <translation type="vanished">Для загрузки программ на EV3 необходимо установить &lt;a href=&quot;https://java.com/ru/download/&quot;&gt;Java&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location line="+135"/>
         <source>Could not upload file to robot. Connect to a robot via %1.</source>
         <translation>Не могу загрузить файл на робота. Подключите робота по %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>The program has been uploaded</source>
         <translation>Загрузка программы завершена успешно</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to run it?</source>
         <translation>Хотите ли Вы запустить эту программу?</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/generatorBase_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/generatorBase_ru.ts
@@ -4,118 +4,95 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="+44"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>Генерация невозможна, на диаграмме нет начальных блоков</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Initial node must not have incoming links</source>
         <translation>В блок &quot;Начало&quot; не должны входить связи</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>This element must have exactly ONE outgoing link</source>
         <translation>От этого элемента должна отходить в точности одна связь</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Final node must not have outgoing links</source>
         <oldsource>Final node must not have outgioing links</oldsource>
         <translation>От блока &quot;Конец&quot; не должно отходить связей</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>If block must have exactly TWO outgoing links</source>
         <translation>От условного блока должно отходить в точности две связи</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Two outgoing links marked with &apos;true&apos; found</source>
         <translation>Обе связи помечены меткой &quot;истина&quot;</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Two outgoing links marked with &apos;false&apos; found</source>
         <translation>Обе связи помечены меткой &quot;ложь&quot;</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>There must be at least one link with &quot;true&quot; or &quot;false&quot; marker on it</source>
         <translation>Должна быть как минимум одна связь с маркером &quot;истина&quot; или &quot;ложь&quot;</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Loop block must have exactly TWO outgoing links</source>
         <translation>От блока &quot;Цикл&quot; должно отходить в точности две связи</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Two outgoing links marked with &quot;body&quot; found</source>
         <translation>Обе связи помечены меткой &quot;тело цикла&quot;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Из блока &quot;Цикл&quot; должна выходить связь с маркером &quot;тело цикла&quot;</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>There must be exactly one link without marker on it (default branch)</source>
         <translation>Ветка без маркера должна быть в точности одна (ветка &quot;default&quot;)</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>There must be a link without marker on it (default branch)</source>
         <translation>Должна быть связь без маркера (ветка &quot;default&quot;)</translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Outgoing links from loop block must be connected to different blocks</source>
         <translation>Исходящие связи должны быть присоединены к разным блокам</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>There must be at list TWO links outgoing from switch block</source>
         <translation>От блока выбора должно отходить минимум ДВЕ связи</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Duplicate case branch: &apos;%1&apos;</source>
         <translation>Найдено более одной ветки &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Из блок &quot;Параллельные задачи&quot; должно выходить как минимум две связи</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Unknown block type</source>
         <translation>Неизвестный блок</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="+79"/>
         <source>There is no opened diagram</source>
         <translation>Сначала откройте диаграмму</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="+32"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не подключена</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/parts/subprograms.cpp" line="+83"/>
         <source>Graphical diagram instance not found</source>
         <translation>Графическая модель диаграммы с подпрограммой не найдена</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Please enter valid c-style name for subprogram &quot;</source>
         <translation>Введите корректный идентификатор подпрограммы &quot;</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Subprograms should have unique names, please rename</source>
         <translation>Подпрограммы должны иметь уникальные имена, переименуйте, пожалуйста</translation>
     </message>
@@ -124,12 +101,10 @@
         <translation type="vanished">Такой идентификатор уже используется: </translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/converters/reservedVariablesConverter.cpp" line="+64"/>
         <source>Device on port %1 is not configured. Please select it on the &quot;Configure devices&quot; panel on the right-hand side.</source>
         <translation>Сенсор на порту %1 не сконфигурирован. Выберите его тип на панели &quot;Настройки сенсоров&quot; справа.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>/* ERROR: SELECT DEVICE TYPE */</source>
         <translation>/* ОШИБКА: ВЫБЕРИТЕ ТИП СЕНСОРА */</translation>
     </message>
@@ -137,17 +112,14 @@
 <context>
     <name>generatorBase::MasterGeneratorBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="+40"/>
         <source>This diagram cannot be generated into the structured code. Generating it into the code with &apos;goto&apos; statements.</source>
         <translation>Данная диаграмма не может быть сгенерирована в структурированный код. Генерирую код с &apos;goto&apos;.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>This diagram cannot be even generated into the code with &apos;goto&apos;statements. Please contact the developers.</source>
         <translation>Данная диаграмма не может быть сгенерирована даже в код с &apos;goto&apos;. Пожалуйста, обратитесь к разработчикам.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This diagram cannot be generated into the structured code.</source>
         <translation>Данная диаграмма не может быть сгенерирована в структурированный код.</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/nxt/nxtOsekCGenerator_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/nxt/nxtOsekCGenerator_ru.ts
@@ -4,22 +4,18 @@
 <context>
     <name>nxt::NxtFlashTool</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="+75"/>
         <source>Robot is already being flashed</source>
         <translation>Робот уже прошивается</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Firmware file not found in nxt-tools directory.</source>
         <translation>Файл с прошивкой не найден в директории с инструментами NXT.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Flashing robot is possible only by USB. Please switch to USB mode.</source>
         <translation>Прошивка робота возможна только по USB. Пожалуйста, переключитесь в режим USB.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Firmware flash started. Please don&apos;t disconnect robot during the process</source>
         <translation>Начат процесс загрузки прошивки в робота. Пожалуйста, не отсоединяйте робота, пока процесс не будет завершен</translation>
     </message>
@@ -40,12 +36,10 @@
         <translation type="vanished">Для загрузки прошивки в робота требуется запустить QReal:Robots с правами администратора</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>The program has been uploaded</source>
         <translation>Загрузка завершена</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to run it?</source>
         <translation>Хотите ли Вы запустить эту программу?</translation>
     </message>
@@ -62,102 +56,82 @@
         <translation type="vanished">Процесс загрузки прошивки в робота завершен!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Uploading is already running</source>
         <translation>Программа уже загружается</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Uploading program started. Please don&apos;t disconnect robot during the process</source>
         <translation>Начат процесс загрузки программы в робота. Пожалуйста, не отсоединяйте робота, пока процесс не будет завершен</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Uploading failed. Make sure that X-server allows root to run GUI applications</source>
         <translation>Не удалось загрузить программу в робота. Убедитесь, что TRIKStusio запущена с нужными правами</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Could not upload program. Make sure the robot is connected and ON</source>
         <translation>Не удалось загрузить программу в робота. Убедитесь, что робот включен и подсоединен к компьютеру</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>If you are using GNU/Linux visit https://help.trikset.com/nxt/run-upload-programs to get instructions</source>
         <translation>Если вы используете GNU/Linux, посетите https://help.trikset.com/nxt/run-upload-programs, чтобы получить инструкции</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Error in reading from firmware file: %1</source>
         <translation>Ошибка чтения из файла с прошивкой %1</translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Could not find %1. Check your program was compiled and try again.</source>
         <translation>Не могу найти %1. Проверьте, что программа скомпилировалась, путь до нее не содержит пробелов и русских букв и попробуйте еще раз.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Could not delete old file. Make sure the robot is connected, turned on.</source>
         <translation>Не могу удалить старый файл с робота. Пожалуйста, проверьте, что робот включен и подключен к компьютера и попробуйте еще раз.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Could not upload program. Make sure the robot is connected, turned on and has enough free memory.</source>
         <translation>Попытка загрузки программы не удалась. Проверьте, что робот включен, подключен к компьютеру и имеет достаточно свободной памяти.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Could not close file on brick. Probably connection to NXT lost at the last stage of uploading</source>
         <translation>Не могу закрыть файл на роботе после записи данных в него. Возможно, связь с NXT была потеряна на самом последнем шагу загрузки</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Uploading completed successfully</source>
         <translation>Загрузка программы завершена успешно</translation>
     </message>
     <message>
-        <location line="-303"/>
         <source>Compilation error occured. Please check your function blocks syntax. If you sure in their validness contact developers</source>
         <translation>Произошла ошибка компиляции. Проверьте синтаксис выражений внутри блоков &quot;Функция&quot;;. Если Вы уверены в их корректности, обратитесь к разработчикам</translation>
     </message>
     <message>
-        <location line="-186"/>
         <source>Could not open %1 for reading.</source>
         <translation>Не могу открыть файл %1 для чтения.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Firmware file is too large to fit into NXT brick memory.</source>
         <translation>Файл с прошивкой слишком велик для памяти NXT.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not write firmware into NXT memory.</source>
         <translation>Попытка записи прошивки в память NXT не удалась.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Firmware successfully flashed into robot, but starting it failed.</source>
         <translation>Прошивка была успешно записана в память робота, но ее запуск не удался. Попробуйте перезагрузить робота.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Flashing process completed successfully.</source>
         <translation>Процесс прошивки робота успешно завершен.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Flashing NXT brick...</source>
         <translation>Прошиваю робота...</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>You need to have superuser privileges to flash NXT robot</source>
         <translation>Загрузка программы не удалась. Возможно, стоит попробовать перезапустить среду с правами суперпользователя</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>QReal requires superuser privileges to upload programs on NXT robot</source>
         <translation>Для загрузки программ в робота требуется запустить TRIKStudio с правами администратора</translation>
     </message>
@@ -169,43 +143,34 @@
         <translation type="vanished">Файл исходного кода Lego NXT OSEK C</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="+32"/>
         <source>Generation (NXT OSEK C)</source>
         <translation>Генерация (C)</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+131"/>
         <source>NXT tools package is not installed</source>
         <translation>Пакет &quot;Инструменты NXT&quot; не установлен</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Generate code</source>
         <translation>Генерировать код</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Flash robot</source>
         <translation>Прошить</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Upload program</source>
         <translation>Загрузить программу</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Generate NXT OSEK code</source>
         <translation>Сгенерировать код NXT OSEK</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload program to NXT device</source>
         <translation>Загрузить программу на устройство NXT</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>flash.sh not found. Make sure it is present in QReal installation directory</source>
         <translation>Не найден скрипт flash.sh. Убедитесь, что пакет nxt-tools установлен корректно</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/pioneer/pioneerLuaGenerator_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/pioneer/pioneerLuaGenerator_ru.ts
@@ -4,12 +4,10 @@
 <context>
     <name>PioneerAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="+14"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Base station connection mode:</source>
         <translation>Режим подключения базовой станции:</translation>
     </message>
@@ -34,7 +32,6 @@
         <translation type="vanished">Использовать &quot;controller&quot; для загрузки и выполнения программы</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Connection Settings</source>
         <translation>Настройки соединения</translation>
     </message>
@@ -47,7 +44,6 @@
         <translation type="vanished">COM1</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Base station port:</source>
         <translation>Порт базовой станции:</translation>
     </message>
@@ -64,7 +60,6 @@
         <translation type="vanished">Настройки базовой станции</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Base station IP:</source>
         <translation>IP-адрес базовой станции:</translation>
     </message>
@@ -88,28 +83,22 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaMasterGenerator.cpp" line="+111"/>
         <source>There is no opened diagram</source>
         <translation>Диаграмма не открыта</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="+121"/>
         <source>Generation internal error, please send bug report to developers.Additional info: zone node %1 can not be used as labeled node.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: узел зоны %1 не может быть использован как помеченный узел.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Generation internal error, synchronous zone parent is a zone node.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: в семантическом дереве родитель узла-зоны сам является узлом-зоной.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Generation internal error, synchronous fragment zone is absent.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: не найдена зона для узла начала синхронного фрагмента.</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+108"/>
         <source>Generation internal error, zone contains zone node.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: в семантическом дереве узел-зона содержит узел-зону в качестве непосредственного сына.</translation>
     </message>
@@ -188,50 +177,38 @@
         <translation type="vanished">Загрузка начата, пожалуйста, подождите...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="+134"/>
         <source>Uploading finished.</source>
         <translation>Загрузка завершена.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Start finished.</source>
         <translation>Запуск завершён.</translation>
     </message>
     <message>
-        <location line="-82"/>
-        <location line="+40"/>
         <source>Pioneer base station IP address is not set. It can be set in Settings window.</source>
         <translation>IP-адрес базовой станции Пионера не указан. Его можно указать в окне &quot;Настройки&quot; -&gt; &quot;Роботы&quot; -&gt; &quot;Пионер&quot;.</translation>
     </message>
     <message>
-        <location line="-34"/>
-        <location line="+40"/>
         <source>Pioneer base station port is not set. It can be set in Settings window.</source>
         <translation>Порт базовой станции Пионера не указан. Его можно указать в окне &quot;Настройки&quot; -&gt; &quot;Роботы&quot; -&gt; &quot;Пионер&quot;.</translation>
     </message>
     <message>
-        <location line="-34"/>
-        <location line="+9"/>
         <source>Generation failed, upload aborted.</source>
         <translation>Генерация завершились с ошибкой, загрузка отменена.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Uploading to: %1, please wait...</source>
         <translation>Производится загрузка на %1, пожалуйста, подождите...</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Starting program. Senging request to: %1, please wait...</source>
         <translation>Скрипт запускается. Запрос запуска к %1, пожалуйста, подождите...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Stopping program is not supported for HTTP communication mode.</source>
         <translation>Остановка программы не поддерживается в режиме передачи по HTTP, используйте инструмент &quot;controller&quot; для связи с роботом (включается в настройках).</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Pioneer base station took too long to respond. Request aborted.</source>
         <translation>НСУ Пионер не отвечает.</translation>
     </message>
@@ -258,7 +235,6 @@
         <translation type="vanished">Квадрокоптер &quot;Пионер&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="+45"/>
         <source>Pioneer model (real copter)</source>
         <translation>Реальный квадрокоптер</translation>
     </message>
@@ -267,47 +243,38 @@
         <translation type="vanished">Симулятор</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generate to Pioneer Lua</source>
         <translation>Генерировать в .lua для Пионера</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Upload generated program to Pioneer</source>
         <translation>Загрузить программу на Пионер</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Choose robot`s mode</source>
         <translation>Выберите режим робота</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Robot`s IP-address</source>
         <translation>IP-адрес робота</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Robot`s port</source>
         <translation>Порт робота</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Sorry, but uploading works only on Windows</source>
         <translation>Извините, загрузка работает только на Windows</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>site</source>
         <translation>сайте</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please download uploader from </source>
         <translation>Пожалуйста, скачайте загрузчик с </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Exit code </source>
         <translation>Код завершения </translation>
     </message>
@@ -324,12 +291,10 @@
         <translation type="vanished">Язык Lua</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Generate Lua script for Pioneer Quadcopter</source>
         <translation>Генерировать скрипт на Lua для квадрокоптера &quot;Пионер&quot;</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Upload Pioneer program</source>
         <translation>Загрузить программу на квадрокоптер &quot;Пионер&quot;</translation>
     </message>
@@ -389,7 +354,6 @@
 <context>
     <name>pioneer::lua::PioneerLuaMasterGenerator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaMasterGenerator.cpp" line="+34"/>
         <source>Generation failed. Possible causes are internal error in generator or too complex program structure.</source>
         <translation>Генерация закончилась с ошибкой. Возможные причины: внутренняя ошибка генератора или слишком сложная структура программы. Обратитесь к разработчикам.</translation>
     </message>
@@ -417,7 +381,6 @@
         <translation type="vanished">Количество блоков &quot;Условие&quot; и &quot;Конец условия&quot; должно быть равным.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="+195"/>
         <source>Generation internal error, failed to create a node.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: не удалось создать узел семантического дерева.</translation>
     </message>
@@ -434,58 +397,46 @@
         <translation type="vanished">Использование блока &quot;Конец условия&quot; без блока &quot;Условие&quot; не допускается.</translation>
     </message>
     <message>
-        <location line="-142"/>
         <source>The diagram must have the same number of &quot;Conditonal&quot; and &quot;End If&quot; blocks.</source>
         <translation>Количество блоков &quot;Условие&quot; и &quot;Конец условия&quot; должно быть равным.</translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location line="+85"/>
         <source>&quot;End If&quot; block occurs before &quot;If block&quot;</source>
         <translation>Использование блока &quot;Конец условия&quot; без блока &quot;Условие&quot; не допускается</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Nested If&apos;s constructions is not allowed.</source>
         <translation>Вложенные условные конструкции не допускаются.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Generation internal error, zone node corresponds to a block in a diagram.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: узел-зона семантического дерева соответствует блоку на диаграмме. Узел-зона может быть только частью представления блока.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Generation internal error, non-zone node is a start of a fragment.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: синхронный фрагмент начинается с узла-зоны.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Generation internal error, program ends abruptly.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: программа неожиданно закончилась. Такие ошибки должны ловиться при предварительной проверке программы.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Generation internal error, asynchronous node does not have target node.</source>
         <translation>Внутренняя ошибка генерации. Дополнительная информация: асинхронный узел не имеет узла, которому надо передать управления после асинхронной операции.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>There is a problem with If construction or with loops (loops without sending requests to the autopilot through &quot;Takeoff&quot;, &quot;Landing&quot;, &quot;Go to local point&quot; blocks are not supported yet).</source>
         <translation>В диаграмме присутстует ошибка в использовании условных конструкций или циклов (циклы без использования обращений к автопилоту через блоки &quot;Взлет&quot;, &quot;Посадка&quot;, &quot;Лететь в точку (ЛК)&quot; пока не поддержаны).</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>The blocks (&quot;Takeoff&quot;, &quot;Landing&quot;, &quot;Go to local point&quot;) which work with autopilot were observed in both (or only in one) conditional branches.</source>
         <translation>Блоки (&quot;Взлет&quot;, &quot;Посадка&quot;, &quot;Лететь в точку (ЛК)&quot;), работающие с автопилотом квадрокоптера, найдены в диаграмме в одной или нескольких ветвях.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Such blocks must appear and finish both branches (the &quot;End if&quot; block must have two such parents) or not appear at branches at all.</source>
         <translation>Такие блоки должны встречаться и заканчивать обе ветви условной конструкции (блок &quot;Конец условия&quot; должен иметь два таких предка) или не встречаться вовсе.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Such blocks may appear in each branch several times but one of them must finish it in each branch.</source>
         <translation>Такие блоки могут встречаться в каждой ветви условной конструкции неограниченное число раз, но один из них в каждой ветви должен быть завершающим.</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/trik/trikGeneratorBase_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/trik/trikGeneratorBase_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikGeneratorBase/src/trikBlocksValidator.cpp" line="+111"/>
         <source>Property should not be empty.</source>
         <translation>Свойство не должно быть пустым.</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/trik/trikPythonGeneratorLibrary_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/trik/trikPythonGeneratorLibrary_ru.ts
@@ -4,63 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="+141"/>
         <source>Trying to join a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Попытка присоединиться к потоку с неизвестным идентификатором. Возможные причины: распараллеливание внутри подпрограммы или попытка склеить два потока без блока &quot;join&quot;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Join block must have exactly one outgoing link</source>
         <translation>Из блок соединения потоков должна выходить в точности одна связь</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+45"/>
         <source>Guard property of a link outgoing from a join must contain an id of one of joined threads</source>
         <translation>На стрелке из блока соединения потоков должен быть идентификатор одного из склеиваемых потоков</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Joining threads in a loop is forbidden</source>
         <translation>Соединение потоков в цикле запрещено</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Trying to fork from a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Попытка создать поток в потоке с неизвестным идентификатором. Возможные причины: создание нового потока в подпрограмме или попытка склеить два потока без блока Join</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Блок &quot;Параллельные задачи&quot; должен иметь как минимум две исходящие связи</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Links outgoing from a fork block must have different thread ids</source>
         <translation>Идентификаторы на связях из блока &quot;Параллельные задачи&quot; должны быть различны</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Fork block must have a link marked with an id of a thread from which the fork is called, &apos;%1&apos; in this case</source>
         <translation>Из блока &quot;Параллельные задачи&quot; должна выходить связь с идентификатором текущего потока, в данном случае &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Trying to create a thread with an already occupied id &apos;%1&apos;</source>
         <translation>Попытка создать поток с уже занятым идентификатором &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Creation of threads in a cycle is forbidden, check for links to before a fork</source>
         <translation>Создание потоков в цикле запрещено, проверьте связи, ведущие в блоки перед блоком &quot;Параллельные задачи&quot;</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не присоединена</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonControlFlowValidator.cpp" line="+35"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>На диаграмме нет блока &quot;Начало&quot;</translation>
     </message>
@@ -68,57 +55,46 @@
 <context>
     <name>trik::python::TrikPythonGeneratorPluginBase</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="+73"/>
         <source>Network operation timed out</source>
         <translation>Не удалось получить ответ от робота, проверьте настройки, проверьте, включён ли робот</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Casing model mismatch, check TRIK Studio settings, &quot;Robots&quot; page. It seems that TRIK casing version selected in TRIK Studio differs from version on robot.</source>
         <translation>Модель корпуса робота не совпадает с указанной в настройках. Проверьте окно настроек, вкладка &quot;Роботы&quot;, должна быть выбрана модель ТРИКа, соответствующая корпусу робота.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Generate python code</source>
         <translation>Генерировать код на Python</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Upload program</source>
         <translation>Загрузить программу</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Run program</source>
         <translation>Загрузить и выполнить программу</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Stop robot</source>
         <translation>Остановить робота</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Generate Python code</source>
         <translation>Сгенерированть код для ТРИК на QtScript</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload Python program</source>
         <translation>Загрузить программу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Run Python program</source>
         <translation>Исполнить программу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop Python program</source>
         <translation>Остановить выполнение программы для TRIK</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>There are no files to upload. You must open or generate at least one *.js or *.py file.</source>
         <translation>Нет файлов для загрузки. Вы должны открыть или сгенерировать хотя бы один *.js или *.py файл.</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/trik/trikQtsGeneratorLibrary_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/trik/trikQtsGeneratorLibrary_ru.ts
@@ -4,33 +4,26 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="+141"/>
         <source>Trying to join a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Попытка присоединиться к потоку с неизвестным идентификатором. Возможные причины: распараллеливание внутри подпрограммы или попытка склеить два потока без блока &quot;join&quot;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Join block must have exactly one outgoing link</source>
         <translation>Из блок соединения потоков должна выходить в точности одна связь</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+45"/>
         <source>Guard property of a link outgoing from a join must contain an id of one of joined threads</source>
         <translation>На стрелке из блока соединения потоков должен быть идентификатор одного из склеиваемых потоков</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Joining threads in a loop is forbidden</source>
         <translation>Соединение потоков в цикле запрещено</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Trying to fork from a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Попытка создать поток в потоке с неизвестным идентификатором. Возможные причины: создание нового потока в подпрограмме или попытка склеить два потока без блока Join</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Блок &quot;Параллельные задачи&quot; должен иметь как минимум две исходящие связи</translation>
     </message>
@@ -39,32 +32,26 @@
         <translation type="vanished">На всех связях, исходящих из блока &quot;Параллельные задачи&quot; должнен быть проставлен идентификатор потока</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Links outgoing from a fork block must have different thread ids</source>
         <translation>Идентификаторы на связях из блока &quot;Параллельные задачи&quot; должны быть различны</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Fork block must have a link marked with an id of a thread from which the fork is called, &apos;%1&apos; in this case</source>
         <translation>Из блока &quot;Параллельные задачи&quot; должна выходить связь с идентификатором текущего потока, в данном случае &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Trying to create a thread with an already occupied id &apos;%1&apos;</source>
         <translation>Попытка создать поток с уже занятым идентификатором &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Creation of threads in a cycle is forbidden, check for links to before a fork</source>
         <translation>Создание потоков в цикле запрещено, проверьте связи, ведущие в блоки перед блоком &quot;Параллельные задачи&quot;</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не присоединена</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsControlFlowValidator.cpp" line="+37"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>На диаграмме нет блока &quot;Начало&quot;</translation>
     </message>
@@ -123,57 +110,46 @@
 <context>
     <name>trik::qts::TrikQtsGeneratorPluginBase</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="+73"/>
         <source>Network operation timed out</source>
         <translation>Не удалось получить ответ от робота, проверьте настройки, проверьте, включён ли робот</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Casing model mismatch, check TRIK Studio settings, &quot;Robots&quot; page. It seems that TRIK casing version selected in TRIK Studio differs from version on robot.</source>
         <translation>Модель корпуса робота не совпадает с указанной в настройках. Проверьте окно настроек, вкладка &quot;Роботы&quot;, должна быть выбрана модель ТРИКа, соответствующая корпусу робота.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Generate TRIK code</source>
         <translation>Генерировать JavaScript код</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Upload program</source>
         <translation>Загрузить программу</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Run program</source>
         <translation>Загрузить и выполнить программу</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Stop robot</source>
         <translation>Остановить робота</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Generate TRIK Code</source>
         <translation>Сгенерировать JavaScript код для TRIK</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Upload TRIK Program</source>
         <translation>Загрузить программу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Run TRIK Program</source>
         <translation>Исполнить программу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop TRIK Robot</source>
         <translation>Остановить выполнение программы для TRIK</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>There are no files to upload. You must open or generate at least one *.js or *.py file.</source>
         <translation>Нет файлов для загрузки. Вы должны открыть или сгенерировать хотя бы один *.js или *.py файл.</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/trik/trikV62PythonGenerator_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/trik/trikV62PythonGenerator_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::python::TrikV62PythonGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikV62PythonGenerator/trikV62PythonGeneratorPlugin.cpp" line="+29"/>
         <source>Generation (Python)</source>
         <translation>Генерация (Python)</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/generators/trik/trikV62QtsGenerator_ru.ts
+++ b/qrtranslations/ru/plugins/robots/generators/trik/trikV62QtsGenerator_ru.ts
@@ -110,7 +110,6 @@
 <context>
     <name>trik::qts::TrikV62QtsGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikV62QtsGenerator/trikV62QtsGeneratorPlugin.cpp" line="+29"/>
         <source>Generation (Java Script)</source>
         <translation>Генерация (JavaScript)</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/interpreters/ev3KitInterpreter_ru.ts
+++ b/qrtranslations/ru/plugins/robots/interpreters/ev3KitInterpreter_ru.ts
@@ -4,48 +4,38 @@
 <context>
     <name>Ev3AdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="+14"/>
         <source>Form</source>
         <translation>Настройки EV3</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Robot&apos;s Folders</source>
         <translation>Папки Робота</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>ts</source>
         <translation>ts</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Common folder:</source>
         <translation>Общая папка:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use common folder for all projects</source>
         <translation>Использовать общую папку для всех проектов</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bluetooth Settings</source>
         <translation>Настройки Bluetooth</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+17"/>
         <source>COM Port:</source>
         <translation>COM-Порт</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>No COM ports found. If you have a Bluetooth connection with active virtual COM port, please enter its name. Example: COM3</source>
         <translation>COM-порты не найдены. Если установлено Bluetooth-соединение с активным COM-портом, пожалуйста, укажите его имя. Пример: COM3</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Specify COM port manually</source>
         <translation>Указать COM-порт вручную</translation>
     </message>
@@ -53,7 +43,6 @@
 <context>
     <name>Ev3DisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3DisplayWidget.ui" line="+435"/>
         <source>tr(Ev3Display)</source>
         <translation>Дисплей EV3</translation>
     </message>
@@ -61,7 +50,6 @@
 <context>
     <name>ev3::Ev3AdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.cpp" line="+29"/>
         <source>2D robot image:</source>
         <translation>Изображение робота в 2D:</translation>
     </message>
@@ -69,7 +57,6 @@
 <context>
     <name>ev3::Ev3KitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3KitInterpreterPlugin.cpp" line="+108"/>
         <source>Lego EV3</source>
         <translation>Lego EV3</translation>
     </message>
@@ -77,7 +64,6 @@
 <context>
     <name>ev3::robotModel::real::BluetoothRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/bluetoothRealRobotModel.cpp" line="+34"/>
         <source>Interpretation (Bluetooth)</source>
         <translation>Интерпретация (Bluetooth)</translation>
     </message>
@@ -85,7 +71,6 @@
 <context>
     <name>ev3::robotModel::real::UsbRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/usbRealRobotModel.cpp" line="+34"/>
         <source>Interpretation (USB)</source>
         <translation>Интерпретация (USB)</translation>
     </message>
@@ -93,7 +78,6 @@
 <context>
     <name>ev3::robotModel::real::parts::RangeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/parts/rangeSensor.h" line="+31"/>
         <source>Sonar sensor</source>
         <translation>Датчик сонара</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/interpreters/interpreterCore_ru.ts
+++ b/qrtranslations/ru/plugins/robots/interpreters/interpreterCore_ru.ts
@@ -4,77 +4,62 @@
 <context>
     <name>PreferencesRobotSettingsPage</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="+192"/>
         <source>Sensors Settings</source>
         <translation>Настройки сенсоров</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Uploading &amp;&amp; Running</source>
         <translation>Загрузка и запуск программ</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Running after uploading:</source>
         <translation>Запуск после загрузки:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Ask</source>
         <translation>Спрашивать</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Always run</source>
         <translation>Всегда запускать</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Never run</source>
         <translation>Никогда не запускать</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>2D-model Editor Settings</source>
         <translation>Настройки редактора 2D модели</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enable Region Editor Mode</source>
         <translation>Включить режим редактирования регионов</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Advanced settings for creating restrictions</source>
         <translation>Продвинутые настройки для создания ограничений</translation>
     </message>
     <message>
-        <location line="-134"/>
         <source>Robotics construction kit</source>
         <translation>Платформа</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Robot model</source>
         <translation>Модель робота</translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Graphics Watcher update intervals</source>
         <translation>Интервалы обновления графиков</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Sensors  (ms)</source>
         <translation>Сенсоры  (мс)</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Autoscaling  (ms)</source>
         <translation>Масштабирование  (мс)</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Text info (ms)</source>
         <translation>Текстовая информация (мс)</translation>
     </message>
@@ -82,32 +67,26 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="+27"/>
         <source>TRIK Studio</source>
         <translation>TRIK Studio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="+63"/>
         <source>Blocks</source>
         <translation>Блоки</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Configure devices</source>
         <translation>Настройки сенсоров</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Sensors state</source>
         <translation>Графики</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="+54"/>
         <source>Subprograms</source>
         <translation>Подпрограммы</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The list of all declared subprograms in the project</source>
         <translation>Список всех объявленных в проекте подпрограмм</translation>
     </message>
@@ -126,77 +105,62 @@
         <translation type="vanished">time</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="+32"/>
         <source>Run</source>
         <translation>Выполнить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop robot</source>
         <translation>Остановить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to robot</source>
         <translation>Подключиться</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Save as task...</source>
         <translation>Сохранить как упражнение...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Debug</source>
         <translation>Отладка</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Switch to debug mode</source>
         <translation>Переключиться в режим отладки</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Switch to edit mode</source>
         <translation>Переключиться в режим редактирования</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Run interpreter</source>
         <translation>Запуск интерпретации</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stop interpreter</source>
         <translation>Остановить интерпретацию</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Robot settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/exerciseExportManager.cpp" line="+53"/>
         <source>Select file to export save to</source>
         <translation>Укажите имя файла, в который будет сохранено упражнение</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Файл сохранения TRIK Studio (*.qrs)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/details/autoconfigurer.cpp" line="+60"/>
         <source>%2 has been auto configured to port %1</source>
         <translation>%2 был автоматически сгонфигурирован на порту %1</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sensor on port %1 does not correspond to blocks on the diagram.</source>
         <translation>Выставленный на порту %1 сенсор не соответствует блокам на диаграмме.</translation>
     </message>
@@ -204,17 +168,14 @@
 <context>
     <name>interpreterCore::ActionsManager</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="+10"/>
         <source>To main page</source>
         <translation>На главную</translation>
     </message>
     <message>
-        <location line="+246"/>
         <source>Real robot</source>
         <translation>Реальный робот</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2D model</source>
         <translation>2D модель</translation>
     </message>
@@ -222,7 +183,6 @@
 <context>
     <name>interpreterCore::DefaultRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/defaultRobotModel.cpp" line="+31"/>
         <source>Empty model</source>
         <translation>Пустая модель</translation>
     </message>
@@ -230,22 +190,18 @@
 <context>
     <name>interpreterCore::RobotsPluginFacade</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="+159"/>
         <source>Robots</source>
         <translation>Роботы</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Cannot export exercise to the given location (try to change location)</source>
         <translation>Экспорт упражнения по заданному пути не удался (попробуйте другой путь)</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>The specified script file could not be opened for reading </source>
         <translation>Не удалось открыть указанный файл для чтения скрипта</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>No saved code found in the qrs file</source>
         <translation>В qrs не найден сохраннёный код</translation>
     </message>
@@ -254,7 +210,6 @@
         <translation type="vanished">В qrs не найден сохраннёный js код</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Toggle robot console panel</source>
         <translation>Показать/спрятать панель консоли</translation>
     </message>
@@ -262,37 +217,30 @@
 <context>
     <name>interpreterCore::UiManager</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="-66"/>
         <source>Miscellaneous</source>
         <translation>Прочее</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Robot console</source>
         <translation>Консоль робота</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>edit mode</source>
         <translation>режим редактирования</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>debug mode</source>
         <translation>режим отладки</translation>
     </message>
     <message>
-        <location line="+151"/>
         <source>Edit mode</source>
         <translation>Режим редактирования</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Debug mode</source>
         <translation>Режим отладки</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Modes</source>
         <translation>Режимы</translation>
     </message>
@@ -300,38 +248,30 @@
 <context>
     <name>interpreterCore::interpreter::BlockInterpreter</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="+92"/>
-        <location line="+74"/>
         <source>No connection to robot</source>
         <translation>Нет соединения с роботом</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Interpreter is already running</source>
         <translation>Программа уже запущена</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Connected successfully</source>
         <translation>Подключение к роботу выполнено</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Can&apos;t connect to a robot.</source>
         <translation>Не удалось подключиться к роботу.</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Cannot create new thread with already occupied id %1</source>
         <translation>Идентификатор потока %1 уже занят</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Threads limit exceeded. Maximum threads count is %1</source>
         <translation>Превышено максимальное число возможных потоков (максимум %1 потоков)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Killing non-existent thread %1</source>
         <translation>Попытка завершить несуществующий поток %1</translation>
     </message>
@@ -339,42 +279,34 @@
 <context>
     <name>interpreterCore::ui::ExerciseExportDialog</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="+31"/>
         <source>Select non-modifiable parts of exercize</source>
         <translation>Выберите неизменяемые части упражнения</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>2D model world is read-only</source>
         <translation>2D модель мира неизменяема</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sensors are read-only</source>
         <translation>Датчики неизменяемы</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2D model robot position is read-only</source>
         <translation>Позиция 2D модели робота неизменяема</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Motors to wheels binding is read-only</source>
         <translation>Редукция мотор-колесо неизменяема</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2D model simulation settings are read-only</source>
         <translation>Параметры симуляции неизменяемы</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Ok</source>
         <translation>ОК</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -382,7 +314,6 @@
 <context>
     <name>interpreterCore::ui::ModeStripe</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/modeStripe.cpp" line="+22"/>
         <source>press %2 or click here to switch to %3</source>
         <translation>нажмите %2 или кликните здесь для переключения в %3</translation>
     </message>
@@ -390,22 +321,18 @@
 <context>
     <name>interpreterCore::ui::RobotsSettingsPage</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="+58"/>
         <source>Templates directory:</source>
         <translation>Директория с шаблонами:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Choose templates directory</source>
         <translation>Выбрать директорию с шаблонами</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>No constructor kit plugins loaded</source>
         <translation>Не загружено ни одного плагина с описанием робоплатформы</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>No robot models available for </source>
         <translation>Ни одной модели робота не найдено в плагине </translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/interpreters/nullKitInterpreter_ru.ts
+++ b/qrtranslations/ru/plugins/robots/interpreters/nullKitInterpreter_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>nullKitInterpreter::NullKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nullKitInterpreter/src/nullKitInterpreterPlugin.cpp" line="+33"/>
         <source>Empty Kit</source>
         <translation>Пустая модель</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>nullKitInterpreter::NullRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nullKitInterpreter/src/nullRobotModel.cpp" line="+31"/>
         <source>Null model</source>
         <translation>Пустая модель</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/interpreters/nxtKitInterpreter_ru.ts
+++ b/qrtranslations/ru/plugins/robots/interpreters/nxtKitInterpreter_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>NxtAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="+14"/>
         <source>Form</source>
         <translation>Настройки NXT</translation>
     </message>
@@ -21,33 +20,26 @@
         <translation type="vanished">USB</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Bluetooth Settings</source>
         <translation>Настройки Bluetooth</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+7"/>
         <source>COM Port:</source>
         <translation>COM-Порт:</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>No COM ports found. If you have a Bluetooth connection with active virtual COM port, please enter its name. Example: COM3</source>
         <translation>COM-порты не найдены. Если установлено Bluetooth-соединение с активным COM-портом, пожалуйста, укажите его имя. Пример: COM3</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>nxtOSEK Generator Settings</source>
         <translation>Настройки генератора nxtOSEK</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>TextLabel</source>
         <translation>Текстовая метка</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Specify COM port manually</source>
         <translation>Указать COM-порт вручную</translation>
     </message>
@@ -62,7 +54,6 @@
 <context>
     <name>NxtDisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtDisplayWidget.ui" line="+435"/>
         <source>tr(NxtDisplay)</source>
         <translation>Дисплей NXT</translation>
     </message>
@@ -70,17 +61,14 @@
 <context>
     <name>nxt::NxtAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.cpp" line="+33"/>
         <source>2D robot image:</source>
         <translation>Картинка робота в 2D:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to arm-none-eabi:</source>
         <translation>Путь к arm-none-eabi:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>WARNING: Current directory doesn&apos;t exist. 
 Open &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;link&lt;/a&gt; for instructions</source>
         <translation>ВНИМАНИЕ: Текущая директория не существует. 
@@ -90,7 +78,6 @@ Open &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;
 <context>
     <name>nxt::NxtKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtKitInterpreterPlugin.cpp" line="+107"/>
         <source>Lego NXT</source>
         <translation>Lego NXT</translation>
     </message>
@@ -139,7 +126,6 @@ Open &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;
 <context>
     <name>nxt::robotModel::real::BluetoothRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/bluetoothRealRobotModel.cpp" line="+35"/>
         <source>Interpretation (Bluetooth)</source>
         <translation>Интерпретация (Bluetooth)</translation>
     </message>
@@ -147,7 +133,6 @@ Open &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;
 <context>
     <name>nxt::robotModel::real::UsbRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/usbRealRobotModel.cpp" line="+34"/>
         <source>Interpretation (USB)</source>
         <translation>Интерпретация (USB)</translation>
     </message>
@@ -155,7 +140,6 @@ Open &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;
 <context>
     <name>nxt::robotModel::real::parts::SonarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/parts/sonarSensor.h" line="+31"/>
         <source>Sonar sensor</source>
         <translation>Сенсор расстояния</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/interpreters/pioneerKitInterpreter_ru.ts
+++ b/qrtranslations/ru/plugins/robots/interpreters/pioneerKitInterpreter_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>pioneerKitInterpreter::PioneerKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/pioneerKitInterpreter/src/pioneerKitInterpreterPlugin.cpp" line="+33"/>
         <source>Pioneer Kit</source>
         <translation>Квадрокоптер «Пионер»</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/interpreters/robotsPlugin_ru.ts
+++ b/qrtranslations/ru/plugins/robots/interpreters/robotsPlugin_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/robotsPlugin/robotsPlugin.cpp" line="+51"/>
         <source>Robots</source>
         <translation>Роботы</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/interpreters/trikKitInterpreterCommon_ru.ts
+++ b/qrtranslations/ru/plugins/robots/interpreters/trikKitInterpreterCommon_ru.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="+166"/>
         <source>Bogus input values</source>
         <translation>Неподходящие значения аргументов</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error: File %1 couldn&apos;t be opened!</source>
         <translation>Ошибка: Не удаётся открыть файл %1!</translation>
     </message>
@@ -17,17 +15,14 @@
 <context>
     <name>TrikAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="+14"/>
         <source>Form</source>
         <translation>Настройки TRIK</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>TCP Settings</source>
         <translation>Настройки TCP</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enter robot IP-address here</source>
         <translation>Введите IP-адрес робота</translation>
     </message>
@@ -36,42 +31,34 @@
         <translation type="vanished">Настройки мультимедия</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Camera Settings</source>
         <translation>Настройки камеры</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Use real camera</source>
         <translation>Использовать камеру</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Camera:</source>
         <translation>Камера:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Use images from project</source>
         <translation>Использовать запакованные в проект изображения</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Browse...</source>
         <translation>Открыть...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Pack images to project</source>
         <translation>Запаковывать изображения в проект</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Network Settings</source>
         <translation>Настройки сети</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enable Mailbox</source>
         <translation>Активировать Mailbox</translation>
     </message>
@@ -80,7 +67,6 @@
         <translation type="vanished">Бортномер:</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Images:</source>
         <translation>Изображения:</translation>
     </message>
@@ -147,7 +133,6 @@
 <context>
     <name>TrikDisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikDisplayWidget.ui" line="+14"/>
         <source>Trik Display</source>
         <translation>Дисплей TRIK</translation>
     </message>
@@ -155,14 +140,12 @@
 <context>
     <name>TwoDExecutionControl</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp" line="+28"/>
         <source>&apos;%1&apos; is disabled
 </source>
         <translation>&apos;%1&apos; отключен
 </translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>No cofigured random device</source>
         <translation>Генератор случайных чисел не сконфигурирован</translation>
     </message>
@@ -170,22 +153,18 @@
 <context>
     <name>trik::TrikAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="+33"/>
         <source>2D robot image:</source>
         <translation>Картинка робота в 2D:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Select Directory</source>
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You should restart the program to apply changes</source>
         <translation>Перезапустите программу, чтобы применить изменения</translation>
     </message>
@@ -197,19 +176,14 @@
 <context>
     <name>trik::TrikBrick</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="+84"/>
-        <location line="+76"/>
         <source>2d model shell part was not found</source>
         <translation>Консоль 2d модели не найдена</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+283"/>
         <source>Trying to read from file %1 failed</source>
         <translation>Не удалось открыть файл %1</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>No configured motor on port: %1</source>
         <translation>Не найден сконфигурированный  мотор на порту: %1</translation>
     </message>
@@ -218,67 +192,54 @@
         <translation type="vanished">Не найден сконфигурированный  сенсор на порту: %1</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>No configured scalar sensor on port: %1</source>
         <translation>Не настроен скалярный датчик на порту: %1</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No configured lidar on port: %1</source>
         <translation>Не настроен лидар на порту: %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>No configured accelerometer</source>
         <translation>Акселерометр не сконфигурирован</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>No configured gyroscope</source>
         <translation>Гиродатчик не сконфигурирован</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>No configured LineSensor on port: %1</source>
         <translation>Не найден сконфигурированный сенсор линии на порту: %1</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>No configured ColorSensor on port: %1</source>
         <translation>Не настроен датчик цвета на порту: %1</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Sensor not implemented in simulation mode. Used port: %1</source>
         <translation>Датчик не поддержан в режиме имитационного моделирования. Порт: %1</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>No configured encoder on port: %1</source>
         <translation>Не найден сконфигурированный енкодер на порту: %1</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>No configured led</source>
         <translation>LED не сконфигурирован</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Get photo with camera started</source>
         <translation>Процесс получения снимка начат</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Get photo with camera finished</source>
         <translation>Процесс получения снимка завершен</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Cannot get a photo from camera (possibly because of wrong camera name)</source>
         <translation>Получить снимок с помощью камеры не удалось (возможно из-за неправильного имени камеры)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot get a photo from folders/project (possibly because of wrong path/empty project)</source>
         <translation>Получить снимок из папки/проекта не удалось (возможно из-за неправильного пути/отстуствия снимков в проекте)</translation>
     </message>
@@ -298,32 +259,26 @@
         <translation type="vanished">Оставновить QTS</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="+39"/>
         <source>Start</source>
         <translation>Запустить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Stop</source>
         <translation>Оставновить</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>TRIK_PYTHONPATH must be set correctly to run Python script.</source>
         <translation>Для запуска программы на Python доложна быть корректно выставлена переменная окружения TRIK_PYTHONPATH</translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Run program</source>
         <translation>Выполнить программу</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Stop robot</source>
         <translation>Остановить программу</translation>
     </message>
     <message>
-        <location line="+199"/>
         <source>Enter robot`s IP-address here...</source>
         <translation>Введите IP-адрес робота...</translation>
     </message>
@@ -331,8 +286,6 @@
 <context>
     <name>trik::TrikTextualInterpreter</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="-96"/>
-        <location line="+15"/>
         <source>Unsupported script file type</source>
         <translation>Неверный формат файла</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/interpreters/trikV62KitInterpreter_ru.ts
+++ b/qrtranslations/ru/plugins/robots/interpreters/trikV62KitInterpreter_ru.ts
@@ -8,7 +8,6 @@
         <translation type="vanished">ТРИК (новый корпус)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikV62KitInterpreter/src/trikV62KitInterpreterPlugin.cpp" line="+47"/>
         <source>TRIK</source>
         <translation>ТРИК</translation>
     </message>
@@ -16,7 +15,6 @@
 <context>
     <name>trik::robotModel::real::RealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikV62KitInterpreter/src/robotModel/real/trikV62RealRobotModel.cpp" line="+69"/>
         <source>Interpretation (Wi-Fi)</source>
         <translation>Интерпретация (Wi-Fi)</translation>
     </message>

--- a/qrtranslations/ru/plugins/robots/utils_ru.ts
+++ b/qrtranslations/ru/plugins/robots/utils_ru.ts
@@ -4,18 +4,14 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="+27"/>
         <source>Current TRIK runtime version can not be received</source>
         <translation>Не удаётся получить текущую версию прошивки ТРИК</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>TRIK runtime version is too old, please update it by pressing &apos;Upload Runtime&apos; button on toolbar</source>
         <translation>ПО робота устарело, обновите его, нажав на кнопку &quot;Загрузить ПО на робот&quot; на панели инструментов</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+5"/>
         <source>From robot: </source>
         <translation>На роботе: </translation>
     </message>
@@ -23,7 +19,6 @@
 <context>
     <name>SensorsGraph</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.ui" line="+25"/>
         <source>SensorsGraph</source>
         <translation>Сенсоры</translation>
     </message>
@@ -96,23 +91,18 @@
 <context>
     <name>trik::UploaderTool</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="+131"/>
         <source>WinSCP process failed to launch, check path in settings.</source>
         <translation>Не удалось запустить WinSCP, проверьте, что папка winscp есть в папке с TRIK Studio и в ней есть WinSCP.exe.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+15"/>
         <source>Uploading failed, check connection and try again.</source>
         <translation>Загрузка ПО не удалась, проверьте соединение и попробуйте еще раз.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Uploaded successfully!</source>
         <translation>Загрузка успешно завершена!</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>%1 is not installed. Please install %1 first.</source>
         <translation>%1 не установлен. Пожалуйста, сначала установите %1.</translation>
     </message>
@@ -143,12 +133,10 @@
 <context>
     <name>utils::robotCommunication::TcpRobotCommunicator</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicator.cpp" line="+81"/>
         <source>Empty program name, can not upload</source>
         <translation>Пустое имя программы, загрузка на робот невозможна</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Can not read generated file, uploading aborted</source>
         <translation>Невозможно прочитать сгенерированный файл, загрузка отменена</translation>
     </message>
@@ -156,12 +144,10 @@
 <context>
     <name>utils::robotCommunication::TcpRobotCommunicatorWorker</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicatorWorker.cpp" line="+232"/>
         <source>Unable to resolve host.</source>
         <translation>Указанное имя робота неизвестно.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Connection failed. IP: %1</source>
         <translation>Не удалось установить соединение с роботом. IP адрес: %1</translation>
     </message>
@@ -173,17 +159,14 @@
 <context>
     <name>utils::sensorsGraph::SensorViewer</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorViewer.cpp" line="+109"/>
         <source>Save values history</source>
         <translation>Сохранить значения</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Comma-Separated Values Files (*.csv)</source>
         <translation>Файлы значений, разделённых запятыми (*.csv)</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>value: </source>
         <translation>значение: </translation>
     </message>
@@ -191,32 +174,26 @@
 <context>
     <name>utils::sensorsGraph::SensorsGraph</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="+141"/>
         <source>Stop tracking</source>
         <translation>Остановить отслеживание</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Start tracking</source>
         <translation>Начать отслеживание</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reset plot</source>
         <translation>Очистить график</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Zoom In</source>
         <translation>Увеличить</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Zoom Out</source>
         <translation>Уменьшить</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export values...</source>
         <translation>Экспорт показаний...</translation>
     </message>

--- a/qrtranslations/ru/plugins/tools/subprogramsImporterExporter_ru.ts
+++ b/qrtranslations/ru/plugins/tools/subprogramsImporterExporter_ru.ts
@@ -4,17 +4,14 @@
 <context>
     <name>SubprogramsCollectionDialog</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="+29"/>
         <source>Subprograms collection manager</source>
         <translation>Менеджер коллекции подпрограмм</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select All</source>
         <translation>Выбрать все</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Deselect All</source>
         <translation>Снять все</translation>
     </message>
@@ -22,22 +19,18 @@
 <context>
     <name>subprogramsCollectionDialog</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Диалог</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Available subprograms:</source>
         <translation>Доступные подпрограммы:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select all</source>
         <translation>Выделить все</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>WARNING: existing subprograms will be overwritten!</source>
         <translation>ПРЕДУПРЕЖДЕНИЕ: существующие подпрограммы будут перезаписаны!</translation>
     </message>
@@ -45,83 +38,66 @@
 <context>
     <name>subprogramsImporterExporter::SubprogramsImporterExporterPlugin</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="+38"/>
         <source>Subprograms</source>
         <translation>Подпрограммы</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Import from file...</source>
         <translation>Импортировать из файла...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to file...</source>
         <translation>Экспортировать в файл...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save to collection...</source>
         <translation>Сохранить в коллекцию...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Load from collection</source>
         <translation>Загрузить из коллекции</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear collection</source>
         <translation>Очистить коллекцию</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Select subprograms file (name for new one)</source>
         <translation>Выберите файл с подпрограммами (имя для нового)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+43"/>
         <source>QReal Save File(*.qrs)</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>There are no subprograms in your project.</source>
         <translation>В проекте нет подпрограмм.</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>There are not subprograms in your project</source>
         <translation>В проекте нет подпрограмм</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>There are no subprograms in your collection for %1 robot.</source>
         <translation>В коллекции нет подпрограмм для робота %1</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>Select subprograms file</source>
         <translation>Выберите файл с подпрограммами</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>Clear the collection</source>
         <translation>Очистить коллекцию</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Remove all subprograms for all kits from the collection?</source>
         <translation>Удалить из коллекции все подпрограммы для всех видов конструторов?</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>There is no opened project</source>
         <translation>Нет открытого проекта</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>There are different subprograms with the same name in your project. Please make them unique.</source>
         <translation>В проекте есть разные подпрограммы с одинаковыми именами. Пожалуйтса, сделайте имена уникальными.</translation>
     </message>

--- a/qrtranslations/ru/plugins/tools/updatesChecker_ru.ts
+++ b/qrtranslations/ru/plugins/tools/updatesChecker_ru.ts
@@ -4,22 +4,18 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="+23"/>
         <source>New updates are available!</source>
         <translation>Доступны новые обновления!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Update</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Later</source>
         <translation>Позже</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Yeah!</source>
         <translation>Ура!</translation>
     </message>
@@ -27,27 +23,22 @@
 <context>
     <name>updatesChecker::UpdatesCheckerPlugin</name>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="+33"/>
         <source>Check for updates</source>
         <translation>Проверить на наличие обновлений</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>There is some connection problem, may be network is disabled</source>
         <translation>Неполадки с подключением, возможно доступ к сети Интернет отсутсвует</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>There is some unrecognized error with updating process</source>
         <translation>Неожиданная ошибка при попытке обновиться (пожалуйста, сообщите разработчикам)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>No updates available</source>
         <translation>Обновлений пока что нет</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Check for updates on start</source>
         <translation>Проверять на наличие обновлений при старте</translation>
     </message>

--- a/qrtranslations/ru/qrgui/dialogs_ru.ts
+++ b/qrtranslations/ru/qrgui/dialogs_ru.ts
@@ -4,27 +4,22 @@
 <context>
     <name>AddNodeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="+14"/>
         <source>Node properties</source>
         <translation>Свойства узла</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>name: *</source>
         <translation>Имя: *</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Make it root element of a diagram</source>
         <translation>Сделать корневым элементом диаграммы</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>* Need to be filled</source>
         <translation>* Обязательно для заполнения</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
@@ -32,17 +27,14 @@
 <context>
     <name>ChooseTypeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/chooseTypeDialog.ui" line="+14"/>
         <source>Choose element type</source>
         <translation>Выберите тип создаваемого элемента</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Entity</source>
         <translation>Сущность</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Relationship</source>
         <translation>Связь</translation>
     </message>
@@ -50,12 +42,10 @@
 <context>
     <name>DynamicPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="+35"/>
         <source>Dialog</source>
         <translation>Подпрограмма</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Subprogram name:</source>
         <translation>Имя подпрограммы:</translation>
     </message>
@@ -68,27 +58,22 @@
         <translation type="vanished">Добавить параметр</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Subprogram arguments:</source>
         <translation>Аргументы подпрограммы:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Add Argument</source>
         <translation>Добавить аргумент</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Subprogram picture:</source>
         <translation>Картинка:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Subprogram picture background:</source>
         <translation>Фон:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save All</source>
         <translation>Сохранить все</translation>
     </message>
@@ -96,118 +81,90 @@
 <context>
     <name>EdgePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="+14"/>
         <source>Edge properties</source>
         <translation>Свойства связи</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>name: *</source>
         <translation>Имя: *</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text</source>
         <translation>Метка</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>labelText:</source>
         <translation>Текстовая метка:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>labelType:</source>
         <translation>Тип метки:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Dynamic text</source>
         <translation>Динамическая метка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Static text</source>
         <translation>Статическая метка</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>lineType:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>solidLine</source>
         <translation>Сплошная</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>dashLine</source>
         <translation>Пунктирная</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>dotLine</source>
         <translation>Точечная</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>beginType:</source>
         <translation>Форма начала линии:</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+80"/>
         <source>no_arrow</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>open_arrow</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>empty_arrow</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>filled_arrow</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>empty_rhomb</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-71"/>
-        <location line="+80"/>
         <source>filled_rhomb</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>endType:</source>
         <translation>Форма конца линии:</translation>
     </message>
     <message>
-        <location line="-138"/>
         <source>* Need to be filled</source>
         <translation>* Обязательно для заполнения</translation>
     </message>
     <message>
-        <location line="+230"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
@@ -215,32 +172,26 @@
 <context>
     <name>EditPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Редактирование свойств</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>name: *</source>
         <translation>Имя: *</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>attributeType: *</source>
         <translation>Тип: *</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>defaultValue: </source>
         <translation>Значение:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>* Need to be filled</source>
         <translation>* Обязательно для заполнения</translation>
     </message>
@@ -248,67 +199,54 @@
 <context>
     <name>FindReplaceDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Найти и заменить</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Find what:</source>
         <translation>Искать:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Replace with:</source>
         <translation>Заменить на:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Find</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>by name</source>
         <translation>по имени</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>by type</source>
         <translation>по типу</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>by property</source>
         <translation>по свойствам</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>by property content</source>
         <translation>по содержимому свойств</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>by regular expression</source>
         <translation>используя регулярные выражения</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>case sensitivity</source>
         <translation>чувствительность к регистру</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.cpp" line="+43"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source> / </source>
         <translation> / </translation>
     </message>
@@ -316,27 +254,22 @@
 <context>
     <name>PropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Свойства </translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Change</source>
         <translation>Изменить</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -344,9 +277,6 @@
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="+123"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="+47"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="+47"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
@@ -354,22 +284,18 @@
 <context>
     <name>RestoreElementDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Восстановление элемента</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>In earlier language versions already used the elements with the same name:</source>
         <translation>В ранних версиях языка уже использовались элементы данного типа с таким именем:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Restore</source>
         <translation>Восстановить</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Create New</source>
         <translation>Создать новый</translation>
     </message>
@@ -377,22 +303,18 @@
 <context>
     <name>RestorePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="+14"/>
         <source>Dialog</source>
         <translation>Восстановление свойства</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>In earlier language versions already used the properties with the same name:</source>
         <translation>В ранних версиях языка уже использовались свойства с таким именем:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Restore</source>
         <translation>Восстановить</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Create New</source>
         <translation>Создать новое</translation>
     </message>
@@ -400,32 +322,26 @@
 <context>
     <name>qReal::EditPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="-20"/>
         <source>Warning:</source>
         <translation>Внимание:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You changed the type of property. In case of incorrect conversion it may result in resetting of the existing property value.</source>
         <translation>Вы изменили тип свойства. В случае  некорректного преобразования это может привести к обнулению существующего значения свойства.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Proceed anyway</source>
         <translation>Продолжить все равно</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cancel the type conversion</source>
         <translation>Отменить преобразование типа</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>All required properties should be filled</source>
         <translation>Все обязательные свойства должны быть заполнены</translation>
     </message>
@@ -434,17 +350,14 @@
         <translation type="obsolete">Все обязательные свойства должны быть заполнены!</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Restore properties</source>
         <translation>Восстановление свойств</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add new property</source>
         <translation>Добавление нового свойства</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Properties editor: </source>
         <translation>Редактор свойств: </translation>
     </message>
@@ -463,7 +376,6 @@
 <context>
     <name>qReal::ProgressDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/progressDialog/progressDialog.cpp" line="+26"/>
         <source>Please wait...</source>
         <translation>Ждите...</translation>
     </message>
@@ -471,27 +383,22 @@
 <context>
     <name>qReal::RestoreElementDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="+48"/>
         <source>Existed</source>
         <translation>Используется</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Deleted</source>
         <translation>Удален</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
@@ -499,32 +406,26 @@
 <context>
     <name>qReal::RestorePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="+29"/>
         <source>Property name</source>
         <translation>Имя свойства</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>State</source>
         <translation>Состояние</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Default value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Deleted</source>
         <translation>Удалено</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Existed</source>
         <translation>Используется</translation>
     </message>
@@ -532,7 +433,6 @@
 <context>
     <name>qReal::SuggestToCreateDiagramDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramDialog.cpp" line="+32"/>
         <source>Create diagram</source>
         <translation>Создание диаграммы</translation>
     </message>
@@ -540,12 +440,10 @@
 <context>
     <name>qReal::SuggestToCreateDiagramWidget</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramWidget.cpp" line="+47"/>
         <source>editor: </source>
         <translation>редактор: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>, diagram: </source>
         <translation>, диаграмма: </translation>
     </message>
@@ -553,7 +451,6 @@
 <context>
     <name>qReal::SuggestToCreateProjectDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateProjectDialog.cpp" line="+33"/>
         <source>Create project</source>
         <translation>Создать проект</translation>
     </message>
@@ -561,12 +458,10 @@
 <context>
     <name>qReal::gui::AddNodeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="-1"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>All required properties should be filled</source>
         <translation>Все обязательные свойства должны быть заполнены</translation>
     </message>
@@ -578,64 +473,50 @@
 <context>
     <name>qReal::gui::DynamicPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="+49"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+104"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There is already a subprogram with that name</source>
         <translation>Уже существует подпрограмма с таким именем</translation>
     </message>
     <message>
-        <location line="+187"/>
         <source>Name is not filled in row %1</source>
         <translation>Имя параметра %1 не заполнено</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name should start with a letter(row %1)</source>
         <translation>Имя аргумента должно начинаться с буквы (строка %1)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Value in row %1 is not integer</source>
         <translation>Значение параметра %1 не целое</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value in row %1 is not float</source>
         <translation>Значение параметра %1 не число</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Duplicate names</source>
         <translation>Одинаковые имена</translation>
     </message>
     <message>
-        <location line="-269"/>
-        <location line="+277"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -643,12 +524,10 @@
 <context>
     <name>qReal::gui::EdgePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="-1"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>All required properties should be filled</source>
         <translation>Все обязательные свойства должны быть заполнены</translation>
     </message>
@@ -660,7 +539,6 @@
 <context>
     <name>qReal::gui::PropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.cpp" line="+41"/>
         <source>Properties: </source>
         <translation>Свойства:</translation>
     </message>

--- a/qrtranslations/ru/qrgui/editor_ru.ts
+++ b/qrtranslations/ru/qrgui/editor_ru.ts
@@ -22,32 +22,26 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="+23"/>
         <source>Add connection</source>
         <translation>Добавить провязку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to other</source>
         <translation>Присоединить к другому</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disconnect</source>
         <translation>Убрать провязку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Go to connected element</source>
         <translation>Перейти к присоединенному элементу</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Expand explosion</source>
         <translation>Развернуть эксплозию</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Collapse explosion</source>
         <translation>Свернуть эксплозию</translation>
     </message>
@@ -149,17 +143,14 @@
 <context>
     <name>qReal::gui::editor::BrokenLine</name>
     <message>
-        <location filename="../../../qrgui/editor/private/brokenLine.cpp" line="+24"/>
         <source>Delete point</source>
         <translation>Удалить точку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete segment</source>
         <translation>Удалить отрезок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Remove all points</source>
         <translation>Удалить все точки</translation>
     </message>
@@ -167,12 +158,10 @@
 <context>
     <name>qReal::gui::editor::EdgeElement</name>
     <message>
-        <location filename="../../../qrgui/editor/edgeElement.cpp" line="+62"/>
         <source>Reverse</source>
         <translation>Развернуть</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Change shape type</source>
         <translation>Изменить тип линии</translation>
     </message>
@@ -180,28 +169,22 @@
 <context>
     <name>qReal::gui::editor::EditorViewScene</name>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="+294"/>
         <source>Create new element</source>
         <translation>Создать новый элемент</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location line="+9"/>
         <source>Connect with the current item</source>
         <translation>Соединить с данным элементом</translation>
     </message>
     <message>
-        <location line="+328"/>
         <source>Replace by...</source>
         <translation>Заменить на...</translation>
     </message>
     <message>
-        <location line="+232"/>
         <source>Add child</source>
         <translation>Добавить элемент</translation>
     </message>
     <message>
-        <location line="+492"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -225,17 +208,14 @@
 <context>
     <name>qReal::gui::editor::LineFactory</name>
     <message>
-        <location filename="../../../qrgui/editor/private/lineFactory.cpp" line="+49"/>
         <source>Broken</source>
         <translation>Ломаная</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Square</source>
         <translation>Прямоугольная</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
@@ -243,7 +223,6 @@
 <context>
     <name>qReal::gui::editor::NodeElement</name>
     <message>
-        <location filename="../../../qrgui/editor/nodeElement.cpp" line="+53"/>
         <source>Switch on grid</source>
         <translation>Включить сетку</translation>
     </message>
@@ -251,12 +230,10 @@
 <context>
     <name>qReal::gui::editor::PropertyEditorView</name>
     <message>
-        <location filename="../../../qrgui/editor/propertyEditorView.cpp" line="+305"/>
         <source>Specify directory:</source>
         <translation>Выберите каталог:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select file:</source>
         <translation>Выберите файл:</translation>
     </message>
@@ -264,7 +241,6 @@
 <context>
     <name>qReal::gui::editor::PushButtonPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/editor/private/pushButtonProperty.cpp" line="+38"/>
         <source>Click to choose</source>
         <translation>Кликните для выбора</translation>
     </message>
@@ -272,7 +248,6 @@
 <context>
     <name>qReal::gui::editor::SquareLine</name>
     <message>
-        <location filename="../../../qrgui/editor/private/squareLine.cpp" line="+27"/>
         <source>Lay out</source>
         <translation>Переразложить</translation>
     </message>
@@ -280,24 +255,18 @@
 <context>
     <name>qReal::gui::editor::view::details::ExploserView</name>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="+80"/>
-        <location line="+111"/>
         <source>New </source>
         <translation>Новый </translation>
     </message>
     <message>
-        <location line="-61"/>
-        <location line="+14"/>
         <source>Change Properties</source>
         <translation>Изменить свойства</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Change Appearance</source>
         <translation>Изменить внешний вид</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Add element to palette</source>
         <translation>Добавить элемент в палитру</translation>
     </message>

--- a/qrtranslations/ru/qrgui/hotKeyManager_ru.ts
+++ b/qrtranslations/ru/qrgui/hotKeyManager_ru.ts
@@ -4,12 +4,10 @@
 <context>
     <name>PreferencesHotKeyManagerPage</name>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.cpp" line="+98"/>
         <source>Question</source>
         <translation>Вопрос</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>This will clear all current shortcuts. Are you sure?</source>
         <translation>Все текущие настройки горячих клавиш будут удалены. Продолжить?</translation>
     </message>
@@ -17,67 +15,54 @@
 <context>
     <name>hotKeyManagerPage</name>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="+14"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Keyboard Shortcuts</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Import...</source>
         <translation>Импорт...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Export...</source>
         <translation>Экспорт...</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Command</source>
         <translation>Команда</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Shortcut 1</source>
         <translation>Сочетание 1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Shortcut 2</source>
         <translation>Сочетание 2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Shortcut 3</source>
         <translation>Сочетание 3</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Reset All</source>
         <translation>Очистить все</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Shortcut</source>
         <translation>Сочетание</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Reset</source>
         <translation>Очистить</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Key sequence</source>
         <translation>Введите сочетание клавиш...</translation>
     </message>

--- a/qrtranslations/ru/qrgui/mainWindow_ru.ts
+++ b/qrtranslations/ru/qrgui/mainWindow_ru.ts
@@ -4,12 +4,10 @@
 <context>
     <name>ErrorListWidget</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorListWidget.cpp" line="+60"/>
         <source>Clear</source>
         <translation>Очистить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
@@ -17,52 +15,34 @@
 <context>
     <name>FindManager</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="+39"/>
-        <location line="+42"/>
-        <location line="+1"/>
         <source>by name</source>
         <translation>по имени</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>by type</source>
         <translation>по типу</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>by property</source>
         <translation>по свойствам</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+45"/>
-        <location line="+1"/>
         <source>by property content</source>
         <translation>по содержимому свойств</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+4"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>case sensitivity</source>
         <translation>чувствительность к регистру</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+3"/>
-        <location line="+25"/>
-        <location line="+9"/>
         <source>by regular expression</source>
         <translation>используя регулярные выражения</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>, </source>
         <translation>, </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>   :: </source>
         <translation>   ::    </translation>
     </message>
@@ -70,72 +50,58 @@
 <context>
     <name>MainWindowUi</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="+14"/>
         <source>QReal</source>
         <translation>QReal</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>&amp;File</source>
         <translation>Ф&amp;айл</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&amp;View</source>
         <translation>&amp;Вид</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Panels</source>
         <translation>Панели</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Help</source>
         <translation>&amp;Справка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Settings</source>
         <translation>&amp;Настройки</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Tools</source>
         <translation>&amp;Инструменты</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Edit</source>
         <translation>&amp;Правка</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>File Toolbar</source>
         <translation>Панель инструментов &quot;Файл&quot;</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Mini Map</source>
         <translation>Миникарта</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Palette</source>
         <translation>Палитра</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Edit Toolbar</source>
         <translation>Панель инструментов &quot;Правка&quot;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>View Toolbar</source>
         <translation>Панель инструментов &quot;Вид&quot;</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Logical Model Explorer</source>
         <translation>Обозреватель логической модели</translation>
     </message>
@@ -144,17 +110,14 @@
         <translation type="obsolete">Вывод</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Graphical Model Explorer</source>
         <translation>Обозреватель графической модели</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Property Editor</source>
         <translation>Редактор свойств</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Interpreter Toolbar</source>
         <translation>Панель инструментов &quot;Интерпретатор&quot;</translation>
     </message>
@@ -163,87 +126,70 @@
         <translation type="obsolete">Панель инструментов &quot;Генераторы&quot;</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&amp;Quit</source>
         <translation>В&amp;ыход</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Zoom In</source>
         <translation>Приблизить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl++</source>
         <translation>Ctrl++</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Zoom Out</source>
         <translation>Отдалить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+-</source>
         <translation>Ctrl+-</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Antialiasing</source>
         <translation>Антиалиасинг</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>OpenGL Renderer</source>
         <translation>Рендерер OpenGL</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>Generators Toolbar</source>
         <translation>Панель инструментов &quot;Генераторы&quot;</translation>
     </message>
     <message>
-        <location line="-104"/>
         <source>Errors</source>
         <translation>Ошибки</translation>
     </message>
     <message>
-        <location line="+175"/>
         <source>Export to SVG</source>
         <translation>Экспортировать в SVG</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Open in new tab</source>
         <translation>Открыть в новой вкладке</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Small Help</source>
         <translation>Помощь</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Open Logs</source>
         <translation>Открыть лог-файлы</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>About </source>
         <translation>О программе </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>About Qt...</source>
         <translation></translation>
     </message>
@@ -252,275 +198,218 @@
         <translation type="vanished">Показывать сплешскрин</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Save as...</source>
         <translation>Сохранить как...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Open...</source>
         <translation>Открыть...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Show grid</source>
         <translation>Показать сетку</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch on grid</source>
         <translation>Включить сетку</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Mouse gestures</source>
         <translation>Жесты мышью</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Preferences...</source>
         <translation>Настройки...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Switch on alignment</source>
         <translation>Включить направляющие</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Show alignment</source>
         <translation>Показать направляющие</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Debug</source>
         <translation>Отладка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>F9</source>
         <translation>v</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Generate and build</source>
         <translation>Сгенерировать и собрать</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+F9</source>
         <translation>Ctrl+F9</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+3"/>
         <source>Set breakpoints</source>
         <translation>Точки останова</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+F3</source>
         <translation>Ctrl+F3</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cont</source>
         <translation>Продолжить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+F6</source>
         <translation>Ctrl+F6</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Configure</source>
         <translation>Сконфигурировать</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+F2</source>
         <translation>Ctrl+F2</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>New Diagram</source>
         <translation>Новая диаграмма</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create new diagram in a current model</source>
         <translation>Создать новую диаграмму в текущей модели</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+3"/>
         <source>Fullscreen Mode</source>
         <translation>Полный экран</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+F</source>
         <translation>Ctrl+Shift+F</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>New Project</source>
         <translation>Новый проект</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+N</source>
         <translation>Ctrl+Shift+N</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Import...</source>
         <translation>Импортировать...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Import QReal project into current.</source>
         <translation>Импортировать проект QReal в текущий</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Save diagram as a picture...</source>
         <translation>Сохранить диаграмму как картинку...</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Close project</source>
         <translation>Закрыть проект</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Find...</source>
         <translation>Найти...</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Find and replace</source>
         <translation>Найти и заменить</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Replace by...</source>
         <translation>Заменить на...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Z</source>
         <translation>Ctrl+Z</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Redo</source>
         <translation>Повторить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+Z</source>
         <translation>Ctrl+Shift+Z</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export to XML</source>
         <translation>Экспортировать в XML</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Show all text</source>
         <translation>Показать весь текст</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+T</source>
         <translation>Ctrl+Shift+T</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+3"/>
         <source>Hide bottom docks</source>
         <translation>Спрятать панели в нижней части окна</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Esc</source>
         <translation>Esc</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Restore default settings and Quit</source>
         <translation>Восстановить настройки по-умолчанию и выйти</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Open Examples...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
@@ -528,7 +417,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="+160"/>
         <source>Can`t open project file</source>
         <translation>Не могу открыть проект</translation>
     </message>
@@ -536,7 +424,6 @@
 <context>
     <name>ReferenceList</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/referenceList.ui" line="+14"/>
         <source>Choose a reference value</source>
         <translation>Выберите значение</translation>
     </message>
@@ -544,165 +431,130 @@
 <context>
     <name>ShapeEdit</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="+14"/>
         <source>Form</source>
         <translation>Редактор формы фигур</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Draw ellipse</source>
         <translation>Рисовать эллипс</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Add static text</source>
         <translation>Добавить статический текст</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Add dynamic text</source>
         <translation>Добавить динамический текст</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Save as picture</source>
         <translation>Сохранить как картинку</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Draw curve</source>
         <translation>Рисовать кривую</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Save to Xml</source>
         <translation>Сохранить в Xml</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Family</source>
         <translation>Семейство</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+433"/>
-        <location line="+139"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location line="-551"/>
         <source>Text format</source>
         <translation>Формат текста</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Italic</source>
         <translation>Наклонный</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source> Bold</source>
         <translation>Полужирный</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Underline</source>
         <translation>Подчёркнутый</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Stylus</source>
         <translation>Стилус</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Add line port</source>
         <translation>Добавить линейный порт</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Add point port</source>
         <translation>Добавить точечный порт</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Add picture text</source>
         <translation>Добавить текст-картинку</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Draw rectangle</source>
         <translation>Рисовать прямоугольник</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Pen</source>
         <translation>Перо</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+145"/>
         <source>Style</source>
         <translation>Стиль</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Brush</source>
         <translation>Кисть</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Image</source>
         <translation>Картинка</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Draw line</source>
         <translation>Рисовать линию</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>VisibilityConditions</source>
         <translation>Условия видимости</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Clear</source>
         <translation>Очистить</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Delete Item</source>
         <translation>Удалить элемент</translation>
     </message>
@@ -710,7 +562,6 @@
 <context>
     <name>VisibilityConditionsDialog</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/visibilityConditionsDialog.ui" line="+14"/>
         <source>Specify conditions in which choosen element must be shown</source>
         <translation>Укажите условия, в соответствии с которыми элемент будет отображаться</translation>
     </message>
@@ -745,65 +596,50 @@
         <translation type="vanished">О QReal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="+974"/>
-        <location line="+11"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Plugin unloading failed: </source>
         <translation>Выгрузка плагина завершилась ошибкой: </translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Plugin loading failed: </source>
         <translation>Загрузка плагина завершилась ошибкой: </translation>
     </message>
     <message>
-        <location line="+110"/>
-        <location line="+16"/>
-        <location line="+23"/>
         <source>Shape Editor</source>
         <translation>Редактор формы фигур</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Text Editor</source>
         <translation>Текстовый редактор</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Open project</source>
         <translation>Открыть проект</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Save project</source>
         <translation>Сохранить проект</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save project as</source>
         <translation>Сохранить проект как</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New project</source>
         <translation>Создать проект</translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>New diagram</source>
         <translation>Создать диаграмму</translation>
     </message>
     <message>
-        <location line="-1149"/>
         <source>Restore default settings</source>
         <translation>Восстановить настройки по-умолчанию</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you realy want to restore default settings?
 WARNING: Settings restoring cannot be undone
 WARNING: The settings will be restored after application restart</source>
@@ -812,112 +648,90 @@ WARNING: The settings will be restored after application restart</source>
 ВНИМАНИЕ: Настройки будут сброшены после перезапуска приложения</translation>
     </message>
     <message>
-        <location line="+477"/>
         <source>Could not save file, try to save it to another place</source>
         <translation>Не удалось сохранить файл, попробуйте сохранить его в другое место</translation>
     </message>
     <message>
-        <location line="+676"/>
         <source>Open examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation>Повторить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation>Приблизить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation>Отдалить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close current tab</source>
         <translation>Закрыть текущую вкладку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close all tabs</source>
         <translation>Закрыть все вкладки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find and replace</source>
         <translation>Найти и заменить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all text</source>
         <translation>Показать весь текст</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle errors panel</source>
         <translation>Показать/спрятать панель ошибок</translation>
     </message>
     <message>
-        <location line="+202"/>
         <source>Gestures Show</source>
         <translation>Жесты мышью</translation>
     </message>
     <message>
-        <location line="+340"/>
         <source>Shortcuts</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>External tools</source>
         <translation>Сторонние утилиты</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Failed to open %1</source>
         <translation>Не удалось открыть %1</translation>
     </message>
     <message>
-        <location line="+195"/>
         <source>Recent projects</source>
         <translation>Недавние проекты</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Recent files</source>
         <translation>Недавние файлы</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Изображения (*.png *.jpg)</translation>
     </message>
     <message>
-        <location line="+161"/>
         <source>Getting Started</source>
         <translation>Добро пожаловать!</translation>
     </message>
@@ -1014,57 +828,46 @@ WARNING: The settings will be restored after application restart</source>
 <context>
     <name>qReal::ProjectManagerWrapper</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="-89"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Save</source>
         <translation>&amp;Сохранить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Отмена</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Discard</source>
         <translation>&amp;Не сохранять</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to save current project?</source>
         <translation>Сохранить текущий проект?</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Unsaved project</source>
         <translation>Несохраненный проект</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source> [modified]</source>
         <translation> [изменён]</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Select file to save current metamodel to</source>
         <translation>Выберите файл для сохранения метамодели</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>QReal Save File (*.qrs)</source>
         <translation>Файлы сохранения QReal (*.qrs)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>All files (*.*)</source>
         <translation>Все файлы (*.*)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Файлы сохранения QReal (*.qrs)</translation>
     </message>
@@ -1072,7 +875,6 @@ WARNING: The settings will be restored after application restart</source>
 <context>
     <name>qReal::ShapeEdit</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.cpp" line="+352"/>
         <source>Saving</source>
         <translation>Сохранение</translation>
     </message>
@@ -1084,7 +886,6 @@ WARNING: The settings will be restored after application restart</source>
         <translation type="vanished">Открыть проект</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="+135"/>
         <source>New project</source>
         <translation>Создать проект</translation>
     </message>
@@ -1097,42 +898,34 @@ WARNING: The settings will be restored after application restart</source>
         <translation type="vanished">Создать интерпретируемую диаграмму</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Open project</source>
         <translation>Открыть проект</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Recent projects</source>
         <translation>Недавние проекты</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Create </source>
         <translation>Создать </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Editor: </source>
         <translation>Редактор: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>; Diagram: </source>
         <translation>; Диаграмма: </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select file with metamodel to open</source>
         <translation>Выберите файл метамодели для интерпретации</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Enter the diagram name:</source>
         <translation>Введите имя диаграммы:</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>diagram name:</source>
         <translation>имя диаграммы:</translation>
     </message>
@@ -1140,79 +933,58 @@ WARNING: The settings will be restored after application restart</source>
 <context>
     <name>qReal::gui::DraggableElement</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="+89"/>
         <source>Mouse gesture</source>
         <translation>Жест мышью</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Deleting an element: </source>
         <translation>Удаление элемента: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete this item and all its graphicalrepresentation from the scene and from the palette?</source>
         <translation>Вы действительно хотите удалить данный элемент  и все его графические представления со сцены и из палитры?</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+40"/>
-        <location line="+38"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+40"/>
-        <location line="+38"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location line="-48"/>
-        <location line="+33"/>
         <source>Warning</source>
         <translation>Внимание</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <location line="+33"/>
         <source>The deleted element </source>
         <translation>Удаляемый элемент </translation>
     </message>
     <message>
-        <location line="-32"/>
         <source> is the element of root digram. Continue to delete?</source>
         <translation> является элементом корневой диаграммы. Продолжить удаление?</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source> has inheritors:</source>
         <translation> имеет наследников:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If you delete it, its properties will be removed fromthe elements-inheritors. Continue to delete?</source>
         <translation>Если вы удалите его, то все унаследованные свойства будут удалены у его потомков. Продолжить удаление?</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+29"/>
         <source>Change Properties</source>
         <translation>Изменить свойства</translation>
     </message>
     <message>
-        <location line="-24"/>
         <source>Change Appearance</source>
         <translation>Изменить внешний вид</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Delete Element</source>
         <translation>Удалить элемент</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -1220,22 +992,18 @@ WARNING: The settings will be restored after application restart</source>
 <context>
     <name>qReal::gui::ErrorReporter</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="+215"/>
         <source>INFORMATION:</source>
         <translation>ИНФОРМАЦИЯ:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>WARNING:</source>
         <translation>ПРЕДУПРЕЖДЕНИЕ:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>ERROR:</source>
         <translation>ОШИБКА:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>CRITICAL:</source>
         <translation>КРИТИЧЕСКАЯ ОШИБКА:</translation>
     </message>
@@ -1243,7 +1011,6 @@ WARNING: The settings will be restored after application restart</source>
 <context>
     <name>qReal::gui::ModelExplorer</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/modelExplorer.cpp" line="+35"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -1270,12 +1037,10 @@ WARNING: The settings will be restored after application restart</source>
         <translation type="obsolete">Добавить элемент</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="+157"/>
         <source>Add Entity</source>
         <translation>Добавить сущность</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Relastionship</source>
         <translation>Добавить связь</translation>
     </message>

--- a/qrtranslations/ru/qrgui/models_ru.ts
+++ b/qrtranslations/ru/qrgui/models_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>qReal::gui::RenameDialog</name>
     <message>
-        <location filename="../../../qrgui/models/details/renameDialog.cpp" line="+26"/>
         <source>Enter new name</source>
         <translation>Введите имя</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>qReal::models::details::modelsImplementation::AbstractModel</name>
     <message>
-        <location filename="../../../qrgui/models/details/modelsImplementation/abstractModel.cpp" line="+45"/>
         <source>name</source>
         <translation>имя</translation>
     </message>

--- a/qrtranslations/ru/qrgui/mouseGestures_ru.ts
+++ b/qrtranslations/ru/qrgui/mouseGestures_ru.ts
@@ -4,17 +4,14 @@
 <context>
     <name>GesturesWidget</name>
     <message>
-        <location filename="../../../qrgui/mouseGestures/gesturesWidget.ui" line="+20"/>
         <source>Form</source>
         <translation>Жесты</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List of mouse gestures</source>
         <translation>Список жестов мышью</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Click to see how to draw it:</source>
         <translation>Кликните, чтобы посмотреть, как рисовать жест:</translation>
     </message>

--- a/qrtranslations/ru/qrgui/plugins/metaMetaModel_ru.ts
+++ b/qrtranslations/ru/qrgui/plugins/metaMetaModel_ru.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/metaMetaModel/src/metamodel.cpp" line="+74"/>
         <source>Unknown element %1</source>
         <translation>Неизвестный элемент %1</translation>
     </message>

--- a/qrtranslations/ru/qrgui/plugins/pluginManager_ru.ts
+++ b/qrtranslations/ru/qrgui/plugins/pluginManager_ru.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="+598"/>
         <source>Root node for diagram %1 (which is %2) does not exist!</source>
         <translation>Корневой узел диаграммы %1 (который является %2) не существует!</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Name should contain only latin letters, digits, spaces and underscores and should start with latin letter or underscore</source>
         <translation>Имя должно содержать только латинские буквы, цифры, пробелы и подчёркивания, а также начинаться с латинской буквы или подчёркивания</translation>
     </message>
@@ -32,32 +30,26 @@
 <context>
     <name>qReal::QrsMetamodelLoader</name>
     <message>
-        <location line="-438"/>
         <source>Incorrect label type</source>
         <translation>Некорректный тип метки</translation>
     </message>
     <message>
-        <location line="+433"/>
         <source>Name should not be empty</source>
         <translation>Имя не должно быть пустым</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Port type %1 not declared in metamodel</source>
         <translation>Тип порта %1 не объявлен в метамодели</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Unknown link style type %1</source>
         <translation>Неизвестный тип стиля связи %1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unknown link shape type %1</source>
         <translation>Неизвестный тип формы связи %1</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 is not a valid integer number</source>
         <translation>%1 не является допустимым целым числом</translation>
     </message>
@@ -65,12 +57,10 @@
 <context>
     <name>qReal::QrsMetamodelSaver</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelSaver.cpp" line="+389"/>
         <source>Unknown link style type %1</source>
         <translation>Неизвестный тип стиля связи %1</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Unknown link shape type %1</source>
         <translation>Неизвестный тип формы связи %1</translation>
     </message>

--- a/qrtranslations/ru/qrgui/preferencesDialog_ru.ts
+++ b/qrtranslations/ru/qrgui/preferencesDialog_ru.ts
@@ -4,42 +4,34 @@
 <context>
     <name>PreferencesBehaviourPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="+23"/>
         <source>User Interface</source>
         <translation>Пользовательский интерфейс</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Automatics</source>
         <translation>Автоматизация</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Delay after gesture</source>
         <translation>Задержка после жеста</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Widgets</source>
         <translation>Элементы интерфейса</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Dockable mode</source>
         <translation>Режим плавающих окон</translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>msec</source>
         <translation>мсек</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>sec</source>
         <translation>сек</translation>
     </message>
@@ -48,7 +40,6 @@
         <translation type="vanished">Режӥм юзабилити-тестирования</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Autosave</source>
         <translation>Автосохранение</translation>
     </message>
@@ -57,27 +48,22 @@
         <translation type="vanished">Собирать эргономические показатели системы</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Palette tab switching</source>
         <translation>Переключение табов в палитре</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Gestures</source>
         <translation>Жесты мышью</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Touch</source>
         <translation>Тач</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Touch Mode</source>
         <translation>Режим работы на тач-экране</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.cpp" line="+117"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Системный язык&gt;</translation>
     </message>
@@ -85,17 +71,14 @@
 <context>
     <name>PreferencesDebuggerPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/debuggerPage.ui" line="+9"/>
         <source>Presentation</source>
         <translation>Конфигурация</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Debug timeout (ms):</source>
         <translation>Задержка при отладке:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Color of highlighting:</source>
         <translation>Цвет подсветки:</translation>
     </message>
@@ -103,32 +86,26 @@
 <context>
     <name>PreferencesDialog</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="+32"/>
         <source>Preferences</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Import</source>
         <translation>Импорт</translation>
     </message>
@@ -136,107 +113,86 @@
 <context>
     <name>PreferencesEditorPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="+24"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Use some of system fonts</source>
         <translation>Использовать системный шрифт</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose Font</source>
         <translation>Выбрать шрифт</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Grid</source>
         <translation>Сетка</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show grid</source>
         <translation>Показать сетку</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Activate grid</source>
         <translation>Выравнивание по сетке</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show alignment</source>
         <translation>Показать направляющие</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Activate alignment</source>
         <translation>Выравнивание по направляющим</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Width</source>
         <translation>Толщина сетки</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Cell size</source>
         <translation>Размер ячейки</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Node Elements</source>
         <translation>Элементы</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Drag area</source>
         <translation>Размер области масштабирования</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edge</source>
         <translation>Связи</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>broken</source>
         <translation>Ломаные линии</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>square</source>
         <translation>Прямоугольные линии</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>curve</source>
         <translation>Кривые Безье</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line mode</source>
         <translation>Тип связей</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Loop edges indent</source>
         <translation>Отступ связей-петель</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Embedded Linkers</source>
         <translation>Встроенные линкеры</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Indent</source>
         <translation>Отступ</translation>
     </message>
@@ -257,27 +213,22 @@
         <translation type="vanished">Расстояние от надписей до элемента</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Palette</source>
         <translation>Палитра</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>   Representation   </source>
         <translation>Представление</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>   Count of items in a row </source>
         <translation>Количество иконок в строке</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Icons  and names</source>
         <translation>Иконки и названия</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Icons</source>
         <translation>Иконки</translation>
     </message>
@@ -285,33 +236,26 @@
 <context>
     <name>PreferencesFeaturesPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="+23"/>
         <source>Element controls</source>
         <translation>Управление элементами</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Gestures</source>
         <translation>Жесты</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+7"/>
         <source>fast linking with mouse</source>
         <translation>Быстрое связывание мышью</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Embedded Linkers</source>
         <translation>Встроенные линкеры</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>fast property editing</source>
         <translation>Бвстрое редактирование свойств</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Embedded Controls</source>
         <translation>Встроенные контролы</translation>
     </message>
@@ -319,22 +263,18 @@
 <context>
     <name>PreferencesMiscellaneousPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="+109"/>
         <source>Graphics</source>
         <translation>Графика</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Antialiasing</source>
         <translation>Антиалиасинг</translation>
     </message>
     <message>
-        <location line="+127"/>
         <source>Other</source>
         <translation>Прочее</translation>
     </message>
     <message>
-        <location line="-108"/>
         <source>Show splashscreen</source>
         <translation>Показывать сплешскрин</translation>
     </message>
@@ -347,32 +287,26 @@
         <translation type="vanished">Рисовать старую линию</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Limit recent projects list</source>
         <translation>Длина списка недавних проектов</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Images</source>
         <translation>Изображения</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Browse</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Toolbars</source>
         <translation>Панель инструментов</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Size</source>
         <translation>Размер панели инструментов</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.cpp" line="+57"/>
         <source>Open Directory</source>
         <translation>Выберите директорию</translation>
     </message>
@@ -380,27 +314,22 @@
 <context>
     <name>qReal::gui::PreferencesDialog</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="+58"/>
         <source>Behaviour</source>
         <translation>Поведение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Miscellaneous</source>
         <translation>Разное</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You should restart the program to apply changes</source>
         <translation>Перезапустите программу, чтобы применить изменения</translation>
     </message>
@@ -409,18 +338,14 @@
         <translation type="vanished">Перезапустите программу, чтобы применить изменения</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+11"/>
         <source>*.ini</source>
         <translation>*.ini</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Open File</source>
         <translation>Открыть файл</translation>
     </message>

--- a/qrtranslations/ru/qrgui/systemFacade_ru.ts
+++ b/qrtranslations/ru/qrgui/systemFacade_ru.ts
@@ -4,62 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="+26"/>
         <source>Information:</source>
         <translation>Информация:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning:</source>
         <translation>Предупреждение:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error:</source>
         <translation>Ошибка:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Critical:</source>
         <translation>Критическая ошибка:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bubble:</source>
         <translation>Всплывающее окно:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="+256"/>
         <source>Can`t open project file</source>
         <translation>Не могу открыть проект</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="+114"/>
         <source>Project was automaticly converted from version %1 to version %2. Please check its contents.</source>
         <translation>Проект был автоматически пробразован из версии %1 до версии %2. Пожалуйста, проверьте его содержимое.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>The attempt to automaticly convert this project to the current enviroment version failed and thus save file can`t be opened. </source>
         <translation>Попытка автоматического преобразования проекта до версии среды закончилась неудачно, файл сохранения не может быть открыт. </translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This project was created by version %1 of the editor.</source>
         <translation>Данный проект был создан редактором версии %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This project was created by too old version of the editor.</source>
         <translation>Данный проект был создан редактором слишком старой версии.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source> It is now considered outdated and cannot be opened.</source>
         <translation> Он устарел и не может быть открыт.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The save you are trying to open is made by version %1 of editor, whitch is newer than currently installed enviroment. Update your version before opening this save.</source>
         <translation>Проект был создан версией %1 редактора, которая новее, чем версия данной среды, обновитесь.</translation>
     </message>
@@ -67,18 +55,14 @@
 <context>
     <name>qReal::Autosaver</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="+145"/>
-        <location line="+14"/>
         <source>Question</source>
         <translation>Вопрос</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>More recent autosaved version of this file was found. Do you wish to open it instead?</source>
         <translation>Похоже, что предыдущая сессия была некоррекно завершена. Найдена более свежая автосохраненная версия выбранного проекта. Открыть ее?</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>It seems like the last application session was terminated in an unusual way. Do you wish to recover unsaved project?</source>
         <translation>Похоже, что предыдущая сессия была некоррекно завершена. Открыть несохраненный проект?</translation>
     </message>
@@ -90,61 +74,48 @@
         <translation type="vanished">Открыть проект</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="-180"/>
-        <location line="+14"/>
         <source>Open project</source>
         <translation>Открыть проект</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+7"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Cannot open file, please try with another one.</source>
         <translation>Невозможно открыть файл, пожалуйста, попробуйте другой.</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Select file with a save to import</source>
         <translation>Выберите файл для импорта</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>There are missing plugins</source>
         <translation>Не хватает плагинов</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>These plugins are not present, but needed to load the save:
 </source>
         <translation>Эти плагины отсутствуют, но нужны для загрузки сохранения:
 </translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>This project contains unknown element %1 and thus can`t be opened. Probably it was created by old or incorrectly working version of QReal.</source>
         <translation>Данный проект содержит неизвестный элемент %1 и потому не может быть открыт. Возможно он был создан старой или некорректной версией QReal.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Can`t open project file</source>
         <translation>Не могу открыть проект</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Select file to save current model to</source>
         <translation>Выберите файл для сохранения модели</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>File not found</source>
         <translation>Файл не найден</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>File %1 not found. Try again</source>
         <translation>Файл %1 не найден. Укажите существующий файл</translation>
     </message>

--- a/qrtranslations/ru/qrgui/textEditor_ru.ts
+++ b/qrtranslations/ru/qrgui/textEditor_ru.ts
@@ -4,47 +4,38 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="+91"/>
         <source>Text File</source>
         <translation>Текстовый файл</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>C Language Source File</source>
         <translation>Файл с исходным кодом на C</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Russian Algorithmic Language Source File</source>
         <translation>Файл с исходным кодом на ШАЯ</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Python Source File</source>
         <translation>Файл с исходным кодом на Python</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Java Script Language Source File</source>
         <translation>Файл с исходным кодом на Java Script</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>QtScript Language Source File</source>
         <translation>Файл с исходным кодом на QtScript</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>F# Language Source File</source>
         <translation>Файл с исходным кодом на F#</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>PascalABC Language Source File</source>
         <translation>Исходный файл на языке PascalABC</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Lua Language Source File</source>
         <translation>Исходный файл на языке Lua</translation>
     </message>
@@ -59,7 +50,6 @@
 <context>
     <name>qReal::text::TextManager</name>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="+86"/>
         <source>Confirmation</source>
         <translation>Подтвердите</translation>
     </message>
@@ -68,17 +58,14 @@
         <translation type="vanished">Закрыть без сохранения?</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save before closing?</source>
         <translation>Сохранить перед закрытием?</translation>
     </message>
     <message>
-        <location line="+193"/>
         <source>All files (*)</source>
         <translation>Все файлы (*)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Save generated code</source>
         <translation>Сохранение кода</translation>
     </message>

--- a/qrtranslations/ru/qrgui/thirdparty_ru.ts
+++ b/qrtranslations/ru/qrgui/thirdparty_ru.ts
@@ -4,15 +4,10 @@
 <context>
     <name>QtBoolEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="+233"/>
-        <location line="+10"/>
-        <location line="+25"/>
         <source>true</source>
         <translation>истина</translation>
     </message>
     <message>
-        <location line="-25"/>
-        <location line="+25"/>
         <source>false</source>
         <translation>ложь</translation>
     </message>
@@ -20,12 +15,10 @@
 <context>
     <name>QtBoolPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="+1696"/>
         <source>true</source>
         <translation>истина</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>false</source>
         <translation>ложь</translation>
     </message>
@@ -33,7 +26,6 @@
 <context>
     <name>QtCharEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="+1700"/>
         <source>Clear Char</source>
         <translation>Очистить</translation>
     </message>
@@ -41,7 +33,6 @@
 <context>
     <name>QtColorEditWidget</name>
     <message>
-        <location line="+668"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -49,22 +40,18 @@
 <context>
     <name>QtColorPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="+4799"/>
         <source>Red</source>
         <translation>Красный</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Green</source>
         <translation>Зеленый</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Blue</source>
         <translation>Синий</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Alpha</source>
         <translation>Прозрачность (Альфа)</translation>
     </message>
@@ -72,97 +59,78 @@
 <context>
     <name>QtCursorDatabase</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="-210"/>
         <source>Arrow</source>
         <translation>Стрелка</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Up Arrow</source>
         <translation>Стрелка вверх</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Cross</source>
         <translation>Крест</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wait</source>
         <translation>Ожидание</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>IBeam</source>
         <translation>Курсор в виде буквы I</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size Vertical</source>
         <translation>Изменение размера по вертикали</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size Horizontal</source>
         <translation>Изменение размера по горизонтали</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size Backslash</source>
         <translation>Изменение размера по диагонали (обратный слеш)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size Slash</source>
         <translation>Изменение размера по диагонали (прямой слеш)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Size All</source>
         <translation>Изменение размера во всех направлениях</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Blank</source>
         <translation>Пусто</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Split Vertical</source>
         <translation>Вертикальное разделение</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Split Horizontal</source>
         <translation>Горизонтальное разделение</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pointing Hand</source>
         <translation>Указывающая рука</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Forbidden</source>
         <translation>Запрещено</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Open Hand</source>
         <translation>Открытая рука</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Closed Hand</source>
         <translation>Закрытая рука</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>What&apos;s This</source>
         <translation>Что это такое</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Busy</source>
         <translation>Занято</translation>
     </message>
@@ -170,12 +138,10 @@
 <context>
     <name>QtFontEditWidget</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="+209"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Select Font</source>
         <translation>Выберите шрифт</translation>
     </message>
@@ -183,37 +149,30 @@
 <context>
     <name>QtFontPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="-350"/>
         <source>Family</source>
         <translation>Семейство</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Point Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Bold</source>
         <translation>Жирный</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Italic</source>
         <translation>Курсив</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Underline</source>
         <translation>Подчеркнутый</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Strikeout</source>
         <translation>Перечеркнутый</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Kerning</source>
         <translation>Кернинг</translation>
     </message>
@@ -221,7 +180,6 @@
 <context>
     <name>QtKeySequenceEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="+234"/>
         <source>Clear Shortcut</source>
         <translation>Очистить</translation>
     </message>
@@ -229,17 +187,14 @@
 <context>
     <name>QtLocalePropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="-3608"/>
         <source>%1, %2</source>
         <translation>%1, %2</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Country</source>
         <translation>Страна</translation>
     </message>
@@ -247,17 +202,14 @@
 <context>
     <name>QtPointFPropertyManager</name>
     <message>
-        <location line="+409"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -265,17 +217,14 @@
 <context>
     <name>QtPointPropertyManager</name>
     <message>
-        <location line="-319"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -283,12 +232,10 @@
 <context>
     <name>QtPropertyBrowserUtils</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="-141"/>
         <source>[%1, %2, %3] (%4)</source>
         <translation>[%1, %2, %3] (%4)</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>[%1, %2]</source>
         <translation>[%1, %2]</translation>
     </message>
@@ -296,27 +243,22 @@
 <context>
     <name>QtRectFPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="+1701"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Height</source>
         <translation>Высота</translation>
     </message>
@@ -324,27 +266,22 @@
 <context>
     <name>QtRectPropertyManager</name>
     <message>
-        <location line="-611"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Height</source>
         <translation>Высота</translation>
     </message>
@@ -352,17 +289,14 @@
 <context>
     <name>QtSizeFPropertyManager</name>
     <message>
-        <location line="-534"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Height</source>
         <translation>Высота</translation>
     </message>
@@ -370,33 +304,26 @@
 <context>
     <name>QtSizePolicyPropertyManager</name>
     <message>
-        <location line="+1779"/>
-        <location line="+1"/>
         <source>&lt;Invalid&gt;</source>
         <translation>&lt;Некорректное значение&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[%1, %2, %3, %4]</source>
         <translation>[%1, %2, %3, %4]</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Horizontal Policy</source>
         <translation>Горизонтальная политика</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Vertical Policy</source>
         <translation>Вертикальная политика</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Horizontal Stretch</source>
         <translation>Растяжимость по горизонтали</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Vertical Stretch</source>
         <translation>Растяжимость по вертикали</translation>
     </message>
@@ -404,17 +331,14 @@
 <context>
     <name>QtSizePropertyManager</name>
     <message>
-        <location line="-2355"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Height</source>
         <translation>Высота</translation>
     </message>
@@ -422,12 +346,10 @@
 <context>
     <name>QtTreePropertyBrowser</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="+478"/>
         <source>Property</source>
         <translation>Свойство</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>

--- a/qrtranslations/ru/qrmc_ru.ts
+++ b/qrtranslations/ru/qrmc_ru.ts
@@ -4,19 +4,16 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrmc/main.cpp" line="+26"/>
         <source>QReal Metamodel Compiler. It takes .qrs file with QReal metamodel created by metaeditor and generates Qt project with editor plugin for that metamodel. Project is ready to be built with qmake, but it actively uses QReal sources and build system, so it can not be built alone. Example of command line:
 </source>
         <translation>Компилятор метамоделей QReal. Принимает .qrs-файл с метамоделью QReal, созданной в редакторе метамоделей, и генерирует проект Qt с плагином редактора для этой метамодели. Проект готов к сборке с помощью qmake, но активно использует исходные коды и систему сборки QReal, поэтому не может быть собран отдельно. Пример командной строки:
 </translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Metamodel file to be processed.</source>
         <translation>Файл метамодели, который необходимо обработать.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory to which source code of the editor plugin shall be generated.</source>
         <translation>Каталог, в который будет сгенерирован исходный код плагина редактора.</translation>
     </message>

--- a/qrtranslations/ru/qrtext_ru.ts
+++ b/qrtranslations/ru/qrtext_ru.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/lexer/lexer.h" line="+60"/>
         <source>Invalid regexp: </source>
         <translation>Некорректное регулярное выражение: </translation>
     </message>
     <message>
-        <location line="+111"/>
         <source>Unknown sequence of symbols: </source>
         <translation>Неизвестная последовательность символов: </translation>
     </message>
@@ -22,20 +20,14 @@
         <translation type="vanished">Неожиданный конец файла</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="+40"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/concatenationParser.h" line="+43"/>
         <source>Unexpected end of input</source>
         <translation>Неожиданный конец текста</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Parser can not decide which alternative to use on </source>
         <translation>Синтаксический анализатор не может решить, какую альтернативу использовать в продукции </translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/parser.h" line="+54"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="+11"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/concatenationParser.h" line="+29"/>
         <source>Unexpected token</source>
         <translation>Неожиданная лексема</translation>
     </message>
@@ -44,7 +36,6 @@
         <translation type="vanished">Не удалось вывести тип</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="+68"/>
         <source>Type mismatch</source>
         <translation>Несоответствие типов</translation>
     </message>
@@ -53,17 +44,14 @@
         <translation type="vanished">Не могу вывести тип, это выражение может быть любого типа</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Can not deduce type, expression can be of following types: %1</source>
         <translation>Не могу вывести тип, это выражение может быть следующих типов: %1</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Type mismatch.</source>
         <translation>Несоответствие типов.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="+417"/>
         <source>Explicit table indexes of non-integer type are not supported</source>
         <translation>Явное указание индексов нечисловых типов в таблицах не поддержано</translation>
     </message>
@@ -72,37 +60,26 @@
         <translation type="vanished">Эта переменная только для чтения</translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="+387"/>
         <source>Variable %1 is read-only</source>
         <translation>Переменная %1 только для чтения</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+39"/>
         <source>This construction is not supported by interpreter</source>
         <translation>Конструкция не поддерживается интерпретатором</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Seems like accessing an uninitialized variable %1</source>
         <translation>Обращение к неинициализированной переменной %1</translation>
     </message>
     <message>
-        <location line="+230"/>
         <source>Currently interpreter allows only tables denoted by identifier and by integer expression index, as in &apos;a[1 + 2][3]&apos;</source>
         <translation>Сейчас интерпретатор поддерживает именованные таблицы с целочисленным выражением в качестве индекса, например, &apos;a[1 + 2][3]&apos;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Tables denoted by something other than identifier (like f(x)[0]) are not allowed</source>
         <translation>Разрешены только таблицы, определяемые идентификатором (например, f(x)[0] писать нельзя)</translation>
     </message>
     <message>
-        <location line="+61"/>
-        <location line="+17"/>
-        <location line="+54"/>
-        <location line="+14"/>
         <source>Negative index for a table</source>
         <translation>Отрицательный индекс при обращении к таблице</translation>
     </message>
@@ -111,186 +88,146 @@
         <translation type="vanished">Сейчас интерпретатор поддерживает именованные таблицы с целочисленным выражением в качестве индекса, например, &apos;a[1 + 2] = 3&apos;</translation>
     </message>
     <message>
-        <location line="-274"/>
-        <location line="+10"/>
-        <location line="+13"/>
         <source>Division by zero</source>
         <translation>Деление на 0</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="+158"/>
         <source>node in &apos;stat&apos; semantic action is of unexpected type</source>
         <translation>Узел в семантическом действии &apos;stat&apos; неизвестного типа</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Number of variables in assignment shall be equal to the number of assigned values</source>
         <translation>Количество переменных в выражении присваивания должно совпадать с количеством присваиваемых значений</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Assignment to function call is impossible</source>
         <translation>Присваивание вызову функции невозможно</translation>
     </message>
     <message>
-        <location line="+127"/>
         <source>In &apos;args&apos; semantic action node is of incorrect type</source>
         <translation>Узел в семантическом действии &apos;args&apos; неправильного типа</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>In &apos;table constructor&apos; semantic action fieldList is of incorrect type</source>
         <translation>Узел в семантическом действии &apos;table constructor&apos; неправильного типа</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>In &apos;field&apos; semantic action node is of incorrect type</source>
         <translation>Узел в семантическом действии &apos;field&apos; неправильного типа</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="-6"/>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="-194"/>
         <source>This construction is not supported by semantic analysis</source>
         <translation>Конструкция не поддерживается семантическим анализатором</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="-80"/>
         <source>Intrinsic function used as an identifier</source>
         <translation>Встроенная функция не может использоваться как идентификатор</translation>
     </message>
     <message>
-        <location line="+167"/>
         <source>Incorrect assignment, only variables and tables can be assigned to.</source>
         <translation>Неправильное присваивание, присваивать можно только переменным и таблицам.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Left and right operand have mismatched types.</source>
         <translation>Левый и правый операнд имеют несовпадающие типы.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>An attempt will be made to implicitly cast the right operand to the type &apos;%1&apos;</source>
         <translation>Будет предпринята попытка неявно привести правый операнд к типу &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Indirect function calls are not supported</source>
         <translation>Непрямые вызовы функций не поддержаны</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Unknown function</source>
         <translation>Неизвестная функция</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Too many parameters, %1 expected</source>
         <translation>Слишком много параметров, ожидается %1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Not enough parameters, %1 expected</source>
         <translation>Недостаточно параметров, ожидалось %1</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Undeclared identifier: %1</source>
         <translation>Неизвестная переменная: %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/expressionParser.h" line="+94"/>
         <source>Binary operator in expression is of the wrong type</source>
         <translation>Бинарный оператор в выражении неправильного типа</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Right operand required</source>
         <translation>Правый операнд не найден</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/tokenStream.h" line="+62"/>
         <source>Expected &quot;%1&quot;, got &quot;%2&quot;</source>
         <translation>Ожидалось: &quot;%1&quot;, имеем: &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="+30"/>
         <source>whitespace</source>
         <translation>пробел</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>newline</source>
         <translation>новая строка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>identifier</source>
         <translation>идентификатор</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/string.h" line="+28"/>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="+66"/>
         <source>string</source>
         <translation>строка</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="+5"/>
         <source>integer literal</source>
         <translation>целое число</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>float literal</source>
         <translation>вещественное число</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>comment</source>
         <translation>комментарий</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/types/any.h" line="+28"/>
         <source>any</source>
         <translation>любой</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/boolean.h" line="+28"/>
         <source>boolean</source>
         <translation>логический</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/float.h" line="+28"/>
         <source>float</source>
         <translation>вещественный</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/integer.h" line="+28"/>
         <source>integer</source>
         <translation>целый</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/nil.h" line="+28"/>
         <source>nil</source>
         <translation>нулевой</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/number.h" line="+28"/>
         <source>number</source>
         <translation>число</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/table.h" line="+44"/>
         <source>table[%1]</source>
         <translation>массив[%1]</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/simpleParser.h" line="+51"/>
         <source>Semantic action incorrectly discarded node in SimpleParser</source>
         <translation>Семантическое действие не по делу выкинуло узел в SimpleParser</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/tokenParser.h" line="+52"/>
         <source>Semantic action incorrectly discarded node in TokenParser</source>
         <translation>Семантическое действие не по делу выкинуло узел в TokenParser</translation>
     </message>

--- a/qrtranslations/ru/qrutils_ru.ts
+++ b/qrtranslations/ru/qrutils_ru.ts
@@ -27,72 +27,58 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="+642"/>
         <source>Unexpected end of stream at %1. Mb you forget &apos;;&apos;?</source>
         <translation>Неожиданный конец выражения в позиции %1. Может быть, Вы забыли &apos;;&apos;?</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unexpected symbol at %1 : expected %2, got %3</source>
         <translation>Неожиданный символ в позиции %1 : ожидалось %2, получено %3</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Types mismatch at %1: %2 = %3. Possible loss of data</source>
         <translation>Несовпадение типов в позиции %1: %2 = %3. Возможна потеря данных</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unknown identifier at %1 &apos; %2 &apos;</source>
         <translation>Неизвестный идентификатор в позиции %1: &apos;%2&apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Empty process is unnecessary</source>
         <translation>Пустое выражение</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Condition can&apos;t be empty</source>
         <translation>Условие не может быть пустым</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Using reserved variable %1</source>
         <translation>Использование зарезервированного слова в качестве идентификатора (%1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No value of expression</source>
         <translation>Отсутствует значение выражения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Incorrect variable declaration: use function block for it</source>
         <translation>Некорректное объявление пременной: используйте блок &quot;Функция&quot; для этого</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unexpected symbol after the end of expression</source>
         <translation>Неожиданный символ за концом выражения</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown element property used</source>
         <translation>Неизвестное свойство элемента</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown element name used</source>
         <translation>Неизвестное имя элемента</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Integer division by zero</source>
         <translation>Целичисленное деление на ноль</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphicsUtils/abstractItem.cpp" line="+696"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
@@ -183,23 +169,18 @@
 <context>
     <name>qReal::BaseGraphTransformationUnit</name>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="+48"/>
         <source>no current diagram</source>
         <translation>Откройте диаграмму</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+48"/>
         <source>Rule &apos;</source>
         <translation>Правило &apos;</translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>&apos; has not any appropriate nodes</source>
         <translation>&apos; не имеет подходящих узлов</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>&apos; has unconnected link</source>
         <translation>&apos; содержит неподключенную связь</translation>
     </message>
@@ -207,28 +188,22 @@
 <context>
     <name>qReal::interpretation::Block</name>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="+60"/>
         <source>Control flow break detected, stopping</source>
         <translation>Обнаружен разрыв потока управления, исполнение завершено</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Too many outgoing links</source>
         <translation>Слишком много исходящих связей</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>No outgoing links, please connect this block to something or use Final Node to end program</source>
         <translation>Нет исходящих связей. Пожалуйста, подключите этот блок к чему-нибудь или используйте блок &quot;Конец&quot;, чтобы завершить выполнение программы</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не подключена</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+93"/>
         <source>Block has disappeared!</source>
         <translation>Блок исчез!</translation>
     </message>
@@ -236,22 +211,18 @@
 <context>
     <name>qReal::interpretation::Interpreter</name>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="+55"/>
         <source>Interpreter is already running</source>
         <translation>Программа уже запущена</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Cannot create new thread with already occupied id %1</source>
         <translation>Попытка создать задачу с уже занятым идентификатором %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Threads limit exceeded. Maximum threads count is %1</source>
         <translation>Превышено максимальное число возможных потоков (максимум %1 потоков)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Killing non-existent thread %1</source>
         <translation>Попытка завершить несуществующую задачу %1</translation>
     </message>
@@ -263,17 +234,14 @@
 <context>
     <name>qReal::interpretation::Thread</name>
     <message>
-        <location filename="../../qrutils/interpreter/thread.cpp" line="+117"/>
         <source>No entry point found, please add Initial Node to a diagram</source>
         <translation>Не найдено начало программы. Пожалуйста, добавьте блок &quot;Начало&quot;</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Stack overflow</source>
         <translation>Переполнение стека</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Block has disappeared!</source>
         <translation>Блок исчез!</translation>
     </message>
@@ -281,7 +249,6 @@
 <context>
     <name>qReal::interpretation::blocks::CommentBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/commentBlock.cpp" line="+28"/>
         <source>The comment block with incoming links detected!</source>
         <translation>Блок &quot;Комментарий&quot; не может иметь входящих связей!</translation>
     </message>
@@ -289,17 +256,14 @@
 <context>
     <name>qReal::interpretation::blocks::ForkBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="+43"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не подключена</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Cannot create two threads with the same id %1</source>
         <translation>Невозможно создать две задачи с одинаковыми идентификаторами %1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>There must be a link that has its &apos;Guard&apos; property set to the current thread id %1</source>
         <translation>Должна быть исходящая связь, помеченная идентификатором текущей задачи (%1)</translation>
     </message>
@@ -308,7 +272,6 @@
         <translation type="vanished">Должна быть исходящая связь, используйте блок &quot;Конец&quot;, чтобы закончить программу</translation>
     </message>
     <message>
-        <location line="-33"/>
         <source>There must be at least two outgoing links</source>
         <translation>Должно быть как минимум две исходящие связи</translation>
     </message>
@@ -316,27 +279,22 @@
 <context>
     <name>qReal::interpretation::blocks::IfBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="+36"/>
         <source>There must be exactly TWO links outgoing from if block</source>
         <translation>От условного блока должно отходить ровно ДВЕ связи</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не подключена</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Two links marked with &apos;true&apos; found</source>
         <translation>Обнаружено обе связи помечены условием &apos;Истина&apos;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Two links marked with &apos;false&apos; found</source>
         <translation>Обе связи помечены условием &apos;Ложь&apos;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>There must be at least one link with &quot;true&quot; or &quot;false&quot; marker on it</source>
         <translation>Должна быть как минимум одна связь с маркером &quot;истина&quot; или &quot;ложь&quot;</translation>
     </message>
@@ -348,49 +306,38 @@
 <context>
     <name>qReal::interpretation::blocks::InputBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="+27"/>
         <source>Input</source>
         <translation>Ввод</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Input value for %1:</source>
         <translation>Введите значение для %1:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Only one link with &quot;%1&quot; is allowed</source>
         <translation>Разрешается только одна связь вида &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>One of the outgoing links must be marked with &quot;%1&quot;</source>
         <translation>Одна из исходящих связей должны быть помечена как &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Link to the next statement is missing</source>
         <translation>Не указан следующий блок</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>No outgoing links, please connect this block to something or use Final Node to end program</source>
         <translation>Нет исходящих связей. Пожалуйста, подключите этот блок к чему-нибудь или используйте блок &quot;Конец&quot;, чтобы завершить выполнение программы</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>There should be a maximum of TWO links outgoing from input block</source>
         <translation>От блока ввода должно исходить не более ДВУХ связей</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не подключена</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+4"/>
-        <location line="+7"/>
         <source>cancel</source>
         <translation>отмена</translation>
     </message>
@@ -407,7 +354,6 @@
         <translation type="vanished">Хотя бы одна связь должна быть не с маркером &quot;cancel&quot;</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>You must input some value!</source>
         <translation>Вы должны ввести какое-нибудь значение!</translation>
     </message>
@@ -415,7 +361,6 @@
 <context>
     <name>qReal::interpretation::blocks::JoinBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/joinBlock.cpp" line="+32"/>
         <source>Link outgoing from join block must have surviving thread id in its &apos;Guard&apos; property</source>
         <translation>Связь, исходящая из блока &quot;Слияние задач&quot;, должна быть помечена идентификатором задачи, продолжающей работу после слияния</translation>
     </message>
@@ -423,7 +368,6 @@
 <context>
     <name>qReal::interpretation::blocks::KillThreadBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/killThreadBlock.cpp" line="+24"/>
         <source>Need to specify a thread to be stopped</source>
         <translation>Необходимо указать задачу, которая должна быть остановлена</translation>
     </message>
@@ -435,17 +379,14 @@
         <translation type="vanished">Необходима исходящая из блока связь, в которой в значении свойства &lt;b&gt;Условие&lt;/b&gt; установлено в &lt;b&gt;итерация&lt;/b&gt;. Подробности см. в справке в разделе &lt;i&gt;Создание программ&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="+43"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Из блока &quot;Цикл&quot; должна выходить стрелка с маркером &quot;тело цикла&quot;</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не подключена</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Two links marked as &quot;body&quot; found</source>
         <translation>Найдено две связи, помеченные как &quot;тело цикла&quot;</translation>
     </message>
@@ -454,7 +395,6 @@
         <translation type="vanished">Найдено две связи, помеченные как &quot;итерация&quot;</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>There must be a non-marked outgoing link</source>
         <translation>Должна быть непомеченная исходящая связь</translation>
     </message>
@@ -462,23 +402,18 @@
 <context>
     <name>qReal::interpretation::blocks::PreconditionalLoopBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="+41"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не подключена</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two links marked as &quot;body&quot; found</source>
         <translation>Найдено две связи, помеченные как &quot;тело цикла&quot;</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+7"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Из блока &quot;Цикл&quot; должна выходить стрелка с маркером &quot;тело цикла&quot;</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>There must be a non-marked outgoing link</source>
         <translation>Должна быть непомеченная исходящая связь</translation>
     </message>
@@ -486,7 +421,6 @@
 <context>
     <name>qReal::interpretation::blocks::ReceiveThreadMessageBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/receiveThreadMessageBlock.cpp" line="+25"/>
         <source>Need to specify variable which will contain received message</source>
         <translation>Необходимо указать переменную, которая будет содержать полученное сообщение</translation>
     </message>
@@ -494,7 +428,6 @@
 <context>
     <name>qReal::interpretation::blocks::SendThreadMessageBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/sendThreadMessageBlock.cpp" line="+23"/>
         <source>Need to specify a receiving thread in &apos;Thread&apos; property</source>
         <translation>Необходимо указать задачу-получателя сообщения</translation>
     </message>
@@ -502,7 +435,6 @@
 <context>
     <name>qReal::interpretation::blocks::SubprogramBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/subprogramBlock.cpp" line="+35"/>
         <source>Please enter valid c-style name for subprogram &quot;</source>
         <translation>Укажите корректный идентификатор подпрограммы (в c-стиле)</translation>
     </message>
@@ -510,22 +442,18 @@
 <context>
     <name>qReal::interpretation::blocks::SwitchBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="+36"/>
         <source>There must be at list TWO links outgoing from switch block</source>
         <translation>От блока выбора должно отходить минимум ДВЕ связи</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Outgoing link is not connected</source>
         <translation>Исходящая связь ни к чему не подключена</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>There must be exactly one link without marker on it (default branch)</source>
         <translation>Ветка без маркера должна быть в точности одна (ветка &quot;default&quot;)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>There must be a link without marker on it (default branch)</source>
         <translation>Должна быть связь без маркера (ветка &quot;default&quot;)</translation>
     </message>
@@ -534,7 +462,6 @@
         <translation type="vanished">Связь с пустым свойством &quot;Условие&quot; должна быть только одна (ветка &quot;default&quot;).</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Duplicate case branch: &apos;%1&apos;</source>
         <translation>Найдено более одной ветки &apos;%1&apos;</translation>
     </message>
@@ -546,7 +473,6 @@
 <context>
     <name>qReal::interpretation::blocks::UnsupportedBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/unsupportedBlock.cpp" line="+21"/>
         <source>Block of a type which is unsupported by an interpreter</source>
         <translation>Блок типа, не поддерживаемого в интерпретаторе</translation>
     </message>
@@ -554,12 +480,10 @@
 <context>
     <name>qReal::ui::ColorDialog</name>
     <message>
-        <location filename="../../qrutils/widgets/colorDialog.cpp" line="+34"/>
         <source>Select background color in the 2D-model editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Select the background color of the scene</source>
         <translation type="unfinished"></translation>
     </message>
@@ -567,7 +491,6 @@
 <context>
     <name>qReal::ui::ConsoleDock</name>
     <message>
-        <location filename="../../qrutils/widgets/consoleDock.cpp" line="+50"/>
         <source>Reset shell</source>
         <translation>Очистить консоль</translation>
     </message>
@@ -575,7 +498,6 @@
 <context>
     <name>qReal::ui::DirPicker</name>
     <message>
-        <location filename="../../qrutils/widgets/dirPicker.cpp" line="+33"/>
         <source>Browse...</source>
         <translation>Обзор...</translation>
     </message>
@@ -587,17 +509,14 @@
 <context>
     <name>qReal::ui::ImagePicker</name>
     <message>
-        <location filename="../../qrutils/widgets/imagePicker.cpp" line="+35"/>
         <source>Browse...</source>
         <translation>Обзор...</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Select image</source>
         <translation>Выберите изображение</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Images (*.png *.svg *.jpg *.gif *.bmp);;All files (*.*)</source>
         <translation>Картинки (*.png *.svg *.jpg *.gif *.bmp);;Все файлы (*.*)</translation>
     </message>
@@ -605,27 +524,22 @@
 <context>
     <name>qReal::ui::SearchLineEdit</name>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="+31"/>
         <source>Clear text</source>
         <translation>Очистить текст</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Case insensitive</source>
         <translation>Не учитывать регистр</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Case sensitive</source>
         <translation>Учитывать регистр</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Regular expression</source>
         <translation>Регулярное выражение</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enter search text...</source>
         <translation>Введите текст поиска...</translation>
     </message>
@@ -633,13 +547,10 @@
 <context>
     <name>qReal::ui::SearchLinePanel</name>
     <message>
-        <location filename="../../qrutils/widgets/searchLinePanel.cpp" line="+134"/>
-        <location line="+10"/>
         <source>Enter search text...</source>
         <translation>Введите текст поиска...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&lt;line&gt;:&lt;column&gt;</source>
         <translation>&lt;строка&gt;:&lt;столбец&gt;</translation>
     </message>
@@ -647,22 +558,18 @@
 <context>
     <name>utils::MetamodelGeneratorSupport</name>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="+72"/>
         <source>Please, fill compiler settings</source>
         <translation>Пожалуйста, заполните форму настроек копмилятора в настройках</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot unload plugin</source>
         <translation>Не могу отгрузить плагин</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Cannot load new editor</source>
         <translation>Не могу загрузить новый редактор</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Cannot build new editor</source>
         <translation>Не могу скомпилировать новый редактор. Проверьте имена элементов</translation>
     </message>
@@ -670,97 +577,78 @@
 <context>
     <name>utils::QRealMessageBox</name>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="+30"/>
         <source>Ok</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discard</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation>Помощь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save All</source>
         <translation>Сохранить все</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Yes To All</source>
         <translation>Да для всех</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>No To All</source>
         <translation>Нет для всех</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Abort</source>
         <translation>Остановить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Retry</source>
         <translation>Повторить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ignore</source>
         <translation>Игнорировать</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>NoButton</source>
         <translation>Не кнопка</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Restore Defaults</source>
         <translation>Восстановить по умолчанию</translation>
     </message>
@@ -818,17 +706,14 @@
 <context>
     <name>watchListWindow</name>
     <message>
-        <location filename="../../qrutils/watchListWindow.ui" line="+41"/>
         <source>Watch List</source>
         <translation>Переменные</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/checker/patcher_vi.ts
+++ b/qrtranslations/vi/plugins/robots/checker/patcher_vi.ts
@@ -4,37 +4,30 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="25"/>
         <source>Patcher for save files, replaces world model with contents of a given XML world model</source>
         <translation>Công cụ vá tệp lưu, thay thế mô hình thế giới bằng nội dung của mô hình thế giới XML đã cho</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="38"/>
         <source>TRIK Studio save file to be patched.</source>
         <translation>Tệp lưu TRIK Studio cần được vá.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="40"/>
         <source>XML file with prepared 2D model field. Both world and robot configurations (position + ports) will be patched.</source>
         <translation>Tệp XML với trường mô hình 2D đã chuẩn bị. Cả cấu hình thế giới và robot (vị trí + cổng) sẽ được vá.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="43"/>
         <source>Script file to be patched into save file.</source>
         <translation>Tệp kịch bản cần được vá vào tệp lưu.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="45"/>
         <source>XML file with prepared 2D model field. Only world configurations will be patched.</source>
         <translation>Tệp XML với trường mô hình 2D đã chuẩn bị. Chỉ các cấu hình thế giới sẽ được vá.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="49"/>
         <source>XML file with prepared 2D model field. Only world configurations and robot position will be patched.</source>
         <translation>Tệp XML với trường mô hình 2D đã chuẩn bị. Chỉ các cấu hình thế giới và vị trí robot sẽ được vá.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/patcher/main.cpp" line="53"/>
         <source>Reset robot position to start position</source>
         <translation>Đặt lại vị trí robot về vị trí ban đầu</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/checker/twoDModelRunner_vi.ts
+++ b/qrtranslations/vi/plugins/robots/checker/twoDModelRunner_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="30"/>
         <source>Emulates robot`s behaviour on TRIK Studio 2D model separately from programming environment. Passed .qrs will be interpreted just like when &apos;Run&apos; button was pressed in TRIK Studio. 
 In background mode the session will be terminated just after the execution ended and return code will then contain binary information about program correctness.Example: 
 </source>
@@ -13,82 +12,66 @@ In background mode the session will be terminated just after the execution ended
 </translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="102"/>
         <source>Save file to be interpreted.</source>
         <translation>Tập tin lưu để được thông dịch.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="103"/>
         <source>Run emulation in background.</source>
         <translation>Chạy mô phỏng ở chế độ nền.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="105"/>
         <source>A path to file where checker results will be written (JSON).</source>
         <translation>Đường dẫn đến tập tin nơi ghi kết quả kiểm tra (JSON).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="108"/>
         <source>A path to file where robot`s trajectory will be written. The writing will not be performed not immediately, each trajectory point will be written just when obtained by checker, so FIFOs are recommended to be targets for this option.</source>
         <translation>Đường dẫn đến tập tin nơi ghi quỹ đạo của robot. Việc ghi không diễn ra ngay lập tức, mỗi điểm quỹ đạo sẽ được ghi lại ngay khi bộ kiểm tra thu được, do đó nên sử dụng các tập tin FIFO làm đích cho tùy chọn này.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="112"/>
         <source>Inputs for JavaScript solution.</source>
         <translation>Dữ liệu đầu vào cho giải pháp JavaScript.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="114"/>
         <source>Set to &quot;script&quot; for execution of js/py from the project or set to &quot;diagram&quot; for block diagram.</source>
         <translation>Đặt thành &quot;script&quot; để thực thi tập tin js/py từ dự án hoặc đặt thành &quot;diagram&quot; để thực thi sơ đồ khối.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="118"/>
         <source>Speed factor, try from 5 to 20, or even 1000 (at your own risk!).</source>
         <translation>Hệ số tốc độ, thử từ 5 đến 20, hoặc thậm chí 1000 (tự chịu rủi ro!).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="121"/>
         <source>Close the window and exit if the diagram/script finishes without errors.</source>
         <translation>Đóng cửa sổ và thoát nếu sơ đồ/kịch bản kết thúc mà không có lỗi.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="124"/>
         <source>Close the window and exit after diagram/script finishes.</source>
         <translation>Đóng cửa sổ và thoát sau khi sơ đồ/kịch bản hoàn thành.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="126"/>
         <source>Shows robot&apos;s console.</source>
         <translation>Hiển thị bảng điều khiển của robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="127"/>
         <source>Shows robot&apos;s display.</source>
         <translation>Hiển thị màn hình của robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="129"/>
         <source>The complete file path, including the filename, to save the generated JavaScript or Python code.</source>
         <translation>Đường dẫn đầy đủ đến tập tin, bao gồm tên tập tin, để lưu mã JavaScript hoặc Python được tạo ra.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="132"/>
         <source>Select &quot;python&quot; or &quot;javascript&quot;.</source>
         <translation>Chọn &quot;python&quot; hoặc &quot;javascript&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="135"/>
         <source>The path to the Python or JavaScript file that will be used for interpretation.</source>
         <translation>Đường dẫn đến tập tin Python hoặc JavaScript sẽ được dùng để thông dịch.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="138"/>
         <source>Do not run the interpretation in any mode, this is a parameter that is only used to generate a file.</source>
         <translation>Không thực thi việc thông dịch ở bất kỳ chế độ nào, đây là tham số chỉ dùng để tạo tập tin.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/main.cpp" line="141"/>
         <source>Add a delay in milliseconds after executing the script before closing the window</source>
         <translation>Thêm độ trễ tính bằng mili giây sau khi thực thi kịch bản trước khi đóng cửa sổ</translation>
     </message>
@@ -96,7 +79,6 @@ In background mode the session will be terminated just after the execution ended
 <context>
     <name>twoDModel::Runner</name>
     <message>
-        <location filename="../../../../../plugins/robots/checker/twoDModelRunner/runner.cpp" line="241"/>
         <source>Robot console</source>
         <translation>Bảng điều khiển robot</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/common/ev3Kit_vi.ts
+++ b/qrtranslations/vi/plugins/robots/common/ev3Kit_vi.ts
@@ -4,17 +4,14 @@
 <context>
     <name>ev3::blocks::details::Ev3ReadRGBBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/blocks/details/ev3ReadRGBBlock.cpp" line="43"/>
         <source>Sensor reading should consist of three components</source>
         <translation>Việc đọc cảm biến nên bao gồm ba thành phần</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/blocks/details/ev3ReadRGBBlock.cpp" line="53"/>
         <source>Sensor reading failed</source>
         <translation>Đọc cảm biến thất bại</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/blocks/details/ev3ReadRGBBlock.cpp" line="58"/>
         <source>Color raw sensor is not configured on port %2</source>
         <translation>Cảm biến màu dạng raw chưa được cấu hình ở cổng %2</translation>
     </message>
@@ -22,7 +19,6 @@
 <context>
     <name>ev3::communication::BluetoothRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/bluetoothRobotCommunicationThread.cpp" line="82"/>
         <source>Cannot open port </source>
         <translation>Không thể mở cổng </translation>
     </message>
@@ -30,7 +26,6 @@
 <context>
     <name>ev3::communication::Ev3RobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/ev3RobotCommunicationThread.cpp" line="55"/>
         <source>EV3 limits filename length to %1 characters, but you have %2, please, rename your project.</source>
         <translation>EV3 giới hạn độ dài tên tệp là %1 ký tự, nhưng bạn đang dùng %2 ký tự, vui lòng đổi tên dự án của bạn.</translation>
     </message>
@@ -38,7 +33,6 @@
 <context>
     <name>ev3::communication::UsbRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/src/communication/usbRobotCommunicationThread.cpp" line="99"/>
         <source>Cannot find EV3 device. Check robot connected and turned on and try again.</source>
         <translation>Không thể tìm thấy thiết bị EV3. Hãy kiểm tra xem robot đã được kết nối và bật nguồn chưa, rồi thử lại.</translation>
     </message>
@@ -46,7 +40,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3ACIRSeeker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3ACIRSeeker.h" line="27"/>
         <source>NXT IRSeeker V2 (AC)</source>
         <translation>NXT IRSeeker V2 (AC)</translation>
     </message>
@@ -54,7 +47,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Compass</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Compass.h" line="27"/>
         <source>Compass</source>
         <translation>La bàn</translation>
     </message>
@@ -62,7 +54,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3DCIRSeeker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3DCIRSeeker.h" line="27"/>
         <source>NXT IRSeeker V2 (DC)</source>
         <translation>NXT IRSeeker V2 (DC)</translation>
     </message>
@@ -70,7 +61,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Led</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Led.h" line="53"/>
         <source>LED</source>
         <translation>Điốt phát quang (LED)</translation>
     </message>
@@ -78,7 +68,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3Motor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3Motor.h" line="27"/>
         <source>Motor</source>
         <translation>Động cơ</translation>
     </message>
@@ -86,7 +75,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Color</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Color.h" line="27"/>
         <source>NXT color sensor V2 (color)</source>
         <translation>Cảm biến màu NXT V2 (màu sắc)</translation>
     </message>
@@ -94,7 +82,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Passive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Passive.h" line="27"/>
         <source>NXT color sensor V2 (passive)</source>
         <translation>Cảm biến màu NXT V2 (thụ động)</translation>
     </message>
@@ -102,7 +89,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2RGB</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2RGB.h" line="27"/>
         <source>NXT color sensor V2 (RGB)</source>
         <translation>Cảm biến màu NXT V2 (RGB)</translation>
     </message>
@@ -110,7 +96,6 @@
 <context>
     <name>ev3::robotModel::parts::Ev3NXTColorSensorV2Raw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/ev3Kit/include/ev3Kit/robotModel/parts/ev3NXTColorSensorV2Raw.h" line="27"/>
         <source>NXT color sensor V2 (raw)</source>
         <translation>Cảm biến màu NXT V2 (dạng raw)</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/common/kitBase_vi.ts
+++ b/qrtranslations/vi/plugins/robots/common/kitBase_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/blocksBase/common/deviceBlock.h" line="47"/>
         <source>%1 is not configured.</source>
         <translation>%1 chưa được cấu hình.</translation>
     </message>
@@ -12,17 +11,14 @@
 <context>
     <name>kitBase::DevicesConfigurationWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/devicesConfigurationWidget.cpp" line="103"/>
         <source>%1:</source>
         <translation>%1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/devicesConfigurationWidget.cpp" line="103"/>
         <source>Port %1:</source>
         <translation>Cổng %1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/devicesConfigurationWidget.cpp" line="111"/>
         <source>Unused</source>
         <translation>Không sử dụng</translation>
     </message>
@@ -30,7 +26,6 @@
 <context>
     <name>kitBase::blocksBase::common::WaitForButtonBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/blocksBase/common/waitForButtonBlock.cpp" line="37"/>
         <source>Incorrect button port %1</source>
         <translation>Cổng nút bấm %1 không đúng</translation>
     </message>
@@ -38,7 +33,6 @@
 <context>
     <name>kitBase::blocksBase::common::WaitForSensorBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/src/blocksBase/common/waitForSensorBlock.cpp" line="46"/>
         <source>%1 is not configured on port %2</source>
         <translation>%1 chưa được cấu hình trên cổng %2</translation>
     </message>
@@ -46,7 +40,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::AccelerometerSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/accelerometerSensor.h" line="29"/>
         <source>Accelerometer</source>
         <translation>Cảm biến gia tốc</translation>
     </message>
@@ -54,7 +47,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Button</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/button.h" line="29"/>
         <source>Button</source>
         <translation>Nút bấm</translation>
     </message>
@@ -62,7 +54,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensor.h" line="32"/>
         <source>Color sensor</source>
         <translation>Cảm biến màu</translation>
     </message>
@@ -70,7 +61,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorAmbient</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorAmbient.h" line="29"/>
         <source>EV3 color sensor (ambient)</source>
         <translation>Cảm biến màu EV3 (ánh sáng môi trường)</translation>
     </message>
@@ -78,7 +68,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorBlue</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorBlue.h" line="30"/>
         <source>NXT color sensor (blue)</source>
         <translation>Cảm biến màu NXT (xanh dương)</translation>
     </message>
@@ -86,7 +75,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorFull</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorFull.h" line="33"/>
         <source>NXT / EV3 color sensor (full)</source>
         <translation>Cảm biến màu NXT / EV3 (đầy đủ màu)</translation>
     </message>
@@ -94,7 +82,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorGreen</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorGreen.h" line="30"/>
         <source>NXT color sensor (green)</source>
         <translation>Cảm biến màu NXT (xanh lá)</translation>
     </message>
@@ -102,7 +89,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorPassive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorPassive.h" line="33"/>
         <source>NXT color sensor (passive)</source>
         <translation>Cảm biến màu NXT (thụ động)</translation>
     </message>
@@ -110,7 +96,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorRaw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorRaw.h" line="29"/>
         <source>EV3 color sensor (raw)</source>
         <translation>Cảm biến màu EV3 (thô)</translation>
     </message>
@@ -118,7 +103,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorRed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorRed.h" line="30"/>
         <source>NXT color sensor (red)</source>
         <translation>Cảm biến màu NXT (đỏ)</translation>
     </message>
@@ -126,7 +110,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::ColorSensorReflected</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/colorSensorReflected.h" line="29"/>
         <source>EV3 color sensor (reflected)</source>
         <translation>Cảm biến màu EV3 (phản xạ)</translation>
     </message>
@@ -134,7 +117,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Communicator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/communicator.h" line="29"/>
         <source>Communicator</source>
         <translation>Bộ truyền thông</translation>
     </message>
@@ -142,7 +124,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Display</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/display.h" line="29"/>
         <source>Display</source>
         <translation>Màn hình hiển thị</translation>
     </message>
@@ -150,7 +131,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::EncoderSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/encoderSensor.h" line="29"/>
         <source>Encoder</source>
         <translation>Bộ mã hóa</translation>
     </message>
@@ -158,7 +138,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::GyroscopeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/gyroscopeSensor.h" line="29"/>
         <source>Gyroscope</source>
         <translation>Con quay hồi chuyển</translation>
     </message>
@@ -166,7 +145,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::LidarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lidarSensor.h" line="29"/>
         <source>Lidar</source>
         <translation>Lidar</translation>
     </message>
@@ -174,7 +152,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::LightSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/lightSensor.h" line="29"/>
         <source>Light sensor</source>
         <translation>Cảm biến ánh sáng</translation>
     </message>
@@ -182,7 +159,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Motor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/motor.h" line="29"/>
         <source>Motor</source>
         <translation>Động cơ</translation>
     </message>
@@ -190,7 +166,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::MotorsAggregator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/motorsAggregator.h" line="29"/>
         <source>Motors aggregator</source>
         <translation>Bộ tổng hợp động cơ</translation>
     </message>
@@ -198,7 +173,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Random</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/random.h" line="30"/>
         <source>Random</source>
         <translation>Số ngẫu nhiên</translation>
     </message>
@@ -206,7 +180,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::RangeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/rangeSensor.h" line="30"/>
         <source>Range sensor</source>
         <translation>Cảm biến khoảng cách</translation>
     </message>
@@ -214,7 +187,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Shell</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/shell.h" line="28"/>
         <source>Shell</source>
         <translation>Bảng điều khiển</translation>
     </message>
@@ -222,7 +194,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::SoundSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/soundSensor.h" line="30"/>
         <source>Sound sensor</source>
         <translation>Cảm biến âm thanh</translation>
     </message>
@@ -230,7 +201,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::Speaker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/speaker.h" line="29"/>
         <source>Speaker</source>
         <translation>Loa</translation>
     </message>
@@ -238,7 +208,6 @@
 <context>
     <name>kitBase::robotModel::robotParts::TouchSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/kitBase/include/kitBase/robotModel/robotParts/touchSensor.h" line="30"/>
         <source>Touch sensor</source>
         <translation>Cảm biến chạm</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/common/nxtKit_vi.ts
+++ b/qrtranslations/vi/plugins/robots/common/nxtKit_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>nxt::communication::BluetoothRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/bluetoothRobotCommunicationThread.cpp" line="86"/>
         <source>Cannot open port </source>
         <translation>Không thể mở cổng </translation>
     </message>
@@ -12,32 +11,26 @@
 <context>
     <name>nxt::communication::NxtUsbDriverInstaller</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="54"/>
         <source>Driver for NXT is not installed. An attempt to attach TRIK Studio driver also failed (probably NXT tools package was not installer). No panic! Driver can still be installed manually, see documentation, chapter &quot;Installing NXT driver manually.&quot;. Also TRIK Studio supports &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>Trình điều khiển cho NXT chưa được cài đặt. Việc thử cài đặt trình điều khiển TRIK Studio cũng thất bại (có thể gói công cụ NXT chưa được cài đặt). Đừng lo! Trình điều khiển vẫn có thể được cài đặt thủ công, xem tài liệu, chương &quot;Cài đặt trình điều khiển NXT thủ công&quot;. Ngoài ra, TRIK Studio hỗ trợ &lt;a href=&apos;%1&apos;&gt;trình điều khiển Lego Fantom&lt;/a&gt;, bạn có thể tải về và cài đặt nó.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="63"/>
         <source>Driver installation cancelled. Please note that TRIK Studio also supports official &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>Việc cài đặt trình điều khiển đã bị hủy. Lưu ý rằng TRIK Studio cũng hỗ trợ trình điều khiển chính thức &lt;a href=&apos;%1&apos;&gt;Lego Fantom&lt;/a&gt;, bạn có thể tải về và cài đặt nó.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="91"/>
         <source>An attempt to attach TRIK Studio driver failed. No panic! Driver can be still installed manually, see documentation, chapter &quot;Installing NXT driver manually.&quot;. Also TRIK Studio supports &lt;a href=&apos;%1&apos;&gt;Lego Fantom driver&lt;/a&gt;, you can just download and install it.</source>
         <translation>Việc thử cài đặt trình điều khiển TRIK Studio thất bại. Đừng lo! Trình điều khiển vẫn có thể được cài đặt thủ công, xem tài liệu, chương &quot;Cài đặt trình điều khiển NXT thủ công&quot;. Ngoài ra, TRIK Studio hỗ trợ &lt;a href=&apos;%1&apos;&gt;trình điều khiển Lego Fantom&lt;/a&gt;, bạn có thể tải về và cài đặt nó.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="113"/>
         <source>NXT drivers not found</source>
         <translation>Không tìm thấy trình điều khiển NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="114"/>
         <source>Drivers for LEGO NXT brick are not installed. TRIK Studio can install own drivers to communicate with NXT. Do you want to do it?</source>
         <translation>Trình điều khiển cho khối LEGO NXT chưa được cài đặt. TRIK Studio có thể tự cài đặt trình điều khiển để giao tiếp với NXT. Bạn có muốn thực hiện không?</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/nxtUsbDriverInstaller.cpp" line="116"/>
         <source>TRIK Studio drivers are not officially registered, so two red warning messages will be shown by Windows. Confirm them to proceed installation.</source>
         <translation>Trình điều khiển TRIK Studio chưa được đăng ký chính thức, do đó Windows sẽ hiển thị hai cảnh báo màu đỏ. Hãy xác nhận để tiếp tục cài đặt.</translation>
     </message>
@@ -45,33 +38,26 @@
 <context>
     <name>nxt::communication::UsbRobotCommunicationThread</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="169"/>
         <source>USB Device configuration problem. Try to restart TRIK Studio and re-plug NXT.</source>
         <translation>Lỗi cấu hình thiết bị USB. Hãy thử khởi động lại TRIK Studio và cắm lại thiết bị NXT.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="178"/>
         <source>NXT device is already used by another software.</source>
         <translation>Thiết bị NXT đang được một phần mềm khác sử dụng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="199"/>
         <source>NXT handshake procedure failed. Please contact developers.</source>
         <translation>Thao tác bắt tay với NXT thất bại. Vui lòng thử lại, nếu lỗi này tiếp tục xảy ra, hãy liên hệ với nhà phát triển.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="216"/>
         <source>Cannot find NXT device. Check robot connected and turned on and try again.</source>
         <translation>Không tìm thấy thiết bị NXT. Hãy kiểm tra robot đã được kết nối và bật nguồn, sau đó thử lại.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="252"/>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="271"/>
         <source>Connection to NXT lost</source>
         <translation>Mất kết nối với NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/src/communication/usbRobotCommunicationThread.cpp" line="311"/>
         <source>Cannot find NXT device in resetted mode. Check robot resetted, connected and ticking and try again.</source>
         <translation>Không thể tìm thấy thiết bị NXT ở chế độ cài đặt lại. Hãy kiểm tra robot đã được đặt lại, đã kết nối và đang phát ra âm thanh lặp lại (tíc tíc), sau đó thử lại.</translation>
     </message>
@@ -79,7 +65,6 @@
 <context>
     <name>nxt::robotModel::parts::NxtMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/nxtKit/include/nxtKit/robotModel/parts/nxtMotor.h" line="27"/>
         <source>Motor</source>
         <translation>Động cơ</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/common/trikKit_vi.ts
+++ b/qrtranslations/vi/plugins/robots/common/trikKit_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::blocks::details::WaitForMessageBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/blocks/details/waitForMessageBlock.cpp" line="46"/>
         <source>Device not found for port name CommunicatorPort</source>
         <translation>Không tìm thấy thiết bị cho tên cổng CommunicatorPort</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>trik::blocks::details::WaitGamepadButtonBlock</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/blocks/details/waitGamepadButtonBlock.cpp" line="41"/>
         <source>Incorrect port for gamepad button %1</source>
         <translation>Cổng không đúng cho nút tay cầm điều khiển %1</translation>
     </message>
@@ -20,13 +18,10 @@
 <context>
     <name>trik::robotModel::TrikRobotModelBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="93"/>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="305"/>
         <source>Video 2</source>
         <translation>Video 2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/src/robotModel/trikRobotModelBase.cpp" line="309"/>
         <source>Lidar</source>
         <translation>Lidar</translation>
     </message>
@@ -34,7 +29,6 @@
 <context>
     <name>trik::robotModel::parts::TrikColorSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikColorSensor.h" line="29"/>
         <source>Color Sensor</source>
         <translation>Cảm biến màu</translation>
     </message>
@@ -42,7 +36,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadButton</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadButton.h" line="28"/>
         <source>Android Gamepad Button</source>
         <translation>Nút tay cầm điều khiển Android</translation>
     </message>
@@ -50,7 +43,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadConnectionIndicator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadConnectionIndicator.h" line="28"/>
         <source>Android Gamepad Connection Indicator</source>
         <translation>Chỉ báo kết nối tay cầm điều khiển Android</translation>
     </message>
@@ -58,7 +50,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadPad</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadPad.h" line="29"/>
         <source>Android Gamepad Pad</source>
         <translation>Vùng cảm ứng tay cầm điều khiển Android</translation>
     </message>
@@ -66,7 +57,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadPadPressSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadPadPressSensor.h" line="28"/>
         <source>Android Gamepad Pad as Button</source>
         <translation>Vùng cảm ứng tay cầm điều khiển Android như nút bấm</translation>
     </message>
@@ -74,7 +64,6 @@
 <context>
     <name>trik::robotModel::parts::TrikGamepadWheel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikGamepadWheel.h" line="29"/>
         <source>Android Gamepad Wheel</source>
         <translation>Vô lăng tay cầm điều khiển Android</translation>
     </message>
@@ -82,7 +71,6 @@
 <context>
     <name>trik::robotModel::parts::TrikInfraredSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikInfraredSensor.h" line="27"/>
         <source>Infrared Sensor</source>
         <translation>Cảm biến khoảng cách hồng ngoại</translation>
     </message>
@@ -90,7 +78,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLed.h" line="27"/>
         <source>Led</source>
         <translation>Đèn LED</translation>
     </message>
@@ -98,7 +85,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLightSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLightSensor.h" line="28"/>
         <source>Light sensor</source>
         <translation>Cảm biến ánh sáng</translation>
     </message>
@@ -106,7 +92,6 @@
 <context>
     <name>trik::robotModel::parts::TrikLineSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikLineSensor.h" line="28"/>
         <source>Line Sensor</source>
         <translation>Cảm biến đường line</translation>
     </message>
@@ -114,7 +99,6 @@
 <context>
     <name>trik::robotModel::parts::TrikMotionSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikMotionSensor.h" line="27"/>
         <source>Motion Sensor</source>
         <translation>Cảm biến chuyển động</translation>
     </message>
@@ -122,7 +106,6 @@
 <context>
     <name>trik::robotModel::parts::TrikMotorsAggregator</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikMotorsAggregator.h" line="27"/>
         <source>Trik Motors Aggregator</source>
         <translation>Bộ tổng hợp động cơ Trik</translation>
     </message>
@@ -130,7 +113,6 @@
 <context>
     <name>trik::robotModel::parts::TrikObjectSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikObjectSensor.h" line="28"/>
         <source>Object Sensor</source>
         <translation>Cảm biến vật thể</translation>
     </message>
@@ -138,7 +120,6 @@
 <context>
     <name>trik::robotModel::parts::TrikPowerMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikPowerMotor.h" line="27"/>
         <source>Power Motor</source>
         <translation>Động cơ mạnh</translation>
     </message>
@@ -146,7 +127,6 @@
 <context>
     <name>trik::robotModel::parts::TrikServoMotor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikServoMotor.h" line="27"/>
         <source>Servo Motor</source>
         <translation>Động cơ servo</translation>
     </message>
@@ -154,7 +134,6 @@
 <context>
     <name>trik::robotModel::parts::TrikSonarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikSonarSensor.h" line="27"/>
         <source>Sonic Sensor</source>
         <translation>Cảm biến khoảng cách siêu âm</translation>
     </message>
@@ -162,7 +141,6 @@
 <context>
     <name>trik::robotModel::parts::TrikTouchSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikTouchSensor.h" line="28"/>
         <source>Touch sensor</source>
         <translation>Cảm biến chạm</translation>
     </message>
@@ -170,7 +148,6 @@
 <context>
     <name>trik::robotModel::parts::TrikVideoCamera</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/trikKit/include/trikKit/robotModel/parts/trikVideoCamera.h" line="27"/>
         <source>Video Camera</source>
         <translation>Camera video</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/common/twoDModel_vi.ts
+++ b/qrtranslations/vi/plugins/robots/common/twoDModel_vi.ts
@@ -4,370 +4,290 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/speedPopup.cpp" line="25"/>
         <source>Speed:&amp;nbsp;&amp;nbsp;&lt;b&gt;%1%&lt;/b&gt;</source>
         <translation>Tốc độ:&amp;nbsp;&amp;nbsp;&lt;b&gt;%1%&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/colorFieldItem.cpp" line="52"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="181"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp" line="261"/>
         <source>Remove</source>
         <translation>Xóa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/colorFieldItem.cpp" line="53"/>
         <source>Convert to region</source>
         <translation>Chuyển đổi thành vùng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/colorFieldItem.cpp" line="54"/>
         <source>Bind to region</source>
         <translation>Liên kết với vùng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="182"/>
         <source>Save</source>
         <translation>Lưu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="182"/>
         <source>Edit</source>
         <translation>Chỉnh sửa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="183"/>
         <source>Cancel</source>
         <translation>Hủy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="65"/>
         <source>Root element must be &quot;constraints&quot; tag</source>
         <translation>Phần tử gốc phải là thẻ &quot;constraints&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="102"/>
         <source>There must be a &quot;timelimit&quot; constraint.</source>
         <translation>Phải có ràng buộc &quot;timelimit&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="107"/>
         <source>There must be only one &quot;timelimit&quot; tag.</source>
         <translation>Chỉ được phép có một thẻ &quot;timelimit&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="156"/>
         <source>Event tag must have &quot;condition&quot; or &quot;conditions&quot; child tag. &quot;%1&quot; found instead.</source>
         <translation>Thẻ &quot;event&quot; phải có thẻ con &quot;condition&quot; hoặc &quot;conditions&quot;. Thay vào đó tìm thấy &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="162"/>
         <source>Event tag must have &quot;trigger&quot; or &quot;triggers&quot; child tag. &quot;%1&quot; found instead.</source>
         <translation>Thẻ &quot;event&quot; phải có thẻ con &quot;trigger&quot; hoặc &quot;triggers&quot;. Thay vào đó tìm thấy &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="228"/>
         <source>Program worked for too long time</source>
         <translation>Chương trình chạy quá lâu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="272"/>
         <source>&quot;Glue&quot; attribute must have value &quot;and&quot; or &quot;or&quot;.</source>
         <translation>Thuộc tính &quot;Glue&quot; phải có giá trị là &quot;and&quot; hoặc &quot;or&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="331"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="543"/>
         <source>Unknown tag &quot;%1&quot;.</source>
         <translation>Thẻ không xác định &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="456"/>
         <source>There must be only one tag &quot;return&quot; in &quot;using&quot; expression.</source>
         <translation>Chỉ được phép có một thẻ &quot;return&quot; trong biểu thức &quot;using&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="468"/>
         <source>There must be &quot;return&quot; tag in &quot;using&quot; expression.</source>
         <translation>Phải có thẻ &quot;return&quot; trong biểu thức &quot;using&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="802"/>
         <source>Unknown value &quot;%1&quot;.</source>
         <translation>Giá trị không xác định &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="882"/>
         <source>Invalid integer value &quot;%1&quot;</source>
         <translation>Giá trị số nguyên không hợp lệ &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="896"/>
         <source>Invalid floating point value &quot;%1&quot;</source>
         <translation>Giá trị số thực không hợp lệ &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="909"/>
         <source>Invalid boolean value &quot;%1&quot; (expected &quot;true&quot; or &quot;false&quot;)</source>
         <translation>Giá trị boolean không hợp lệ &quot;%1&quot; (mong đợi &quot;true&quot; hoặc &quot;false&quot;)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="925"/>
         <source>Duplicate id: &quot;%1&quot;</source>
         <translation>ID bị trùng lặp: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="936"/>
         <source>When using the extended form for the %1 tag, the number of arguments starting with _ must be %2, %3 was provided</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="949"/>
         <source>%1 tag must have exactly %2 child tag(s)</source>
         <translation>Thẻ %1 phải có chính xác %2 thẻ con</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="961"/>
         <source>%1 tag must have at least %2 child tag(s)</source>
         <translation>Thẻ %1 phải có ít nhất %2 thẻ con</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="972"/>
         <source>&quot;%1&quot; tag must have &quot;%2&quot; attribute.</source>
         <translation>Thẻ &quot;%1&quot; phải có thuộc tính &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="982"/>
         <source>Expected &quot;%1&quot; tag, got &quot;%2&quot;.</source>
         <translation>Dự kiến thẻ &quot;%1&quot;, nhưng lại nhận được &quot;%2&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/constraintsParser.cpp" line="996"/>
         <source>Attribute &quot;%1&quot; of the tag &quot;%2&quot; must not be empty.</source>
         <translation>Thuộc tính &quot;%1&quot; của thẻ &quot;%2&quot; không được để trống.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="100"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="125"/>
         <source>No such object: %1</source>
         <translation>Không tồn tại đối tượng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="105"/>
         <source>No such region: %1</source>
         <translation>Không tồn tại vùng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="113"/>
         <source>%1 is not a region</source>
         <translation>%1 không phải là một vùng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="169"/>
         <source>%1 has incorrect type for matching it with region</source>
         <translation>%1 có kiểu dữ liệu không phù hợp để so khớp với vùng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="178"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/conditionsFactory.cpp" line="190"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="112"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="124"/>
         <source>No such event: %1</source>
         <translation>Không tồn tại sự kiện: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="94"/>
         <source>Invalid &lt;setState&gt; object type %1</source>
         <translation>Loại đối tượng %1 trong &lt;setState&gt; không hợp lệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/triggersFactory.cpp" line="100"/>
         <source>Object %1 has no property %2</source>
         <translation>Đối tượng %1 không có thuộc tính %2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="64"/>
         <source>Using special syntax with an empty variable name</source>
         <translation>Sử dụng cú pháp đặc biệt với tên biến rỗng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="74"/>
         <source>The name %1 is not a valid variable name or property chain for an object</source>
         <translation>Tên %1 không phải là tên biến hợp lệ hoặc chuỗi thuộc tính của đối tượng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="86"/>
         <source>Requesting variable value with empty name</source>
         <translation>Yêu cầu giá trị biến với tên rỗng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="118"/>
         <source>Object path is empty!</source>
         <translation>Đường dẫn đối tượng trống!</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="249"/>
         <source>Unknown type of object &quot;%1&quot;</source>
         <translation>Không biết kiểu đối tượng &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/details/valuesFactory.cpp" line="256"/>
         <source>Object &quot;%1&quot; has no property &quot;%2&quot;</source>
         <translation>Đối tượng &quot;%1&quot; không có thuộc tính &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="119"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="122"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="125"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="127"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="133"/>
         <source>Pixels</source>
         <translation>Điểm ảnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="134"/>
         <source>Centimeters</source>
         <translation>Xentimét</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="135"/>
         <source>Meters</source>
         <translation>Mét</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/metricSystem.cpp" line="136"/>
         <source>Millimeters</source>
         <translation>Milimét</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="35"/>
         <source>The &amp;lt;template&amp;gt; tag was provided, but the required &quot;name&quot; attribute was missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="45"/>
         <source>Redefinition a template %1 that already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="78"/>
         <source>the &amp;lt;templates&amp;gt; tag can only contain the &amp;lt;template&amp;gt; tag as a child tag, actual %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="31"/>
         <source>The &amp;lt;use&amp;gt; tag must contain a &quot;template&quot; attribute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="37"/>
         <source>Recursive template expansion detected: %1 -&gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="47"/>
         <source>The &amp;lt;use&amp;gt; tag contains a template=%1 attribute that is not the name of a declared template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="71"/>
         <source>After substituting the parameters for the template %1, it did not become a valid xml node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="156"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="171"/>
         <source>line %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesParser.cpp" line="158"/>
         <source>template %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="174"/>
         <source>relative the beginning of the &amp;lt;constraints&amp;gt; tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="177"/>
         <source>relative to the beginning of the %1 template body</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/templatesProcessor.cpp" line="183"/>
         <source>Substitution chain: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="29"/>
         <source>Currently, this method of setting &amp;lt;content&amp;gt; tag for the template %1 is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="47"/>
         <source>When defining the template %1, the syntax %2 was used to substitute an offset %3 for an undeclared parameter %4.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="63"/>
         <source>the &amp;lt;params&amp;gt; tag can only contain the &amp;lt;param&amp;gt; tag as a child tag for template %1, actual tag is &amp;lt;%2&amp;gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="73"/>
         <source>The &amp;lt;param&amp;gt; tag of template %1 was provided, but the required &quot;name&quot; attribute was missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="130"/>
         <source>The &amp;lt;template&amp;gt; of template %1 tag was provided, but the required child tag &amp;lt;content&amp;gt; was missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="143"/>
         <source>The using an undeclared parameter %1 for template %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="170"/>
         <source>The &amp;lt;use&amp;gt; tag can only contain a child tag &amp;lt;with&amp;gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/details/template.cpp" line="210"/>
         <source>The parameter %1 of template %2 has no default value and was not explicitly specified by the user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/templateParserApi.cpp" line="101"/>
         <source>Error while template substitution: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/templates/templateParserApi.cpp" line="110"/>
         <source>Error while parsing template: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/regions/regionItem.cpp" line="262"/>
         <source>Change visibility</source>
         <translation>Thay đổi hiển thị</translation>
     </message>
@@ -375,32 +295,26 @@
 <context>
     <name>TwoDModelWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="14"/>
         <source>2D Robot Model</source>
         <translation>Mô hình robot 2D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="95"/>
         <source>Run program</source>
         <translation>Chạy chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="136"/>
         <source>Stop program</source>
         <translation>Dừng chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="393"/>
         <source>Left wheel:</source>
         <translation>Bánh xe trái:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="403"/>
         <source>Right wheel:</source>
         <translation>Bánh xe phải:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="434"/>
         <source>Metric system units:</source>
         <translation>Đơn vị hệ mét:</translation>
     </message>
@@ -409,95 +323,74 @@
         <translation type="vanished">Số pixel trên 1 cm:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="199"/>
         <source>Edit Regions</source>
         <translation>Chỉnh sửa vùng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="159"/>
         <source>Reset World</source>
         <translation>Đặt lại thế giới</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="448"/>
         <source>Grid size:</source>
         <translation>Kích thước lưới:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="470"/>
         <source>Realistic physics</source>
         <translation>Vật lý thực tế</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="477"/>
         <source>Realistic sensors</source>
         <translation>Cảm biến thực tế</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="484"/>
         <source>Realistic engines</source>
         <translation>Động cơ thực tế</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="543"/>
         <source>Robot height:</source>
         <translation>Chiều cao robot:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="556"/>
         <source>Robot mass:</source>
         <translation>Khối lượng robot:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="569"/>
         <source>Wheel diameter:</source>
         <translation>Đường kính bánh xe:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="620"/>
         <source>Robot track:</source>
         <translation>Chiều rộng cơ sở robot:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="671"/>
         <source>Robot width:</source>
         <translation>Chiều rộng robot:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="678"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="685"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="692"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="706"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="699"/>
         <source>kg</source>
         <translation>kg</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="762"/>
         <source>Decrease speed</source>
         <translation>Giảm tốc độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="803"/>
         <source>Time in 2D model</source>
         <translation>Thời gian trong mô hình 2D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="812"/>
         <source> sec.</source>
         <translation> giây.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="840"/>
         <source>Increase speed</source>
         <translation>Tăng tốc độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.ui" line="948"/>
         <source>px</source>
         <translation>px</translation>
     </message>
@@ -505,17 +398,14 @@
 <context>
     <name>twoDModel::constraints::ConstraintsChecker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="127"/>
         <source>Error while parsing constraints: %1</source>
         <translation>Lỗi khi phân tích cú pháp các ràng buộc: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="133"/>
         <source>Warning while parsing constraints: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/constraints/constraintsChecker.cpp" line="365"/>
         <source>Program has finished, but the task is not accomplished.</source>
         <translation>Chương trình đã kết thúc, nhưng nhiệm vụ chưa hoàn thành.</translation>
     </message>
@@ -523,7 +413,6 @@
 <context>
     <name>twoDModel::engine::TwoDModelEngineFacade</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/twoDModelEngineFacade.cpp" line="207"/>
         <source>Realistic physics&apos; must be turned on to enjoy skittles, cubes and balls</source>
         <translation>Vật lý thực tế phải được bật để tương tác với các vật như cột, khối lập phương và bóng</translation>
     </message>
@@ -531,7 +420,6 @@
 <context>
     <name>twoDModel::items::BallItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/ballItem.cpp" line="54"/>
         <source>Ball (B)</source>
         <translation>Bóng (B)</translation>
     </message>
@@ -539,7 +427,6 @@
 <context>
     <name>twoDModel::items::CommentItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/commentItem.cpp" line="42"/>
         <source>Text (T)</source>
         <translation>Văn bản (T)</translation>
     </message>
@@ -547,7 +434,6 @@
 <context>
     <name>twoDModel::items::CubeItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/cubeItem.cpp" line="62"/>
         <source>Cube (X)</source>
         <translation>Khối lập phương (X)</translation>
     </message>
@@ -555,7 +441,6 @@
 <context>
     <name>twoDModel::items::CurveItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/curveItem.cpp" line="64"/>
         <source>Bezier Curve (Z)</source>
         <translation>Đường cong Bezier (Z)</translation>
     </message>
@@ -563,7 +448,6 @@
 <context>
     <name>twoDModel::items::EllipseItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/ellipseItem.cpp" line="44"/>
         <source>Ellipse (E)</source>
         <translation>Elip (E)</translation>
     </message>
@@ -571,7 +455,6 @@
 <context>
     <name>twoDModel::items::ImageItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/imageItem.cpp" line="80"/>
         <source>Image (I)</source>
         <translation>Hình ảnh (I)</translation>
     </message>
@@ -579,7 +462,6 @@
 <context>
     <name>twoDModel::items::LineItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/lineItem.cpp" line="49"/>
         <source>Line (L)</source>
         <translation>Đường thẳng (L)</translation>
     </message>
@@ -587,7 +469,6 @@
 <context>
     <name>twoDModel::items::RectangleItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/rectangleItem.cpp" line="44"/>
         <source>Rectangle (R)</source>
         <translation>Hình chữ nhật (R)</translation>
     </message>
@@ -595,7 +476,6 @@
 <context>
     <name>twoDModel::items::SkittleItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/skittleItem.cpp" line="54"/>
         <source>Can (C)</source>
         <translation>Lon (C)</translation>
     </message>
@@ -603,7 +483,6 @@
 <context>
     <name>twoDModel::items::StylusItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/stylusItem.cpp" line="62"/>
         <source>Stylus (S)</source>
         <translation>Bút cảm ứng (S)</translation>
     </message>
@@ -611,7 +490,6 @@
 <context>
     <name>twoDModel::items::WallItem</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/items/wallItem.cpp" line="69"/>
         <source>Wall (W)</source>
         <translation>Tường (W)</translation>
     </message>
@@ -619,27 +497,22 @@
 <context>
     <name>twoDModel::model::Model</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="74"/>
         <source>The task was accomplished in %1 sec!</source>
         <translation>Nhiệm vụ đã hoàn thành trong %1 giây!</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="100"/>
         <source>Error in checker: %1</source>
         <translation>Lỗi trong chương trình kiểm tra: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="203"/>
         <source>The &quot;version&quot; field of the &quot;root&quot; tag must not be empty.</source>
         <translation>Trường &quot;version&quot; của thẻ &quot;root&quot; không được để trống.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="209"/>
         <source>The world model has version %1. The current version is %2. Please check that the world model behaves as expected.</source>
         <translation>Mô hình thế giới có phiên bản %1. Phiên bản hiện tại là %2. Vui lòng kiểm tra xem mô hình thế giới có hoạt động như mong đợi hay không.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/model.cpp" line="252"/>
         <source>This robot model already exists</source>
         <translation>Mô hình robot này đã tồn tại</translation>
     </message>
@@ -682,24 +555,14 @@
 <context>
     <name>twoDModel::model::WorldModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="195"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="215"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="234"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="253"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="272"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="291"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="335"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="355"/>
         <source>Trying to add an item with a duplicate id: %1</source>
         <translation>Đang cố thêm một mục với id trùng lặp: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="367"/>
         <source>Incorrect image, please try anouther one</source>
         <translation>Hình ảnh không đúng, vui lòng thử hình khác</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/model/worldModel.cpp" line="910"/>
         <source>Unknown image with imageId %1</source>
         <translation>Hình ảnh không xác định với imageId %1</translation>
     </message>
@@ -707,8 +570,6 @@
 <context>
     <name>twoDModel::robotModel::TwoDRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/robotModel/twoDRobotModel.cpp" line="74"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/robotModel/twoDRobotModel.cpp" line="77"/>
         <source>2D Model</source>
         <translation>Mô hình 2D</translation>
     </message>
@@ -716,7 +577,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorAmbient</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorAmbient.h" line="33"/>
         <source>EV3 color sensor (ambient)</source>
         <translation>Cảm biến màu EV3 (ánh sáng khuếch tán)</translation>
     </message>
@@ -724,7 +584,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorBlue</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorBlue.h" line="36"/>
         <source>Color sensor (blue)</source>
         <translation>Cảm biến màu (xanh dương)</translation>
     </message>
@@ -732,7 +591,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorFull</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorFull.h" line="37"/>
         <source>Color sensor (full)</source>
         <translation>Cảm biến màu (nhận diện màu sắc)</translation>
     </message>
@@ -740,7 +598,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorGreen</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorGreen.h" line="36"/>
         <source>Color sensor (green)</source>
         <translation>Cảm biến màu (xanh lá)</translation>
     </message>
@@ -748,7 +605,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorPassive</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorPassive.h" line="37"/>
         <source>Color sensor (passive)</source>
         <translation>Cảm biến màu (thụ động)</translation>
     </message>
@@ -756,7 +612,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorRaw</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorRaw.h" line="35"/>
         <source>Color sensor (raw)</source>
         <translation>Cảm biến màu (thô)</translation>
     </message>
@@ -764,7 +619,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorRed</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorRed.h" line="36"/>
         <source>Color sensor (red)</source>
         <translation>Cảm biến màu (đỏ)</translation>
     </message>
@@ -772,7 +626,6 @@
 <context>
     <name>twoDModel::robotModel::parts::ColorSensorReflected</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/colorSensorReflected.h" line="33"/>
         <source>EV3 color sensor (reflected)</source>
         <translation>Cảm biến màu EV3 (phản xạ)</translation>
     </message>
@@ -780,7 +633,6 @@
 <context>
     <name>twoDModel::robotModel::parts::Marker</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/include/twoDModel/robotModel/parts/marker.h" line="37"/>
         <source>Marker</source>
         <translation>Con trỏ</translation>
     </message>
@@ -788,42 +640,34 @@
 <context>
     <name>twoDModel::view::ActionsBox</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="26"/>
         <source>Hand dragging mode</source>
         <translation>Chế độ kéo thả bằng tay</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="27"/>
         <source>Multiselection mode</source>
         <translation>Chế độ chọn nhiều mục</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="29"/>
         <source>Save world model...</source>
         <translation>Lưu mô hình thế giới...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="30"/>
         <source>Load world model...</source>
         <translation>Tải mô hình thế giới...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="31"/>
         <source>Load templates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="33"/>
         <source>Load world model without robot configuration...</source>
         <translation>Tải mô hình thế giới mà không có cấu hình robot...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="36"/>
         <source>Clear items</source>
         <translation>Xóa tất cả</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/actionsBox.cpp" line="38"/>
         <source>Clear floor</source>
         <translation>Xóa dấu vết của robot trên sàn</translation>
     </message>
@@ -831,22 +675,18 @@
 <context>
     <name>twoDModel::view::ColorItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="104"/>
         <source>Color</source>
         <translation>Màu sắc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="129"/>
         <source>Disable filling</source>
         <translation>Không tô màu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="129"/>
         <source>Enable filling</source>
         <translation>Tô màu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/colorItemPopup.cpp" line="143"/>
         <source>Thickness</source>
         <translation>Độ dày</translation>
     </message>
@@ -854,32 +694,26 @@
 <context>
     <name>twoDModel::view::DetailsTab</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="38"/>
         <source>Display</source>
         <translation>Màn hình</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="39"/>
         <source>Ports configuration</source>
         <translation>Cổng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="40"/>
         <source>Motors</source>
         <translation>Động cơ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="41"/>
         <source>Physics</source>
         <translation>Vật lý</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="42"/>
         <source>Model parameters</source>
         <translation>Tham số mô hình</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/detailsTab.cpp" line="43"/>
         <source>Metric system</source>
         <translation>Hệ mét</translation>
     </message>
@@ -887,7 +721,6 @@
 <context>
     <name>twoDModel::view::GridParameters</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/gridParameters.cpp" line="34"/>
         <source>Grid</source>
         <translation>Lưới</translation>
     </message>
@@ -895,37 +728,30 @@
 <context>
     <name>twoDModel::view::ImageItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="58"/>
         <source>Image will be packed into save file. Warning: this will increase save file size.</source>
         <translation>Hình ảnh sẽ được nén vào tệp lưu. Cảnh báo: điều này sẽ làm tăng kích thước tệp lưu.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="59"/>
         <source>Image will not be packed into a save file. Warning: if will use save file on other machine or rename file this image will disappear from 2D model.</source>
         <translation>Hình ảnh sẽ không được đưa vào tệp lưu. Cảnh báo: nếu sử dụng tệp lưu trên máy khác hoặc đổi tên tệp, hình ảnh này sẽ biến mất khỏi mô hình 2D.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="66"/>
         <source>The image will be in the background. Warning: the robot does not see this image.</source>
         <translation>Hình ảnh sẽ ở phía sau. Cảnh báo: robot không nhìn thấy hình ảnh này.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="67"/>
         <source>The image will be in the foreground. Warning: robot sees this image with sensors.</source>
         <translation>Hình ảnh sẽ ở phía trước. Cảnh báo: robot nhìn thấy hình ảnh này bằng cảm biến.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="158"/>
         <source>Change image...</source>
         <translation>Thay đổi hình ảnh...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="162"/>
         <source>Select image</source>
         <translation>Chọn hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/imageItemPopup.cpp" line="164"/>
         <source>Graphics (*.*)</source>
         <translation>Đồ họa (*.*)</translation>
     </message>
@@ -933,7 +759,6 @@
 <context>
     <name>twoDModel::view::Palette</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/palette.cpp" line="25"/>
         <source>Cursor (N)</source>
         <translation>Con trỏ (N)</translation>
     </message>
@@ -941,32 +766,26 @@
 <context>
     <name>twoDModel::view::RobotItemPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="78"/>
         <source>Camera folowing robot: %1</source>
         <translation>Camera theo dõi robot: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="79"/>
         <source>enabled</source>
         <translation>bật</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="79"/>
         <source>disabled</source>
         <translation>tắt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="86"/>
         <source>Return robot to the initial position</source>
         <translation>Đưa robot về vị trí ban đầu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="93"/>
         <source>Move start position here</source>
         <translation>Di chuyển vị trí khởi đầu tới đây</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/robotItemPopup.cpp" line="112"/>
         <source>Marker thickness</source>
         <translation>Độ dày con trỏ</translation>
     </message>
@@ -974,7 +793,6 @@
 <context>
     <name>twoDModel::view::SpeedPopup</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/parts/speedPopup.cpp" line="30"/>
         <source>Reset to default</source>
         <translation>Thiết lập lại mặc định</translation>
     </message>
@@ -982,32 +800,26 @@
 <context>
     <name>twoDModel::view::TwoDModelScene</name>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="897"/>
         <source>Select images</source>
         <translation>Chọn hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="899"/>
         <source>Graphics (*.*)</source>
         <translation>Đồ họa (*.*)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="913"/>
         <source>Warning</source>
         <translation>Cảnh báo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="914"/>
         <source>You are trying to load to big image, it may freeze execution for some time. Continue?</source>
         <translation>Bạn đang cố tải một hình ảnh quá lớn, có thể làm chương trình treo trong một thời gian. Tiếp tục?</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="923"/>
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/scene/twoDModelScene.cpp" line="924"/>
         <source>Cannot load %1. Try another file.</source>
         <translation>Không thể tải %1. Hãy thử tệp khác.</translation>
     </message>
@@ -1019,70 +831,54 @@
         <translation type="vanished">cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="193"/>
         <source>kg</source>
         <translation>kg</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="385"/>
         <source>Warning</source>
         <translation>Cảnh báo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="386"/>
         <source>Do you really want to clear scene?</source>
         <translation>Bạn có thực sự muốn xóa toàn bộ cảnh?</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="496"/>
         <source>Training mode: solution will not be checked</source>
         <translation>Chế độ luyện tập: lời giải sẽ không được kiểm tra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="497"/>
         <source>Checking mode: solution will be checked, errors will be reported</source>
         <translation>Chế độ kiểm tra: lời giải sẽ được kiểm tra, các lỗi sẽ được báo cáo</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="560"/>
         <source>Saving world and robot model</source>
         <translation>Đang lưu mô hình thế giới và robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="560"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="580"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="605"/>
         <source>2D model saves (*.xml)</source>
         <translation>Tệp lưu mô hình 2D (*.xml)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="580"/>
         <source>Loading world and robot model</source>
         <translation>Đang tải mô hình thế giới và robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="605"/>
         <source>Loading world without robot model</source>
         <translation>Đang tải mô hình thế giới mà không có mô hình robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="941"/>
         <source>Hide details</source>
         <translation>Ẩn chi tiết</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="941"/>
         <source>Show details</source>
         <translation>Hiển thị chi tiết</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="1152"/>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="1153"/>
         <source>No wheel</source>
         <translation>Không có bánh xe</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/common/twoDModel/src/engine/view/twoDModelWidget.cpp" line="1159"/>
         <source>%1 (port %2)</source>
         <translation>%1 (cổng %2)</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/editor/common_vi.ts
+++ b/qrtranslations/vi/plugins/robots/editor/common_vi.ts
@@ -4,577 +4,422 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="26"/>
         <source>AbstractNode</source>
         <translation>Khối cơ sở</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="61"/>
         <source>Clear Screen</source>
         <translation>Xóa màn hình</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="63"/>
         <source>Clears everything drawn on the robot`s screen.</source>
         <translation>Xóa mọi thứ đã vẽ trên màn hình robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="86"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="926"/>
         <source>Redraw</source>
         <translation>Vẽ lại hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="134"/>
         <source>Comment</source>
         <translation>Ghi chú</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="99"/>
         <source>This block can hold text notes that are ignored by generators and interpreters. Use it for improving the diagram readability.</source>
         <translation>Khối này có thể chứa các ghi chú văn bản mà trình tạo mã và trình thông dịch sẽ bỏ qua. Sử dụng nó để cải thiện tính dễ đọc của sơ đồ.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="134"/>
         <source>Enter some text here...</source>
         <translation>Nhập văn bản tại đây...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="145"/>
         <source>Link</source>
         <translation>Đường nối</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="147"/>
         <source>For creating a link between two elements A and B you can just hover a mouse above A, press the right mouse button and (without releasing it) draw a line to the element B. Alternatively you can just &apos;pull&apos; a link from a small blue circle next to the element.</source>
         <translation>Để tạo liên kết giữa hai phần tử A và B, bạn có thể di chuột lên A, nhấn nút chuột phải và (mà không nhả ra) kéo đường nối đến phần tử B. Hoặc bạn có thể &apos;kéo&apos; một liên kết từ vòng tròn xanh nhỏ bên cạnh phần tử.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="194"/>
         <source>Guard</source>
         <translation>Điều kiện</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="205"/>
         <source>EngineCommand</source>
         <translation>Khối cơ sở điều khiển động cơ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="239"/>
         <source>EngineMovementCommand</source>
         <translation>Khối cơ sở bật động cơ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="263"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="263"/>
         <source>Power (%)</source>
         <translation>Công suất (%)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="274"/>
         <source>End if</source>
         <translation>Kết thúc điều kiện</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="276"/>
         <source>Unites control flow from different condition branches.</source>
         <translation>Gộp các nhánh điều khiển từ các nhánh điều kiện khác nhau.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="309"/>
         <source>Final Node</source>
         <translation>Kết thúc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="311"/>
         <source>The final node of the program. If the program consists of some parallel execution lines the reachment of this block terminates the corresponding execution line. This block can`t have outgoing links.</source>
         <translation>Nút cuối cùng của chương trình. Nếu chương trình gồm nhiều luồng thực thi song song, việc đến được khối này sẽ kết thúc luồng thực thi tương ứng. Khối này không thể có liên kết đi ra.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="344"/>
         <source>Fork</source>
         <translation>Nhiệm vụ song song</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="346"/>
         <source>Separates program execution into a number of threads that will be executed concurrently from the programmers`s point of view. For example in such way signal from sensor and some time interval can be waited synchroniously. This block must have at least two outgoing links. &apos;Guard&apos; property of every link must contain unique thread identifiers, and one of those identifiers must be the same as the identifier of a thread where fork is placed (it must be &apos;main&apos; if it is the first fork in a program.</source>
         <translation>Tách việc thực thi chương trình thành nhiều luồng sẽ được thực hiện đồng thời theo quan điểm của lập trình viên. Ví dụ, theo cách này, có thể đồng thời chờ tín hiệu từ cảm biến và một khoảng thời gian. Khối này phải có ít nhất hai liên kết đi ra. Thuộc tính &apos;Điều kiện&apos; của mỗi liên kết phải chứa các định danh luồng duy nhất, và một trong các định danh đó phải giống với định danh của luồng nơi đặt khối fork (phải là &apos;main&apos; nếu đây là khối fork đầu tiên trong chương trình.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="379"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1297"/>
         <source>Expression</source>
         <translation>Biểu thức</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="381"/>
         <source>Evaluates a value of the given expression. Also new variables can be defined in this block. See the &apos;Expressions Syntax&apos; chapter in help for more information about &apos;Function&apos; block syntax.</source>
         <translation>Tính giá trị của biểu thức đã cho. Cũng có thể định nghĩa các biến mới trong khối này. Xem chương &apos;Cú pháp biểu thức&apos; trong phần trợ giúp để biết thêm thông tin về cú pháp khối &apos;Hàm&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="388"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1273"/>
         <source>Expression:</source>
         <translation>Biểu thức:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="424"/>
         <source>Get Button Code</source>
         <translation>Lấy mã nút bấm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="426"/>
         <source>Assigns a given variable a value of pressed button. If no button is pressed at the moment and &apos;Wait&apos; property is false when variable is set to -1.</source>
         <translation>Gán cho biến đã cho giá trị của nút bấm được nhấn. Nếu không có nút nào được nhấn tại thời điểm đó và thuộc tính &apos;Đợi&apos; là sai thì biến sẽ được đặt thành -1.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="433"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="574"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="948"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1010"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1371"/>
         <source>Variable:</source>
         <translation>Biến:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="441"/>
         <source>Wait:</source>
         <translation>Đợi nhấn:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="465"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="616"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="990"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1297"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1404"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="465"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="616"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="990"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1404"/>
         <source>Variable</source>
         <translation>Biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="466"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="137"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="138"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="139"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="140"/>
         <source>Wait</source>
         <translation>Chờ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="477"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="511"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="864"/>
         <source>Condition</source>
         <translation>Điều kiện</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="479"/>
         <source>Separates program execution in correspondece with the given condition. The &apos;Condition&apos; parameter value must be some boolean expression that will determine subsequent program execution line. This block must have two outgoing links, at least one of them must have &apos;Guard&apos; parameter set to &apos;true&apos; or &apos;false&apos;. The execution will be proceed trough the link marked with the guard corresponding to &apos;Condition&apos; parameter of the block.</source>
         <translation>Tách việc thực thi chương trình theo điều kiện đã cho. Giá trị tham số &apos;Điều kiện&apos; phải là một biểu thức logic sẽ xác định luồng thực thi tiếp theo của chương trình. Khối này phải có hai liên kết đi ra, ít nhất một trong số đó phải có tham số &apos;Điều kiện&apos; được đặt là &apos;đúng&apos; hoặc &apos;sai&apos;. Việc thực thi sẽ tiếp tục qua liên kết được đánh dấu bằng điều kiện tương ứng với tham số &apos;Điều kiện&apos; của khối.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="486"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="840"/>
         <source>Condition:</source>
         <translation>Điều kiện:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="511"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="864"/>
         <source>x &gt; 0</source>
         <translation>x &gt; 0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="522"/>
         <source>Initial Node</source>
         <translation>Bắt đầu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="524"/>
         <source>The entry point of the program execution. Each diagram should have only one such block, it must not have incomming links and it must have only one outgoing link. The interpretation process starts from exactly this block.</source>
         <translation>Điểm khởi đầu của chương trình. Mỗi sơ đồ chỉ nên có một khối như vậy, không được có liên kết đi vào và chỉ được có một liên kết đi ra. Quá trình thông dịch bắt đầu chính xác từ khối này.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="565"/>
         <source>User Input</source>
         <translation>Nhập từ người dùng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="567"/>
         <source>Reads a value into variable from an input dialog.</source>
         <translation>Đọc một giá trị vào biến từ hộp thoại nhập liệu.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="582"/>
         <source>Default:</source>
         <translation>Mặc định:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="590"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="900"/>
         <source>Text:</source>
         <translation>Văn bản:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="627"/>
         <source>Join</source>
         <translation>Gộp nhiệm vụ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="629"/>
         <source>Joins a number of threads into one. &apos;Guard&apos; property of the single outgoing link must contain an identifier of one of threads being joined. The specified thread would wait until the rest of them finish execution, and then proceed in a normal way.</source>
         <translation>Gộp nhiều luồng thành một. Thuộc tính &apos;Điều kiện&apos; của liên kết đi ra duy nhất phải chứa định danh của một trong các luồng đang được gộp. Luồng được chỉ định sẽ chờ cho đến khi các luồng còn lại hoàn thành thực thi, sau đó tiếp tục theo cách thông thường.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="662"/>
         <source>Kill Thread</source>
         <translation>Kết thúc nhiệm vụ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="664"/>
         <source>Terminates execution of a specified thread.</source>
         <translation>Kết thúc việc thực thi một luồng đã chỉ định.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="671"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1121"/>
         <source>Thread:</source>
         <translation>Nhiệm vụ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="695"/>
         <source>main</source>
         <translation>main</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="695"/>
         <source>Thread</source>
         <translation>Nhiệm vụ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="706"/>
         <source>Loop</source>
         <translation>Vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="708"/>
         <source>This block executes a sequence of blocks for a given number of times. The number of repetitions is specified by the &apos;Iterations&apos; parameter. This block must have two outgoing links. One of them must be marked with the &apos;body&apos; guard (that means that the property &apos;Guard&apos; of the link must be set to &apos;body&apos; value). Another outgoing link must be unmarked: the program execution will be proceeded through this link when it will go through our &apos;Loop&apos; block for the given number of times.</source>
         <translation>Khối này thực thi một dãy khối một số lần nhất định. Số lần lặp được xác định bởi tham số &apos;Số lần lặp&apos;. Khối này phải có hai liên kết đi ra. Một trong số đó phải được đánh dấu bằng điều kiện &apos;body&apos; (có nghĩa là thuộc tính &apos;Điều kiện&apos; của liên kết phải được đặt thành giá trị &apos;body&apos;). Liên kết đi ra còn lại phải không đánh dấu: chương trình sẽ tiếp tục thực thi qua liên kết này khi đã đi qua khối &apos;Vòng lặp&apos; đủ số lần quy định.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="715"/>
         <source>Iterations:</source>
         <translation>Số lần lặp:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="741"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="989"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="741"/>
         <source>Iterations</source>
         <translation>Số lần lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="752"/>
         <source>Marker Down</source>
         <translation>Hạ bút</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="754"/>
         <source>Moves the marker of the 2D model robot down to the floor: the robot will draw its trace on the floor after that. If the marker of another color is already drawing at the moment it will be replaced.</source>
         <translation>Hạ bút vẽ của robot mô hình 2D xuống sàn: robot sẽ bắt đầu vẽ quỹ đạo của nó trên sàn. Nếu bút vẽ màu khác đang vẽ, nó sẽ bị thay thế.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="761"/>
         <source>Color:</source>
         <translation>Màu:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="785"/>
         <source>Color</source>
         <translation>Màu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="796"/>
         <source>Marker Up</source>
         <translation>Nhấc bút</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="798"/>
         <source>Lifts the marker of the 2D model robot up: the robot stops drawing its trace on the floor after that.</source>
         <translation>Nhấc bút vẽ của robot mô hình 2D lên: robot sẽ ngừng vẽ quỹ đạo của nó trên sàn.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="831"/>
         <source>Pre-conditional Loop</source>
         <translation>Vòng lặp với điều kiện trước</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="833"/>
         <source>This block executes a sequence of blocks while condition in &apos;Condition&apos; is true. This block must have two outgoing links. One of them must be marked with the &apos;body&apos; guard (that means that the property &apos;Guard&apos; of the link must be set to &apos;body&apos; value). Another outgoing link must be unmarked: the program execution will be proceeded through this link when condition becomes false.</source>
         <translation>Khối này thực thi một dãy khối trong khi điều kiện trong &apos;Điều kiện&apos; là đúng. Khối này phải có hai liên kết đi ra. Một trong số đó phải được đánh dấu bằng điều kiện &apos;body&apos; (có nghĩa là thuộc tính &apos;Điều kiện&apos; của liên kết phải được đặt thành giá trị &apos;body&apos;). Liên kết đi ra còn lại phải không đánh dấu: chương trình sẽ tiếp tục thực thi qua liên kết này khi điều kiện trở thành sai.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="875"/>
         <source>Print Text</source>
         <translation>In văn bản</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="877"/>
         <source>Prints a given line in the specified coordinates on the robot`s screen. The value of &apos;Text&apos; property is interpreted as a plain text unless &apos;Evaluate&apos; property is set to true, then it will be interpreted as an expression (that may be useful for example when debugging variables values).</source>
         <translation>In một dòng văn bản đã cho tại tọa độ chỉ định trên màn hình robot. Giá trị thuộc tính &apos;Văn bản&apos; được hiểu là văn bản thuần túy trừ khi thuộc tính &apos;Đánh giá&apos; được đặt là đúng, khi đó nó sẽ được hiểu là một biểu thức (có thể hữu ích ví dụ khi gỡ lỗi giá trị biến).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="884"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="892"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="924"/>
         <source>Evaluate</source>
         <translation>Đánh giá</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="925"/>
         <source>Enter some text here</source>
         <translation>Nhập văn bản tại đây</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="925"/>
         <source>Text</source>
         <translation>Văn bản</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="927"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="928"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="927"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="928"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="939"/>
         <source>Random Initialization</source>
         <translation>Khởi tạo ngẫu nhiên</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="941"/>
         <source>Sets a variable value to a random value inside given interval.</source>
         <translation>Gán một giá trị ngẫu nhiên trong khoảng đã cho cho biến.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="956"/>
         <source>From:</source>
         <translation>Từ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="964"/>
         <source>To:</source>
         <translation>Đến:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="988"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1403"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="988"/>
         <source>From</source>
         <translation>Từ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="989"/>
         <source>To</source>
         <translation>Đến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1001"/>
         <source>Receive Message From Thread</source>
         <translation>Nhận tin nhắn từ luồng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1003"/>
         <source>Receive a message sent to a thread from which this block is called.</source>
         <translation>Nhận tin nhắn được gửi đến luồng mà khối này được gọi từ đó.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1018"/>
         <source>Synchronized:</source>
         <translation>Đồng bộ hóa:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1042"/>
         <source>Synchronized</source>
         <translation>Đồng bộ hóa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1054"/>
         <source>RobotsDiagramGroup</source>
         <translation>Biểu đồ hành vi robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1069"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="111"/>
         <source>Robot`s Behaviour Diagram</source>
         <translation>Biểu đồ hành vi robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1112"/>
         <source>Send Message To Thread</source>
         <translation>Gửi tin nhắn đến luồng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1114"/>
         <source>Sends a message to a specified thread.</source>
         <translation>Gửi một tin nhắn đến luồng đã chỉ định.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1129"/>
         <source>Message:</source>
         <translation>Tin nhắn:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1165"/>
         <source>Subprogram</source>
         <translation>Chương trình con</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1167"/>
         <source>Subprogram call. Subprograms are used for splitting repetitive program parts into a separate diagram and then calling it from main diagram or other subprograms. When this block is added into a diagram it will be suggested to enter subprogram name. The double click on subprogram call block may open the corresponding subprogram diagram. Moreover user palette will appear containing existing subrpograms, they can be dragged into a diagram like the usual blocks.</source>
         <translation>Gọi chương trình con. Các chương trình con được dùng để tách các phần chương trình lặp lại thành một biểu đồ riêng, sau đó gọi từ biểu đồ chính hoặc các chương trình con khác. Khi khối này được thêm vào biểu đồ, người dùng sẽ được yêu cầu nhập tên chương trình con. Nhấp đúp vào khối gọi chương trình con có thể mở biểu đồ chương trình con tương ứng. Ngoài ra, bảng chọn người dùng sẽ xuất hiện chứa các chương trình con hiện có, có thể kéo thả chúng vào biểu đồ như các khối thông thường.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1207"/>
         <source>Subprogram Diagram</source>
         <translation>Biểu đồ chương trình con</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1249"/>
         <source>SubprogramDiagramGroup</source>
         <translation>Chương trình con</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1264"/>
         <source>Switch</source>
         <translation>Lựa chọn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1266"/>
         <source>Selects the program execution branch in correspondence with some expression value. The value of the expression written in &apos;Expression&apos; property is compared to the values on the outgoing links. If equal value is found then execution will be proceeded by that branch. Else branch without a marker will be selected.</source>
         <translation>Chọn nhánh thực thi chương trình tương ứng với giá trị của một biểu thức. Giá trị của biểu thức trong thuộc tính &apos;Biểu thức&apos; sẽ được so sánh với các giá trị trên các liên kết đi ra. Nếu tìm thấy giá trị bằng nhau, chương trình sẽ tiếp tục theo nhánh đó. Nếu không, nhánh không có nhãn sẽ được chọn.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1308"/>
         <source>Timer</source>
         <translation>Bộ đếm thời gian</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1310"/>
         <source>Waits for a given time in milliseconds.</source>
         <translation>Chờ trong khoảng thời gian đã cho tính bằng mili giây.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1317"/>
         <source>Delay:</source>
         <translation>Độ trễ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1318"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1351"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1351"/>
         <source>Delay (ms)</source>
         <translation>Độ trễ (ms)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1362"/>
         <source>Variable Initialization</source>
         <translation>Khởi tạo biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1364"/>
         <source>Assigns a given value to a given variable.</source>
         <translation>Gán một giá trị đã cho cho một biến đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1379"/>
         <source>Value:</source>
         <translation>Giá trị:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1403"/>
         <source>Value</source>
         <translation>Giá trị</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="118"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="119"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="120"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="121"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="122"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="123"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="124"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="125"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="126"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="127"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="128"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="129"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="130"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="131"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="132"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="133"/>
         <source>Algorithms</source>
         <translation>Thuật toán</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="134"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="135"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="136"/>
         <source>Actions</source>
         <translation>Hành động</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="141"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="143"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="144"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="145"/>
         <source>Drawing</source>
         <translation>Vẽ</translation>
     </message>
@@ -582,37 +427,30 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="413"/>
         <source>Expression</source>
         <translation>Biểu thức</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="614"/>
         <source>Default</source>
         <translation>Mặc định</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="615"/>
         <source>Text</source>
         <translation>Văn bản</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1043"/>
         <source>Variable</source>
         <translation>Biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1101"/>
         <source>Devices configuration</source>
         <translation>Cấu hình thiết bị</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1153"/>
         <source>Message</source>
         <translation>Tin nhắn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/elements.h" line="1154"/>
         <source>Thread</source>
         <translation>Nhiệm vụ</translation>
     </message>
@@ -620,169 +458,134 @@
 <context>
     <name>RobotsMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="159"/>
         <source>norm</source>
         <translation>chuẩn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="159"/>
         <source>x-axis</source>
         <translation>trục x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="159"/>
         <source>y-axis</source>
         <translation>trục y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="159"/>
         <source>z-axis</source>
         <translation>trục z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="161"/>
         <source>Composite</source>
         <translation>Hợp thành</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="161"/>
         <source>None</source>
         <translation>Không có</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="161"/>
         <source>Shared</source>
         <translation>Chung</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="163"/>
         <source>brake</source>
         <translation>phanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="163"/>
         <source>float</source>
         <translation>trôi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="165"/>
         <source>Concurrent</source>
         <translation>Đồng thời</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="165"/>
         <source>Guarded</source>
         <translation>Được bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="165"/>
         <source>Sequential</source>
         <translation>Tuần tự</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>black</source>
         <translation>đen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>blue</source>
         <translation>xanh dương</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>green</source>
         <translation>xanh lá</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>red</source>
         <translation>đỏ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>white</source>
         <translation>trắng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="167"/>
         <source>yellow</source>
         <translation>vàng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="169"/>
         <source>greater</source>
         <translation>lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="169"/>
         <source>less</source>
         <translation>nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="169"/>
         <source>not greater</source>
         <translation>không lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="169"/>
         <source>not less</source>
         <translation>không nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="171"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="177"/>
         <source>false</source>
         <translation>sai</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="171"/>
         <source>body</source>
         <translation>thân vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="171"/>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="177"/>
         <source>true</source>
         <translation>đúng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="173"/>
         <source>In</source>
         <translation>Đầu vào</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="173"/>
         <source>Inout</source>
         <translation>Đầu vào - đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="173"/>
         <source>Out</source>
         <translation>Đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="173"/>
         <source>Return</source>
         <translation>Trả về</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="175"/>
         <source>Package</source>
         <translation>Gói</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="175"/>
         <source>Private</source>
         <translation>Riêng tư</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="175"/>
         <source>Protected</source>
         <translation>Được bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/common/generated/pluginInterface.cpp" line="175"/>
         <source>Public</source>
         <translation>Công khai</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/editor/ev3_vi.ts
+++ b/qrtranslations/vi/plugins/robots/editor/ev3_vi.ts
@@ -4,297 +4,234 @@
 <context>
     <name>Ev3MetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="180"/>
         <source>norm</source>
         <translation>chuẩn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="180"/>
         <source>x-axis</source>
         <translation>trục x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="180"/>
         <source>y-axis</source>
         <translation>trục y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="180"/>
         <source>z-axis</source>
         <translation>trục z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="182"/>
         <source>Composite</source>
         <translation>Tổ hợp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="182"/>
         <source>None</source>
         <translation>Không</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="182"/>
         <source>Shared</source>
         <translation>Tập hợp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="184"/>
         <source>brake</source>
         <translation>phanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="184"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="198"/>
         <source>float</source>
         <translation>Giá trị số thực</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="186"/>
         <source>Concurrent</source>
         <translation>Đồng thời</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="186"/>
         <source>Guarded</source>
         <translation>Có bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="186"/>
         <source>Sequential</source>
         <translation>Tuần tự</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
         <source>black</source>
         <translation>đen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
         <source>blue</source>
         <translation>xanh dương</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>green</source>
         <translation>xanh lá</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>red</source>
         <translation>đỏ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
         <source>white</source>
         <translation>trắng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="188"/>
         <source>yellow</source>
         <translation>vàng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="190"/>
         <source>greater</source>
         <translation>lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="190"/>
         <source>less</source>
         <translation>nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="190"/>
         <source>not greater</source>
         <translation>không lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="190"/>
         <source>not less</source>
         <translation>không nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Back</source>
         <translation>Lùi lại</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Down</source>
         <translation>Xuống dưới</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Enter</source>
         <translation>Tiến lên</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Left</source>
         <translation>Sang trái</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Right</source>
         <translation>Sang phải</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="192"/>
         <source>Up</source>
         <translation>Lên trên</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>green flash</source>
         <translation>xanh lá nhấp nháy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>green pulse</source>
         <translation>xanh lá nhấp nháy mượt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>off</source>
         <translation>tắt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>orange</source>
         <translation>cam</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>orange flash</source>
         <translation>cam nhấp nháy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>orange pulse</source>
         <translation>cam nhấp nháy mượt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>red flash</source>
         <translation>đỏ nhấp nháy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="194"/>
         <source>red pulse</source>
         <translation>đỏ nhấp nháy mượt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="196"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="196"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="196"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="196"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="198"/>
         <source>bool</source>
         <translation>Giá trị logic</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="198"/>
         <source>int</source>
         <translation>Số nguyên</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="198"/>
         <source>string</source>
         <translation>Chuỗi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="200"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="200"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="200"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="200"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="202"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="208"/>
         <source>false</source>
         <translation>sai</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="202"/>
         <source>body</source>
         <translation>thân vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="202"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="208"/>
         <source>true</source>
         <translation>đúng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="204"/>
         <source>In</source>
         <translation>Đầu vào</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="204"/>
         <source>Inout</source>
         <translation>Đầu vào - đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="204"/>
         <source>Out</source>
         <translation>Đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="204"/>
         <source>Return</source>
         <translation>Giá trị trả về</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="206"/>
         <source>Package</source>
         <translation>Gói</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="206"/>
         <source>Private</source>
         <translation>Riêng tư</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="206"/>
         <source>Protected</source>
         <translation>Bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="206"/>
         <source>Public</source>
         <translation>Công khai</translation>
     </message>
@@ -302,1017 +239,706 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="26"/>
         <source>Beep</source>
         <translation>Tiếng bíp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="28"/>
         <source>Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.</source>
         <translation>Phát một âm thanh với tần số cố định trên robot. Có hai tham số: tham số đầu tiên là âm lượng âm thanh, tham số thứ hai xác định chương trình có nên chờ âm thanh kết thúc hay tiếp tục thực hiện khối lệnh tiếp theo ngay lập tức.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="35"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="911"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1972"/>
         <source>Volume:</source>
         <translation>Âm lượng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="43"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="929"/>
         <source>Wait for Completion:</source>
         <translation>Chờ hoàn thành:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="76"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="956"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="76"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="956"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2007"/>
         <source>Volume</source>
         <translation>Âm lượng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="77"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="957"/>
         <source>Wait for Completion</source>
         <translation>Chờ hoàn thành</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="88"/>
         <source>Calibrate Black</source>
         <translation>Hiệu chuẩn màu đen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="90"/>
         <source>Calibrates the black threshold for each sensor in the array. Place the array over the black surface with all sensors on the black area.</source>
         <translation>Hiệu chuẩn ngưỡng màu đen cho từng cảm biến. Đặt cảm biến lên bề mặt màu đen sao cho tất cả các cảm biến đều nằm trên vùng màu đen.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="141"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="185"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="292"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="977"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1030"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1083"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1154"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1313"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1357"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1401"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1498"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1552"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1631"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1694"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1757"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1899"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1964"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2027"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2072"/>
         <source>Port:</source>
         <translation>Cổng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="121"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="165"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="271"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="316"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1009"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1062"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1133"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1186"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1293"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1337"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1381"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1433"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1532"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1610"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1672"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1736"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1807"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1943"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2005"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2052"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2096"/>
         <source>Port</source>
         <translation>Cổng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="132"/>
         <source>Calibrate gyroscope</source>
         <translation>Hiệu chuẩn con quay hồi chuyển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="134"/>
         <source>Sets gyroscope&apos;s angle to zero in current position.</source>
         <translation>Đặt góc của con quay hồi chuyển về 0 ở vị trí hiện tại.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="176"/>
         <source>Calibrate PID</source>
         <translation>Hiệu chuẩn bộ điều khiển PID</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="178"/>
         <source>Sets set point, P, I, D value of PID control and P factor, I factor, D factor for P, I, D value of PID control.</source>
         <translation>Thiết lập điểm đặt (giữa cảm biến trên đường), P/(hệ số P), I/(hệ số I), D/(hệ số D).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="193"/>
         <source>Set point:</source>
         <translation>Điểm đặt:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="201"/>
         <source>P:</source>
         <translation>P:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="209"/>
         <source>P factor:</source>
         <translation>Hệ số P:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="217"/>
         <source>I:</source>
         <translation>I:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="225"/>
         <source>I factor:</source>
         <translation>Hệ số I:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="233"/>
         <source>D:</source>
         <translation>D:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="241"/>
         <source>D factor:</source>
         <translation>Hệ số D:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="265"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="266"/>
         <source>D factor</source>
         <translation>Hệ số D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="267"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="268"/>
         <source>I factor</source>
         <translation>Hệ số I</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="269"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="270"/>
         <source>P factor</source>
         <translation>Hệ số P</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="272"/>
         <source>Set point</source>
         <translation>Giữa cảm biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="283"/>
         <source>Calibrate White</source>
         <translation>Hiệu chuẩn màu trắng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="285"/>
         <source>Calibrates the white threshold for each sensor in the array. Place the array over the white surface with all sensors on the white area.</source>
         <translation>Hiệu chuẩn ngưỡng màu trắng cho từng cảm biến. Đặt cảm biến lên bề mặt màu trắng sao cho tất cả các cảm biến đều nằm trên vùng màu trắng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="327"/>
         <source>Clear Encoder</source>
         <translation>Xóa bộ đếm xung</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="329"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Đặt lại giá trị số vòng quay của động cơ tại các cổng đã chỉ định.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="336"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="696"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="750"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="804"/>
         <source>Ports:</source>
         <translation>Các cổng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="361"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="837"/>
         <source>A, B, C, D</source>
         <translation>A, B, C, D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="361"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="675"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="729"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="783"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="837"/>
         <source>Ports</source>
         <translation>Các cổng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="372"/>
         <source>Draw Circle</source>
         <translation>Vẽ hình tròn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="374"/>
         <source>Draws on the robot screen a circle with the given center and radius.</source>
         <translation>Vẽ một hình tròn trên màn hình robot với tâm và bán kính đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="381"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="525"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="579"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="389"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="533"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="587"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="397"/>
         <source>Radius:</source>
         <translation>Bán kính:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="405"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="611"/>
         <source>Filled:</source>
         <translation>Được tô đầy:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="429"/>
         <source>Radius</source>
         <translation>Bán kính</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="430"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="635"/>
         <source>Filled</source>
         <translation>Được tô đầy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="431"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="501"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="557"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="637"/>
         <source>Redraw</source>
         <translation>Vẽ lại hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="432"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="558"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="639"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="433"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="559"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="640"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="444"/>
         <source>Draw Line</source>
         <translation>Vẽ đoạn thẳng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="446"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Vẽ một đoạn thẳng trên màn hình robot. Các tham số xác định hai điểm đầu mút của đoạn thẳng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="453"/>
         <source>X1:</source>
         <translation>X1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="461"/>
         <source>Y1:</source>
         <translation>Y1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="469"/>
         <source>X2:</source>
         <translation>X2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="477"/>
         <source>Y2:</source>
         <translation>Y2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="502"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="503"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="504"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="505"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="516"/>
         <source>Draw Pixel</source>
         <translation>Vẽ điểm ảnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="518"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Vẽ một điểm ảnh tại tọa độ đã chỉ định trên màn hình robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="570"/>
         <source>Draw Rectangle</source>
         <translation>Vẽ hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="572"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Vẽ một hình chữ nhật trên màn hình robot. Các tham số xác định tọa độ góc trên bên trái, chiều rộng và chiều cao của hình chữ nhật.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="595"/>
         <source>Width:</source>
         <translation>Chiều rộng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="603"/>
         <source>Height:</source>
         <translation>Chiều cao:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="636"/>
         <source>Height</source>
         <translation>Chiều cao</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="638"/>
         <source>Width</source>
         <translation>Chiều rộng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="651"/>
         <source>Ev3EngineMovementCommand</source>
         <translation>Khối điều khiển động cơ EV3 cơ bản</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="675"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="729"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="783"/>
         <source>B, C</source>
         <translation>B, C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="676"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="730"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="784"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="676"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="730"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="784"/>
         <source>Power (%)</source>
         <translation>Công suất (%)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="687"/>
         <source>Motors Backward</source>
         <translation>Mô-tơ lùi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="689"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Bật các mô-tơ ở các cổng đã cho ở chế độ đảo ngược với công suất xác định. Các cổng được chỉ định bằng các chữ cái A, B hoặc C, phân tách bằng dấu phẩy. Công suất được xác định theo phần trăm, từ -100 đến 100; nếu là số âm, mô-tơ sẽ được bật ở chế độ thông thường.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="704"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="758"/>
         <source>Power:</source>
         <translation>Công suất:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="741"/>
         <source>Motors Forward</source>
         <translation>Mô-tơ tiến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="743"/>
         <source>Enables motors on the given ports with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Bật các mô-tơ ở các cổng đã cho với công suất xác định. Các cổng được chỉ định bằng các chữ cái A, B hoặc C, phân tách bằng dấu phẩy. Công suất được xác định theo phần trăm, từ -100 đến 100; nếu là số âm, mô-tơ sẽ được bật ở chế độ đảo ngược.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="795"/>
         <source>Stop Motors</source>
         <translation>Dừng mô-tơ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="797"/>
         <source>Disables motors on the given ports.</source>
         <translation>Tắt các mô-tơ ở các cổng đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="836"/>
         <source>Mode</source>
         <translation>Chế độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="848"/>
         <source>Led</source>
         <translation>Đèn LED</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="850"/>
         <source>Sets the color of the LED on the robot`s front panel.</source>
         <translation>Thiết lập màu sắc đèn LED trên bảng điều khiển phía trước của robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="857"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1506"/>
         <source>Color:</source>
         <translation>Màu sắc:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="882"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1531"/>
         <source>Color</source>
         <translation>Màu sắc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="893"/>
         <source>Play Tone</source>
         <translation>Phát âm thanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="895"/>
         <source>Plays on the robot a sound with the given frequency and duration. This block is similar to the &apos;Beep&apos; block wuth the only difference that here you can specify sound parameters.</source>
         <translation>Phát một âm thanh trên robot với tần số và thời lượng xác định. Khối này tương tự khối &apos;Beep&apos;, chỉ khác ở chỗ bạn có thể chỉ định các thông số âm thanh.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="902"/>
         <source>Frequency:</source>
         <translation>Tần số:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="903"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="912"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="920"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="954"/>
         <source>Duration</source>
         <translation>Thời lượng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="921"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="954"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="955"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="955"/>
         <source>Frequency</source>
         <translation>Tần số</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="968"/>
         <source>Read Sensor to Array</source>
         <translation>Đọc cảm biến vào mảng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="970"/>
         <source>Read the values from the Line Leader.  Amount of light or dark each sensor sees.  Typically between 0-20.  0=black, 100=white.</source>
         <translation>Đọc các giá trị từ cảm biến Line Leader. Lượng ánh sáng hoặc độ tối mà mỗi cảm biến nhận được. Thông thường trong khoảng 0-20. 0 = đen, 100 = trắng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="985"/>
         <source>Array:</source>
         <translation>Mảng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1010"/>
         <source>a</source>
         <translation>a</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1010"/>
         <source>Array Variable</source>
         <translation>Biến mảng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1021"/>
         <source>Read Average to Variable</source>
         <translation>Đọc giá trị trung bình vào biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1023"/>
         <source>Read the Weighted Average value from the sensor.  This value is calculated internally by the sensor where each of the eight sensors is either triggered or not and multiplied by a factor to help determine if the line is left, right or on center of the line (according to the set point). EXPECTED VALUES: 0-80 (-1=ERROR)</source>
         <translation>Đọc giá trị trung bình có trọng số từ cảm biến. Giá trị này được tính toán bên trong cảm biến, trong đó mỗi một trong tám cảm biến được kích hoạt hoặc không, sau đó nhân với một hệ số để xác định đường kẻ nằm bên trái, bên phải hay ở giữa (theo điểm thiết lập). GIÁ TRỊ KỲ VỌNG: 0-80 (-1=LỖI)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1038"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1162"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1409"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1844"/>
         <source>Variable:</source>
         <translation>Biến:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1063"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1187"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1063"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1187"/>
         <source>Variable</source>
         <translation>Biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1074"/>
         <source>Read RGB into Variables</source>
         <translation>Đọc giá trị RGB vào các biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1076"/>
         <source>Reads R, G, B channels values into given variables</source>
         <translation>Đọc giá trị các kênh R, G, B vào các biến đã cho</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1091"/>
         <source>R Variable:</source>
         <translation>Biến R:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1099"/>
         <source>G Variable:</source>
         <translation>Biến G:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1107"/>
         <source>B Variable:</source>
         <translation>Biến B:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1131"/>
         <source>b</source>
         <translation>b</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1131"/>
         <source>B Variable</source>
         <translation>Biến B</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1132"/>
         <source>g</source>
         <translation>g</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1132"/>
         <source>G Variable</source>
         <translation>Biến G</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1134"/>
         <source>r</source>
         <translation>r</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1134"/>
         <source>R Variable</source>
         <translation>Biến R</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1145"/>
         <source>Read Steering to Variable</source>
         <translation>Đọc giá trị điều khiển vào biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1147"/>
         <source>Read the Steering value from the sensor.  This value is calculated internally and can directly be used to set turning values for the robot&apos;s motors. EXPECTED VALUES: -100 to 100 (-101=ERROR)</source>
         <translation>Đọc giá trị điều khiển từ cảm biến. Giá trị này được tính toán bên trong và có thể dùng trực tiếp để thiết lập giá trị rẽ cho các mô-tơ của robot. GIÁ TRỊ KỲ VỌNG: -100 đến 100 (-101=LỖI)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1198"/>
         <source>Send Mail</source>
         <translation>Gửi thư cho robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1200"/>
         <source>Sends mail (message) to another robot. If Receiver name left empty, message will be sent to all connected robots</source>
         <translation>Gửi thư (tin nhắn) đến một robot khác. Nếu tên người nhận để trống, tin nhắn sẽ được gửi đến tất cả các robot đã kết nối</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1207"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1828"/>
         <source>Message type:</source>
         <translation>Loại tin nhắn:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1215"/>
         <source>Message:</source>
         <translation>Tin nhắn:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1223"/>
         <source>Receiver name:</source>
         <translation>Tên người nhận:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1231"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1836"/>
         <source>Mailbox name:</source>
         <translation>Tên hộp thư:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1255"/>
         <source>42</source>
         <translation>42</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1255"/>
         <source>Message</source>
         <translation>Tin nhắn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1256"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1877"/>
         <source>Message type</source>
         <translation>Loại tin nhắn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1257"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1876"/>
         <source>EV3MailBox</source>
         <translation>Hộp thư EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1257"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1876"/>
         <source>Mailbox name</source>
         <translation>Tên hộp thư</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1269"/>
         <source>Ev3SensorBlock</source>
         <translation>Khối cảm biến cơ bản EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1304"/>
         <source>Sleep Line Leader</source>
         <translation>Chuyển cảm biến theo dõi đường sang chế độ ngủ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1306"/>
         <source>Puts the line leader to sleep conserve power</source>
         <translation>Chuyển cảm biến theo dõi đường sang chế độ ngủ để tiết kiệm năng lượng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1348"/>
         <source>Start Compass Calibration</source>
         <translation>Bắt đầu hiệu chuẩn la bàn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1350"/>
         <source>Starts compass calibration under program control. To calibrate, robot needs to spin &gt;=540 clockwise and counterclockwise with minimum 20 seconds duration for each direction. Atfer robot rotation add Stop Compass Сalibration block.</source>
         <translation>Bắt đầu hiệu chuẩn la bàn bằng chương trình. Để hiệu chuẩn, robot cần quay &gt;=540 độ theo chiều kim đồng hồ và ngược lại, mỗi chiều tối thiểu 20 giây. Sau khi quay xong, thêm khối Dừng hiệu chuẩn la bàn.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1392"/>
         <source>Stop Compass Calibration</source>
         <translation>Dừng hiệu chuẩn la bàn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1394"/>
         <source>Ends compass calibration process. Stores result of calibration into the given variable. Not zero means success.</source>
         <translation>Kết thúc quá trình hiệu chuẩn la bàn. Lưu kết quả hiệu chuẩn vào biến đã cho. Giá trị khác không nghĩa là hiệu chuẩn thành công.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1445"/>
         <source>Wait for button</source>
         <translation>Chờ nhấn nút</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1447"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Chờ đến khi nhấn nút trên khối điều khiển robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1454"/>
         <source>Button:</source>
         <translation>Nút:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1478"/>
         <source>Button</source>
         <translation>Nút</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1489"/>
         <source>Wait for Color</source>
         <translation>Chờ màu sắc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1491"/>
         <source>Waits till the color sensor on the given port will recognize the given color.</source>
         <translation>Chờ đến khi cảm biến màu ở cổng đã cho nhận diện được màu chỉ định.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1543"/>
         <source>Wait for Color Intensity</source>
         <translation>Chờ cường độ màu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1545"/>
         <source>Waits till the value returned by the color sensor on the given port will be greater or less than the given in the &apos;Intensity&apos; parameter value (the intensity is specified in percents, 0 to 100).</source>
         <translation>Chờ đến khi giá trị trả về từ cảm biến màu ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị trong tham số &apos;Cường độ&apos; (cường độ được chỉ định theo phần trăm, từ 0 đến 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1560"/>
         <source>Intensity:</source>
         <translation>Cường độ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1568"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1647"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1710"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1773"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1916"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1980"/>
         <source>Sign:</source>
         <translation>Dấu:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1609"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1806"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1942"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2007"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1609"/>
         <source>Intensity</source>
         <translation>Cường độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1611"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1673"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1737"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1808"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1944"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2006"/>
         <source>Sign</source>
         <translation>Dấu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1622"/>
         <source>Wait for Encoder</source>
         <translation>Chờ bộ mã hóa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1624"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Chờ đến khi giới hạn đếm vòng quay của động cơ ở cổng đã cho đạt đến giá trị tham số &apos;Giới hạn đếm vòng&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1639"/>
         <source>Tacho Limit:</source>
         <translation>Giới hạn đếm vòng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1685"/>
         <source>Wait for Gyroscope</source>
         <translation>Chờ con quay hồi chuyển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1687"/>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given.</source>
         <translation>Chờ đến khi giá trị trả về từ con quay hồi chuyển ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1702"/>
         <source>Value:</source>
         <translation>Giá trị:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1735"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1735"/>
         <source>Value</source>
         <translation>Giá trị</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1748"/>
         <source>Wait for Light</source>
         <translation>Chờ ánh sáng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1750"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Chờ đến khi giá trị trả về từ cảm biến ánh sáng ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị trong tham số &apos;Phần trăm&apos; (0 đến 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1765"/>
         <source>Percents:</source>
         <translation>Phần trăm:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1806"/>
         <source>Percents</source>
         <translation>Phần trăm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1819"/>
         <source>Wait for Mail Receiving</source>
         <translation>Chờ nhận tin nhắn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1821"/>
         <source>Stores a message from another robot (fom mailbox) into a given variable. When no incoming messages are present at the moment, a robot will wait for incoming message if &apos;Synchronized&apos; property is true, and doing nothing otherwise.</source>
         <translation>Lưu một tin nhắn từ robot khác (từ hộp thư) vào một biến đã cho. Nếu hiện tại không có tin nhắn đến, robot sẽ chờ tin nhắn nếu thuộc tính &apos;Đồng bộ&apos; là đúng, và không làm gì nếu ngược lại.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1852"/>
         <source>Synchronized:</source>
         <translation>Đồng bộ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1878"/>
         <source>Synchronized</source>
         <translation>Đồng bộ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1890"/>
         <source>Wait for Range Sensor</source>
         <translation>Chờ cảm biến khoảng cách</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1892"/>
         <source>Waits till the value returned by the ultrasonic or infrared range sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, 0 to 255).</source>
         <translation>Chờ đến khi giá trị trả về từ cảm biến khoảng cách siêu âm hoặc hồng ngoại ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị trong tham số &apos;Khoảng cách&apos; (khoảng cách được chỉ định bằng centimet, từ 0 đến 255).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1907"/>
         <source>Distance:</source>
         <translation>Khoảng cách:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1908"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1942"/>
         <source>Distance</source>
         <translation>Khoảng cách</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1955"/>
         <source>Wait for Sound Sensor</source>
         <translation>Chờ cảm biến âm thanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1957"/>
         <source>Waits till the loudness obtained by the sound sensor on the given port will be greater or less than the given value.</source>
         <translation>Chờ đến khi độ lớn âm thanh thu được từ cảm biến âm thanh ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2018"/>
         <source>Wait for Touch Sensor</source>
         <translation>Chờ cảm biến chạm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2020"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Chờ đến khi cảm biến chạm được nhấn. Tham số duy nhất là số cổng của cảm biến (1, 2, 3 hoặc 4).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2063"/>
         <source>Wake Up Line Leader</source>
         <translation>Đánh thức cảm biến theo dõi đường</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="2065"/>
         <source>Wakes the line leader to prepare for use.</source>
         <translation>Đánh thức cảm biến theo dõi đường để chuẩn bị sử dụng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="122"/>
         <source>RobotsDiagram</source>
         <translation>Sơ đồ hành vi robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="129"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="130"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="131"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="132"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="133"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="134"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="135"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="136"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="137"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="138"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="139"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="140"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="141"/>
         <source>Actions</source>
         <translation>Hành động</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="143"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="144"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="145"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="146"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="147"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="148"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="149"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="150"/>
         <source>Line Leader</source>
         <translation>Cảm biến theo dõi đường</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="151"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="152"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="153"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="154"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="155"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="156"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="157"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="158"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="159"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="160"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="161"/>
         <source>Wait</source>
         <translation>Chờ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="162"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="163"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="164"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="165"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/pluginInterface.cpp" line="166"/>
         <source>Drawing</source>
         <translation>Vẽ</translation>
     </message>
@@ -1320,18 +946,14 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1258"/>
         <source>Receiver name</source>
         <translation>Tên người nhận</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1434"/>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1879"/>
         <source>Variable</source>
         <translation>Biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/ev3/generated/elements.h" line="1674"/>
         <source>Tacho Limit</source>
         <translation>Giới hạn đếm vòng</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/editor/nxt_vi.ts
+++ b/qrtranslations/vi/plugins/robots/editor/nxt_vi.ts
@@ -4,209 +4,166 @@
 <context>
     <name>NxtMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="120"/>
         <source>norm</source>
         <translation>chuẩn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="120"/>
         <source>x-axis</source>
         <translation>trục x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="120"/>
         <source>y-axis</source>
         <translation>trục y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="120"/>
         <source>z-axis</source>
         <translation>trục z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="122"/>
         <source>Composite</source>
         <translation>Tổ hợp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="122"/>
         <source>None</source>
         <translation>Không</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="122"/>
         <source>Shared</source>
         <translation>Tập hợp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="124"/>
         <source>brake</source>
         <translation>phanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="124"/>
         <source>float</source>
         <translation>trượt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="126"/>
         <source>Concurrent</source>
         <translation>Đồng thời</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="126"/>
         <source>Guarded</source>
         <translation>Có giám sát</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="126"/>
         <source>Sequential</source>
         <translation>Tuần tự</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>black</source>
         <translation>đen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>blue</source>
         <translation>xanh dương</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>green</source>
         <translation>xanh lá</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>red</source>
         <translation>đỏ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>white</source>
         <translation>trắng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="128"/>
         <source>yellow</source>
         <translation>vàng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="130"/>
         <source>greater</source>
         <translation>lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="130"/>
         <source>less</source>
         <translation>nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="130"/>
         <source>not greater</source>
         <translation>không lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="130"/>
         <source>not less</source>
         <translation>không nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="132"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="142"/>
         <source>false</source>
         <translation>sai</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="132"/>
         <source>body</source>
         <translation>thân vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="132"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="142"/>
         <source>true</source>
         <translation>đúng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="134"/>
         <source>Enter</source>
         <translation>Enter</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="134"/>
         <source>Escape</source>
         <translation>Escape</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="134"/>
         <source>Left</source>
         <translation>Trái</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="134"/>
         <source>Right</source>
         <translation>Phải</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="136"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="136"/>
         <source>2</source>
         <translation>2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="136"/>
         <source>3</source>
         <translation>3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="136"/>
         <source>4</source>
         <translation>4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="138"/>
         <source>In</source>
         <translation>Đầu vào</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="138"/>
         <source>Inout</source>
         <translation>Đầu vào - đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="138"/>
         <source>Out</source>
         <translation>Đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="138"/>
         <source>Return</source>
         <translation>Giá trị trả về</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="140"/>
         <source>Package</source>
         <translation>Gói</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="140"/>
         <source>Private</source>
         <translation>Riêng tư</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="140"/>
         <source>Protected</source>
         <translation>Bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="140"/>
         <source>Public</source>
         <translation>Công khai</translation>
     </message>
@@ -214,578 +171,398 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="26"/>
         <source>Beep</source>
         <translation>Tiếng bíp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="28"/>
         <source>Plays on the robot a sound with the fixed frequency. There are two parameters. The first one is a loudness of the sound, the second means if program should wait for sound completion or go to next block right away.</source>
         <translation>Phát ra âm thanh với tần số cố định trên robot. Có hai tham số. Tham số đầu tiên là độ lớn âm thanh, tham số thứ hai xác định chương trình có nên chờ âm thanh kết thúc hay chuyển ngay sang khối tiếp theo.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="35"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="613"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1098"/>
         <source>Volume:</source>
         <translation>Âm lượng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="43"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="631"/>
         <source>Wait for Completion:</source>
         <translation>Chờ hoàn thành:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="76"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="658"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="76"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="658"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1133"/>
         <source>Volume</source>
         <translation>Âm lượng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="77"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="659"/>
         <source>Wait for Completion</source>
         <translation>Chờ hoàn thành</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="88"/>
         <source>Clear Encoder</source>
         <translation>Xóa bộ mã hóa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="90"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Đặt lại giá trị số vòng quay của động cơ tại các cổng đã chỉ định.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="440"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="496"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="552"/>
         <source>Ports:</source>
         <translation>Cổng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="122"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="584"/>
         <source>A, B, C</source>
         <translation>A, B, C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="122"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="419"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="475"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="531"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="584"/>
         <source>Ports</source>
         <translation>Cổng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="133"/>
         <source>Draw Circle</source>
         <translation>Vẽ hình tròn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="135"/>
         <source>Draws on the robot screen a circle with the given center and radius.</source>
         <translation>Vẽ một hình tròn với tâm và bán kính cho trước lên màn hình robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="277"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="331"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="150"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="285"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="339"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="158"/>
         <source>Radius:</source>
         <translation>Bán kính:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="182"/>
         <source>Radius</source>
         <translation>Bán kính</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="183"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="253"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="309"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="380"/>
         <source>Redraw</source>
         <translation>Vẽ lại</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="184"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="310"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="382"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="185"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="311"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="383"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="196"/>
         <source>Draw Line</source>
         <translation>Vẽ đoạn thẳng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="198"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Vẽ một đoạn thẳng trên màn hình robot. Các tham số xác định hai điểm đầu mút của đoạn thẳng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="205"/>
         <source>X1:</source>
         <translation>X1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="213"/>
         <source>Y1:</source>
         <translation>Y1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="221"/>
         <source>X2:</source>
         <translation>X2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="229"/>
         <source>Y2:</source>
         <translation>Y2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="254"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="255"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="256"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="257"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="268"/>
         <source>Draw Pixel</source>
         <translation>Vẽ điểm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="270"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Vẽ một điểm tại tọa độ đã chỉ định trên màn hình robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="322"/>
         <source>Draw Rectangle</source>
         <translation>Vẽ hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="324"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Vẽ một hình chữ nhật trên màn hình robot. Các tham số xác định tọa độ góc trên bên trái, chiều rộng và chiều cao của hình chữ nhật.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="347"/>
         <source>Width:</source>
         <translation>Chiều rộng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="355"/>
         <source>Height:</source>
         <translation>Chiều cao:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="379"/>
         <source>Height</source>
         <translation>Chiều cao</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="381"/>
         <source>Width</source>
         <translation>Chiều rộng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="394"/>
         <source>NxtEngineMovementCommand</source>
         <translation>Khối điều khiển động cơ NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="418"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="474"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="530"/>
         <source>Mode</source>
         <translation>Chế độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="419"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="475"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="531"/>
         <source>B, C</source>
         <translation>B, C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="420"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="476"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="532"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="420"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="476"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="532"/>
         <source>Power (%)</source>
         <translation>Công suất (%)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="431"/>
         <source>Motors Backward</source>
         <translation>Mô-tơ lùi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="433"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Bật các mô-tơ ở các cổng đã cho ở chế độ đảo ngược với công suất đã cho. Các cổng được chỉ định bằng các chữ cái A, B hoặc C, phân tách bằng dấu phẩy. Công suất được xác định bằng phần trăm, giá trị từ -100 đến 100; nếu giá trị âm được chỉ định, mô-tơ sẽ hoạt động ở chế độ bình thường.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="448"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="504"/>
         <source>Power:</source>
         <translation>Công suất:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="449"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="505"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="614"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="487"/>
         <source>Motors Forward</source>
         <translation>Mô-tơ tiến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="489"/>
         <source>Enables motors on the given ports with the given power. Ports are specified with A, B or C letters divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Bật các mô-tơ ở các cổng đã cho với công suất đã cho. Các cổng được chỉ định bằng các chữ cái A, B hoặc C, phân tách bằng dấu phẩy. Công suất được xác định bằng phần trăm, giá trị từ -100 đến 100; nếu giá trị âm được chỉ định, mô-tơ sẽ hoạt động ở chế độ đảo ngược.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="543"/>
         <source>Stop Motors</source>
         <translation>Dừng mô-tơ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="545"/>
         <source>Disables motors on the given ports.</source>
         <translation>Tắt các mô-tơ ở các cổng đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="595"/>
         <source>Play Tone</source>
         <translation>Phát âm thanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="597"/>
         <source>Plays on the robot a sound with the given frequency and duration. This block is similar to the &apos;Beep&apos; block wuth the only difference that here you can specify sound parameters.</source>
         <translation>Phát một âm thanh trên robot với tần số và thời lượng đã cho. Khối này tương tự khối &apos;Beep&apos;, chỉ khác ở chỗ bạn có thể chỉ định các thông số âm thanh.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="604"/>
         <source>Frequency:</source>
         <translation>Tần số:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="605"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="622"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="656"/>
         <source>Duration</source>
         <translation>Thời lượng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="623"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="656"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="657"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="657"/>
         <source>Frequency</source>
         <translation>Tần số</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="670"/>
         <source>NxtSensorBlock</source>
         <translation>Khối cảm biến cơ bản NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="694"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="792"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="870"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="932"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1004"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1069"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1131"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1178"/>
         <source>Port</source>
         <translation>Cổng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="705"/>
         <source>Wait for Button</source>
         <translation>Chờ nhấn nút</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="707"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Chờ cho đến khi một nút trên khối điều khiển được nhấn.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="714"/>
         <source>Button:</source>
         <translation>Nút:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="738"/>
         <source>Button</source>
         <translation>Nút</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="749"/>
         <source>Wait for Color</source>
         <translation>Chờ màu sắc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="751"/>
         <source>Waits till the color sensor on the given port will recognize the given color.</source>
         <translation>Chờ cho đến khi cảm biến màu ở cổng đã cho nhận diện được màu đã chỉ định.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="758"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="812"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="891"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="954"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1025"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1090"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1153"/>
         <source>Port:</source>
         <translation>Cổng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="766"/>
         <source>Color:</source>
         <translation>Màu sắc:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="791"/>
         <source>Color</source>
         <translation>Màu sắc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="803"/>
         <source>Wait for Color Intensity</source>
         <translation>Chờ cường độ màu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="805"/>
         <source>Waits till the value returned by the color sensor on the given port will be greater or less than the given in the &apos;Intensity&apos; parameter value (the intensity is specified in percents, 0 to 100).</source>
         <translation>Chờ cho đến khi giá trị trả về bởi cảm biến màu ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị đã cho trong tham số &apos;Cường độ&apos; (cường độ được xác định bằng phần trăm, từ 0 đến 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="820"/>
         <source>Intensity:</source>
         <translation>Cường độ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="828"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="907"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="970"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1042"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1106"/>
         <source>Sign:</source>
         <translation>Giá trị đọc được:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="869"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1003"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1068"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1133"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="869"/>
         <source>Intensity</source>
         <translation>Cường độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="871"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="933"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1005"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1070"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1132"/>
         <source>Sign</source>
         <translation>Giá trị đọc được</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="882"/>
         <source>Wait for Encoder</source>
         <translation>Chờ bộ mã hóa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="884"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Chờ cho đến khi giới hạn đếm vòng quay (tacho) của mô-tơ ở cổng đã cho đạt đến giá trị tham số &apos;Giới hạn tacho&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="899"/>
         <source>Tacho Limit:</source>
         <translation>Giới hạn tacho:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="932"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="945"/>
         <source>Wait for Light</source>
         <translation>Chờ ánh sáng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="947"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Chờ cho đến khi giá trị trả về bởi cảm biến ánh sáng ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị đã cho trong tham số &apos;Phần trăm&apos; (0 đến 100).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="962"/>
         <source>Percents:</source>
         <translation>Phần trăm:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1003"/>
         <source>Percents</source>
         <translation>Phần trăm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1016"/>
         <source>Wait for Sonar Distance</source>
         <translation>Chờ khoảng cách sonar</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1018"/>
         <source>Waits till the value returned by the ultrasonic sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, 0 to 255).</source>
         <translation>Chờ cho đến khi giá trị trả về bởi cảm biến siêu âm ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị đã cho trong tham số &apos;Khoảng cách&apos; (khoảng cách được xác định bằng centimet, từ 0 đến 255).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1033"/>
         <source>Distance:</source>
         <translation>Khoảng cách:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1034"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1068"/>
         <source>Distance</source>
         <translation>Khoảng cách</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1081"/>
         <source>Wait for Sound Sensor</source>
         <translation>Chờ cảm biến âm thanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1083"/>
         <source>Waits till the loudness obtained by the sound sensor on the given port will be greater or less than the given value.</source>
         <translation>Chờ cho đến khi độ lớn âm thanh thu được từ cảm biến âm thanh ở cổng đã cho lớn hơn hoặc nhỏ hơn giá trị đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1144"/>
         <source>Wait for Touch Sensor</source>
         <translation>Chờ cảm biến chạm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="1146"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Chờ cho đến khi cảm biến chạm được nhấn. Tham số duy nhất là số cổng của cảm biến (1, 2, 3 hoặc 4).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="79"/>
         <source>RobotsDiagram</source>
         <translation>Biểu đồ hành vi robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="86"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="87"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="88"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="89"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="90"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="91"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="92"/>
         <source>Actions</source>
         <translation>Hành động</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="93"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="94"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="95"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="96"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="98"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="99"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="100"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="101"/>
         <source>Wait</source>
         <translation>Chờ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="102"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="103"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="104"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="105"/>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/pluginInterface.cpp" line="106"/>
         <source>Drawing</source>
         <translation>Vẽ</translation>
     </message>
@@ -793,7 +570,6 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/nxt/generated/elements.h" line="934"/>
         <source>Tacho Limit</source>
         <translation>Giới hạn tacho</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/editor/pioneer_vi.ts
+++ b/qrtranslations/vi/plugins/robots/editor/pioneer_vi.ts
@@ -4,209 +4,166 @@
 <context>
     <name>PioneerMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="126"/>
         <source>norm</source>
         <translation>bình thường</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="126"/>
         <source>x-axis</source>
         <translation>theo trục x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="126"/>
         <source>y-axis</source>
         <translation>theo trục y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="126"/>
         <source>z-axis</source>
         <translation>theo trục z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="128"/>
         <source>Composite</source>
         <translation>Tổ hợp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="128"/>
         <source>None</source>
         <translation>Không</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="128"/>
         <source>Shared</source>
         <translation>Tập hợp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="130"/>
         <source>brake</source>
         <translation>phanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="130"/>
         <source>float</source>
         <translation>float</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="132"/>
         <source>Concurrent</source>
         <translation>Song song</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="132"/>
         <source>Guarded</source>
         <translation>Có bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="132"/>
         <source>Sequential</source>
         <translation>Tuần tự</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>black</source>
         <translation>đen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>blue</source>
         <translation>xanh dương</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>green</source>
         <translation>xanh lá</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>red</source>
         <translation>đỏ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>white</source>
         <translation>trắng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="134"/>
         <source>yellow</source>
         <translation>vàng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="136"/>
         <source>greater</source>
         <translation>lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="136"/>
         <source>less</source>
         <translation>nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="136"/>
         <source>not greater</source>
         <translation>không lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="136"/>
         <source>not less</source>
         <translation>không nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="138"/>
         <source>Altfu</source>
         <translation>Altfu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="138"/>
         <source>Input</source>
         <translation>Đầu vào</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="138"/>
         <source>Output</source>
         <translation>Đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="140"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="148"/>
         <source>false</source>
         <translation>sai</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="142"/>
         <source>body</source>
         <translation>thân vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="142"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="148"/>
         <source>true</source>
         <translation>đúng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="144"/>
         <source>In</source>
         <translation>Đầu vào</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="144"/>
         <source>Inout</source>
         <translation>Đầu vào - đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="144"/>
         <source>Out</source>
         <translation>Đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="144"/>
         <source>Return</source>
         <translation>Trả về</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="146"/>
         <source>Package</source>
         <translation>Gói</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="146"/>
         <source>Private</source>
         <translation>Riêng tư</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="146"/>
         <source>Protected</source>
         <translation>Được bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="146"/>
         <source>Public</source>
         <translation>Công khai</translation>
     </message>
@@ -214,616 +171,446 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="26"/>
         <source>Landing</source>
         <translation>Hạ cánh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="28"/>
         <source>Orders quadcopter to land.</source>
         <translation>Ra lệnh cho quadcopter hạ cánh.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="61"/>
         <source>Takeoff</source>
         <translation>Cất cánh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="63"/>
         <source>Orders quadcopter to takeoff.</source>
         <translation>Ra lệnh cho quadcopter cất cánh.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="96"/>
         <source>Go to point</source>
         <translation>Bay đến điểm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="98"/>
         <source>Orders quadcopter to fly to given GPS coordinates.</source>
         <translation>Ra lệnh cho quadcopter bay đến tọa độ GPS đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="105"/>
         <source>Latitude:</source>
         <translation>Vĩ độ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="113"/>
         <source>Longitude:</source>
         <translation>Kinh độ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="121"/>
         <source>Altitude:</source>
         <translation>Độ cao:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="145"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="145"/>
         <source>Altitude</source>
         <translation>Độ cao</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="146"/>
         <source>600859810</source>
         <translation>600859810</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="146"/>
         <source>Latitude</source>
         <translation>Vĩ độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="147"/>
         <source>304206500</source>
         <translation>304206500</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="147"/>
         <source>Longitude</source>
         <translation>Kinh độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="158"/>
         <source>Go to local point</source>
         <translation>Bay đến điểm (HTC)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="160"/>
         <source>Orders quadcopter to fly to given coordinates.</source>
         <translation>Ra lệnh cho quadcopter bay đến tọa độ đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="167"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="310"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="372"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="434"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="496"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="175"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="318"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="380"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="442"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="504"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="183"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="326"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="388"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="450"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="512"/>
         <source>Z:</source>
         <translation>Z:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="191"/>
         <source>Time:</source>
         <translation>Thời gian:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="217"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="218"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="219"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="715"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="217"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="350"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="412"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="474"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="536"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="218"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="351"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="413"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="475"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="537"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="219"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="352"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="414"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="476"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="538"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="230"/>
         <source>GPIO Initialization</source>
         <translation>Khởi tạo GPIO</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="232"/>
         <source>Create GPIO in settings port.</source>
         <translation>Tạo GPIO tại cổng với các thiết lập đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="239"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="817"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="916"/>
         <source>Pin name:</source>
         <translation>Tên:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="247"/>
         <source>Port:</source>
         <translation>Cổng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="255"/>
         <source>Pin:</source>
         <translation>Chân:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="263"/>
         <source>Mode:</source>
         <translation>Chế độ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="287"/>
         <source>Mode</source>
         <translation>Chế độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="288"/>
         <source>Pin</source>
         <translation>Số chân</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="289"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="849"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="940"/>
         <source>pin_name</source>
         <translation>ten_chan</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="289"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="849"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="940"/>
         <source>Pin name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="290"/>
         <source>Port</source>
         <translation>Cổng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="301"/>
         <source>Get Accelerometer</source>
         <translation>Đọc cảm biến gia tốc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="303"/>
         <source>Returns accelerometer.</source>
         <translation>Trả về dữ liệu cảm biến gia tốc của quadcopter theo ba trục.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="350"/>
         <source>aX</source>
         <translation>aX</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="351"/>
         <source>aY</source>
         <translation>aY</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="352"/>
         <source>aZ</source>
         <translation>aZ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="363"/>
         <source>Get Gyroscope</source>
         <translation>Đọc con quay hồi chuyển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="365"/>
         <source>Returns gyroscope.</source>
         <translation>Trả về dữ liệu con quay hồi chuyển của quadcopter theo ba trục.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="412"/>
         <source>gX</source>
         <translation>gX</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="413"/>
         <source>gY</source>
         <translation>gY</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="414"/>
         <source>gZ</source>
         <translation>gZ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="425"/>
         <source>Get LPS Position</source>
         <translation>Lấy vị trí (HTC)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="427"/>
         <source>Returns position (local positioning system).</source>
         <translation>Trả về vị trí hiện tại trong hệ tọa độ cục bộ.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="474"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="850"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="475"/>
         <source>y</source>
         <translation>y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="476"/>
         <source>z</source>
         <translation>z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="487"/>
         <source>Get LPS Velocity</source>
         <translation>Đọc vận tốc (HTC)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="489"/>
         <source>Returns velocity (local position system).</source>
         <translation>Trả về giá trị vận tốc hiện tại trong hệ tọa độ cục bộ.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="536"/>
         <source>velX</source>
         <translation>velX</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="537"/>
         <source>velY</source>
         <translation>velY</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="538"/>
         <source>velZ</source>
         <translation>velZ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="549"/>
         <source>Get LPS Yaw</source>
         <translation>Đọc góc lệch hướng (HTC)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="551"/>
         <source>Returns yaw (local position system).</source>
         <translation>Trả về góc lệch hướng hiện tại trong hệ tọa độ cục bộ.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="558"/>
         <source>Yaw:</source>
         <translation>Yaw:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="582"/>
         <source>yaw</source>
         <translation>yaw</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="582"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="997"/>
         <source>Yaw</source>
         <translation>Lệch hướng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="593"/>
         <source>Get Orientation</source>
         <translation>Đọc dữ liệu định hướng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="595"/>
         <source>Returns orientation.</source>
         <translation>Trả về dữ liệu định hướng của quadcopter trong không gian - nghiêng, lăn, lệch hướng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="602"/>
         <source>Roll:</source>
         <translation>Góc nghiêng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="610"/>
         <source>Pitch:</source>
         <translation>Góc lăn:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="618"/>
         <source>Azimuth:</source>
         <translation>Góc lệch hướng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="642"/>
         <source>azimuth</source>
         <translation>góc phương vị</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="642"/>
         <source>Azimuth</source>
         <translation>Lệch hướng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="643"/>
         <source>pitch</source>
         <translation>góc nghiêng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="643"/>
         <source>Pitch</source>
         <translation>Góc lăn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="644"/>
         <source>roll</source>
         <translation>góc lăn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="644"/>
         <source>Roll</source>
         <translation>Góc nghiêng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="655"/>
         <source>Led</source>
         <translation>Đèn LED</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="657"/>
         <source>Sets the color of the specified LED on a quadcopter.</source>
         <translation>Đặt màu cho đèn LED đã chỉ định trên quadcopter.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="664"/>
         <source>Number:</source>
         <translation>Số:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="672"/>
         <source>Red:</source>
         <translation>Đỏ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="680"/>
         <source>Green:</source>
         <translation>Xanh lá:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="688"/>
         <source>Blue:</source>
         <translation>Xanh dương:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="713"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="714"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="716"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="1030"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="713"/>
         <source>Blue</source>
         <translation>Xanh dương</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="714"/>
         <source>Green</source>
         <translation>Xanh lá</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="715"/>
         <source>Number</source>
         <translation>Số</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="716"/>
         <source>Red</source>
         <translation>Đỏ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="727"/>
         <source>Magnet</source>
         <translation>Nam châm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="729"/>
         <source>Controls magnet on a quadcopter.</source>
         <translation>Điều khiển nam châm trên quadcopter.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="752"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="941"/>
         <source>State on</source>
         <translation>Bật</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="763"/>
         <source>Print</source>
         <translation>In</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="765"/>
         <source>Prints given string on a console.</source>
         <translation>In chuỗi đã cho ra màn hình điều khiển.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="772"/>
         <source>Text:</source>
         <translation>Văn bản:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="796"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="986"/>
         <source>Evaluate</source>
         <translation>Tính toán</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="797"/>
         <source>Enter some text here</source>
         <translation>Nhập văn bản tại đây</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="797"/>
         <source>Text</source>
         <translation>Văn bản</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="808"/>
         <source>Read GPIO</source>
         <translation>Đọc giá trị GPIO</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="810"/>
         <source>Returns GPIO value.</source>
         <translation>Trả về giá trị trạng thái GPIO.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="825"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="870"/>
         <source>Variable:</source>
         <translation>Biến:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="850"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="896"/>
         <source>Variable</source>
         <translation>Biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="861"/>
         <source>Read Range Sensor</source>
         <translation>Đọc cảm biến khoảng cách</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="863"/>
         <source>Reads distance from rangefinder.</source>
         <translation>Đọc thông tin từ cảm biến đo khoảng cách.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="896"/>
         <source>dist</source>
         <translation>khoảng cách</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="907"/>
         <source>Set GPIO state</source>
         <translation>Đặt trạng thái GPIO</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="909"/>
         <source>Set GPIO value in &quot;true/false&quot;.</source>
         <translation>Đặt GPIO ở trạng thái &quot;đúng/sai&quot;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="952"/>
         <source>System</source>
         <translation>Lệnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="954"/>
         <source>Executes given Lua script.</source>
         <translation>Thực thi chuỗi lệnh Lua đã cho trên quadcopter.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="961"/>
         <source>Command:</source>
         <translation>Lệnh:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="985"/>
         <source>print(&apos;Hello&apos;)</source>
         <translation>print(&apos;Hello&apos;)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="985"/>
         <source>Command</source>
         <translation>Lệnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="999"/>
         <source>Sets yaw for quadcopter</source>
         <translation>Đặt góc lệch hướng cho quadcopter. Tham số &quot;góc&quot; được tính bằng độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="1006"/>
         <source>Angle:</source>
         <translation>Góc:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="1030"/>
         <source>Angle (degrees)</source>
         <translation>Góc (độ)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="88"/>
         <source>RobotsDiagram</source>
         <translation>Biểu đồ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="95"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="96"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="97"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="98"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="99"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="100"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="101"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="102"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="103"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="104"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="105"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="106"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="107"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="108"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="109"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="110"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="111"/>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/pluginInterface.cpp" line="112"/>
         <source>Actions</source>
         <translation>Hành động</translation>
     </message>
@@ -831,7 +618,6 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/pioneer/generated/elements.h" line="216"/>
         <source>Time</source>
         <translation>Thời gian</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/editor/trik_vi.ts
+++ b/qrtranslations/vi/plugins/robots/editor/trik_vi.ts
@@ -4,1259 +4,846 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="26"/>
         <source>TrikAnalogSensorBlock</source>
         <translation>Cảm biến Tương tự</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="50"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="276"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="788"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1732"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2145"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2264"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2335"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2493"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2539"/>
         <source>Port</source>
         <translation>Cổng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="61"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1583"/>
         <source>Angular Servo</source>
         <translation>Servo Góc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="63"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1585"/>
         <source>Manages angular servomotor. Sets up rotation angle on the given port in degrees. Values from 0 to 90 are correspond to a clockwise rotation and values from -90 to 0 correspond to counterclockwise rotation.</source>
         <translation>Điều khiển động cơ servo góc. Thiết lập góc quay trục động cơ tại cổng đã cho (theo độ). Giá trị từ 0 đến 90 tương ứng với chiều quay thuận chiều kim đồng hồ, giá trị từ -90 đến 0 tương ứng với chiều quay ngược chiều kim đồng hồ.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="70"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1592"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1646"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1754"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1835"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1890"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1945"/>
         <source>Ports:</source>
         <translation>Các cổng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="78"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1600"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2701"/>
         <source>Angle:</source>
         <translation>Góc:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="79"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1601"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="103"/>
         <source>E1</source>
         <translation>E1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="103"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1625"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1671"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1779"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1814"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1869"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1924"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1978"/>
         <source>Ports</source>
         <translation>Các cổng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="104"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="365"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="366"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="438"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="439"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="508"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="510"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="637"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="638"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1626"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2038"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2200"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2263"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2334"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2492"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2733"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="104"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1626"/>
         <source>Angle (degrees)</source>
         <translation>Góc (độ)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="115"/>
         <source>Calibrate gyroscope</source>
         <translation>Hiệu chuẩn con quay hồi chuyển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="117"/>
         <source>Sets gyroscope&apos;s angle to zero in current position.</source>
         <translation>Đặt góc con quay hồi chuyển về 0 tại vị trí hiện tại.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="150"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="161"/>
         <source>Detect by Videocamera</source>
         <translation>Phát hiện bằng camera video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="152"/>
         <source>Initializes videocamera line or object detector with the color of the object in the middle of the camera`s sight.</source>
         <translation>Khởi tạo bộ phát hiện đường kẻ hoặc đối tượng bằng camera video với màu sắc của đối tượng ở giữa tầm nhìn của camera.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="159"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="658"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1453"/>
         <source>Mode:</source>
         <translation>Chế độ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="190"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="690"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1484"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1977"/>
         <source>Mode</source>
         <translation>Chế độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="201"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="204"/>
         <source>Line Detector into Variable</source>
         <translation>Bộ phát hiện đường kẻ vào biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="203"/>
         <source>Stores videocamera line detector`s value into a given variable.</source>
         <translation>Lưu giá trị của bộ phát hiện đường kẻ bằng camera video vào một biến đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="217"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1026"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2356"/>
         <source>Variable:</source>
         <translation>Biến:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="241"/>
         <source>err</source>
         <translation>err</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="241"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1050"/>
         <source>Variable</source>
         <translation>Biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="252"/>
         <source>TrikDigitalSensorBlock</source>
         <translation>Khối cảm biến kỹ thuật số cơ bản TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="287"/>
         <source>Draw Arc</source>
         <translation>Vẽ cung</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="289"/>
         <source>Draws the arc defined by the rectangle beginning at (x, y) with the specified width and height, and the given startAngle and spanAngle.</source>
         <translation>Vẽ cung tròn được xác định bởi hình chữ nhật bắt đầu tại (x, y) với chiều rộng và chiều cao đã cho, cùng với góc bắt đầu và góc quét.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="296"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="386"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="531"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="585"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="953"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="304"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="394"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="539"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="593"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="961"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="312"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="402"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="601"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1372"/>
         <source>Width:</source>
         <translation>Chiều rộng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="320"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="410"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="609"/>
         <source>Height:</source>
         <translation>Chiều cao:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="328"/>
         <source>Start Angle:</source>
         <translation>Góc bắt đầu:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="336"/>
         <source>Span Angle:</source>
         <translation>Góc quét:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="360"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="364"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="435"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="437"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="564"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="565"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="634"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="636"/>
         <source>5</source>
         <translation>5</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="360"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="435"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="634"/>
         <source>Height</source>
         <translation>Chiều cao</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="361"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="436"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="507"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="563"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="635"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1004"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1308"/>
         <source>Redraw</source>
         <translation>Vẽ lại</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="362"/>
         <source>SpanAngle</source>
         <translation>Góc quét</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="363"/>
         <source>StartAngle</source>
         <translation>Góc bắt đầu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="364"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="437"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="636"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1396"/>
         <source>Width</source>
         <translation>Chiều rộng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="365"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="438"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="564"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="637"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1005"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="366"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="439"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="565"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="638"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1006"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="377"/>
         <source>Draw Ellipse</source>
         <translation>Vẽ hình elip</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="379"/>
         <source>Draws the ellipse defined by the rectangle beginning at (x, y) with the given width and height.</source>
         <translation>Vẽ hình elip được xác định bởi hình chữ nhật bắt đầu tại (x, y) với chiều rộng và chiều cao đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="434"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="633"/>
         <source>Filled</source>
         <translation>Được điền đầy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="450"/>
         <source>Draw Line</source>
         <translation>Vẽ đoạn thẳng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="452"/>
         <source>Draws a segment on the robot screen. The parameters specify the ends of the segment.</source>
         <translation>Vẽ một đoạn thẳng trên màn hình robot. Các tham số xác định hai đầu mút của đoạn thẳng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="459"/>
         <source>X1:</source>
         <translation>X1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="467"/>
         <source>Y1:</source>
         <translation>Y1:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="475"/>
         <source>X2:</source>
         <translation>X2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="483"/>
         <source>Y2:</source>
         <translation>Y2:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="508"/>
         <source>X1</source>
         <translation>X1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="509"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="511"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="509"/>
         <source>X2</source>
         <translation>X2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="510"/>
         <source>Y1</source>
         <translation>Y1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="511"/>
         <source>Y2</source>
         <translation>Y2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="522"/>
         <source>Draw Pixel</source>
         <translation>Vẽ điểm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="524"/>
         <source>Draws one pixel in the specified coordinates on the robot screen.</source>
         <translation>Vẽ một điểm ảnh tại tọa độ đã chỉ định trên màn hình robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="576"/>
         <source>Draw Rectangle</source>
         <translation>Vẽ hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="578"/>
         <source>Draws a rectangle on the robot screen. The parameters specify the coordinates of top-left corner, the width and the height of the rectangle.</source>
         <translation>Vẽ một hình chữ nhật trên màn hình robot. Các tham số xác định tọa độ góc trên bên trái, chiều rộng và chiều cao của hình chữ nhật.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="649"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="660"/>
         <source>Initialize Videocamera</source>
         <translation>Khởi động camera video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="651"/>
         <source>Enables line or object or color detector by videocamera and draws videostream on the robot`s screen.</source>
         <translation>Bật bộ phát hiện đường kẻ hoặc đối tượng hoặc màu sắc bằng camera video và hiển thị luồng video trên màn hình robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="689"/>
         <source>Draw stream</source>
         <translation>Hiển thị luồng video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="701"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="704"/>
         <source>Enable Video Streaming</source>
         <translation>Bật phát trực tiếp video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="703"/>
         <source>Enables video stream on robot. Video then can be watched on TRIK gamepad or in browser using URL http://ROBOT.IP.ADDRESS:8080/?action=stream</source>
         <translation>Bật luồng video trên robot. Video sau đó có thể được xem trên tay cầm điều khiển TRIK hoặc trong trình duyệt với địa chỉ URL http://IP.ROBOT:8080/?action=stream</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="733"/>
         <source>Grayscaled</source>
         <translation>Ảnh xám</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="734"/>
         <source>Quality</source>
         <translation>Chất lượng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="745"/>
         <source>Join Network</source>
         <translation>Kết nối vào mạng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="747"/>
         <source>Sets the hull number and connects with a peer by a (host)name or an IP-address. Target IP-port can be changed too if required.</source>
         <translation>Thiết lập số thân máy và kết nối với một thiết bị khác qua tên (máy chủ) hoặc địa chỉ IP. Cổng IP đích cũng có thể được thay đổi nếu cần.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="754"/>
         <source>Address:</source>
         <translation>Địa chỉ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="762"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1204"/>
         <source>Hull number:</source>
         <translation>Số thân máy:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="786"/>
         <source>192.168.77.1</source>
         <translation>192.168.77.1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="786"/>
         <source>Address</source>
         <translation>Địa chỉ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="787"/>
         <source>Hull Number</source>
         <translation>Số thân máy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="799"/>
         <source>Led</source>
         <translation>Đèn LED</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="801"/>
         <source>Sets the color of the LED on the robot`s front panel.</source>
         <translation>Thiết lập màu sắc đèn LED trên bảng điều khiển phía trước của robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="808"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1283"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1328"/>
         <source>Color:</source>
         <translation>Màu:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="833"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1307"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1352"/>
         <source>Color</source>
         <translation>Màu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="844"/>
         <source>Play Sound</source>
         <translation>Phát âm thanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="846"/>
         <source>Plays on the robot a sound file (.wav or .mp3) previously uploaded to it.</source>
         <translation>Phát một tệp âm thanh (.wav hoặc .mp3) đã được tải lên robot trước đó.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="853"/>
         <source>File name:</source>
         <translation>Tên tệp:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="878"/>
         <source>media/beep.wav</source>
         <translation>media/beep.wav</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="878"/>
         <source>File Name</source>
         <translation>Tên tệp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="889"/>
         <source>Play Tone</source>
         <translation>Phát âm tần số</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="891"/>
         <source>Plays on the robot a sound with the given frequency and duration.</source>
         <translation>Phát một âm thanh với tần số và thời lượng đã cho trên robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="898"/>
         <source>Frequency:</source>
         <translation>Tần số:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="899"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="907"/>
         <source>Duration:</source>
         <translation>Thời lượng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="908"/>
         <source>ms</source>
         <translation>ms</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="932"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="933"/>
         <source>1000</source>
         <translation>1000</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="932"/>
         <source>Duration</source>
         <translation>Thời lượng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="933"/>
         <source>Frequency</source>
         <translation>Tần số</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="944"/>
         <source>Print Text</source>
         <translation>In văn bản</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="946"/>
         <source>Prints a given line in the specified coordinates and font size on the robot`s screen. The value of &apos;Text&apos; property is interpreted as a plain text unless &apos;Evaluate&apos; property is set to true, then it will be interpreted as an expression (that may be useful for example when debugging variables values).</source>
         <translation>In một dòng văn bản đã cho tại tọa độ và cỡ chữ đã chỉ định trên màn hình robot. Giá trị thuộc tính &apos;Văn bản&apos; được hiểu là văn bản thuần túy trừ khi thuộc tính &apos;Đánh giá&apos; được đặt là đúng, khi đó nó sẽ được hiểu là một biểu thức (có thể hữu ích, ví dụ khi gỡ lỗi giá trị các biến).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="969"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1151"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2813"/>
         <source>Text:</source>
         <translation>Văn bản:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="977"/>
         <source>Font size:</source>
         <translation>Cỡ chữ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1001"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1175"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1572"/>
         <source>Evaluate</source>
         <translation>Đánh giá</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1002"/>
         <source>20</source>
         <translation>20</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1002"/>
         <source>Font size</source>
         <translation>Cỡ chữ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1003"/>
         <source>Enter some text here</source>
         <translation>Nhập văn bản tại đây</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1003"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1176"/>
         <source>Text</source>
         <translation>Văn bản</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1005"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1006"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1396"/>
         <source>1</source>
         <translation>1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1017"/>
         <source>Read Lidar To Variable</source>
         <translation>Đọc dữ liệu Lidar vào biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1019"/>
         <source>Assigns a value from lidar to a given variable.</source>
         <translation>Gán giá trị từ lidar vào một biến đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1050"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1061"/>
         <source>Remove File</source>
         <translation>Xóa tệp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1063"/>
         <source>Removes a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
         <translation>Xóa một tệp. Đường dẫn tệp có thể là tuyệt đối hoặc tương đối so với thư mục chứa tệp thực thi TRIK Studio.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1070"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2805"/>
         <source>File:</source>
         <translation>Tệp:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1094"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2837"/>
         <source>output.txt</source>
         <translation>output.txt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1094"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2837"/>
         <source>File</source>
         <translation>Tệp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1105"/>
         <source>Sad Smile</source>
         <translation>Biểu tượng cảm xúc buồn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1107"/>
         <source>Draws a sad smile on the robot`s screen :(</source>
         <translation>Vẽ biểu tượng cảm xúc buồn trên màn hình robot :(</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1142"/>
         <source>Say</source>
         <translation>Nói</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1144"/>
         <source>Synthesizes the given phrase and plays it on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Text&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
         <translation>Tổng hợp cụm từ đã cho và phát trên robot. Nếu thuộc tính &apos;Đánh giá&apos; được đặt là đúng thì giá trị thuộc tính &apos;Văn bản&apos; sẽ được hiểu là một công thức, nếu không thì sẽ được hiểu là chuỗi ký tự thông thường.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1176"/>
         <source>Hi!</source>
         <translation>Xin chào!</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1187"/>
         <source>Send message</source>
         <translation>Gửi tin nhắn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1189"/>
         <source>Sends message to another robot.</source>
         <translation>Gửi tin nhắn đến một robot khác.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1196"/>
         <source>Message:</source>
         <translation>Tin nhắn:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1240"/>
         <source>TrikSensorBlock</source>
         <translation>Khối cảm biến cơ bản TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1274"/>
         <source>Background Color</source>
         <translation>Màu nền</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1276"/>
         <source>Sets the background color of the current picture on the robot`s screen.</source>
         <translation>Thiết lập màu nền của hình ảnh hiện tại trên màn hình robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1319"/>
         <source>Painter Color</source>
         <translation>Màu vẽ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1321"/>
         <source>Sets the painter color.</source>
         <translation>Thiết lập màu vẽ.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1363"/>
         <source>Painter Width</source>
         <translation>Độ rộng nét vẽ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1365"/>
         <source>Sets the painter width.</source>
         <translation>Thiết lập độ rộng nét vẽ.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1407"/>
         <source>Smile</source>
         <translation>Biểu tượng cảm xúc vui</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1409"/>
         <source>Draws a smile on the robot`s screen :)</source>
         <translation>Vẽ biểu tượng cảm xúc vui trên màn hình robot :)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1444"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1455"/>
         <source>Stop Videocamera</source>
         <translation>Dừng camera video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1446"/>
         <source>Stops line or object or color detector by videocamera.</source>
         <translation>Dừng bộ phát hiện đường kẻ hoặc đối tượng hoặc màu sắc bằng camera video.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1495"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1498"/>
         <source>Disable Video Streaming</source>
         <translation>Tắt phát trực tiếp video</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1497"/>
         <source>Disables video stream on robot.</source>
         <translation>Tắt luồng video trên robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1537"/>
         <source>System Call</source>
         <translation>Gọi hệ thống</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1539"/>
         <source>Invokes bash script-style command on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Command&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
         <translation>Thực thi lệnh kiểu script bash trên robot. Nếu thuộc tính &apos;Đánh giá&apos; được đặt là đúng thì giá trị thuộc tính &apos;Lệnh&apos; sẽ được hiểu là một công thức, nếu không thì sẽ được hiểu là chuỗi ký tự thông thường.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1546"/>
         <source>Command:</source>
         <translation>Lệnh:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1570"/>
         <source>Code</source>
         <translation>Mã</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1571"/>
         <source>echo 123</source>
         <translation>echo 123</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1571"/>
         <source>Command</source>
         <translation>Lệnh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1625"/>
         <source>S1</source>
         <translation>S1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1637"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1745"/>
         <source>Clear Encoder</source>
         <translation>Xóa bộ đếm encoder</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1639"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1747"/>
         <source>Nullifies tacho limit of the motors on the given ports.</source>
         <translation>Đặt lại giá trị giới hạn đếm vòng quay của động cơ tại các cổng đã cho về 0.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1671"/>
         <source>E1, E2, E3, E4</source>
         <translation>E1, E2, E3, E4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1682"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2095"/>
         <source>Wait for Encoder</source>
         <translation>Chờ encoder</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1684"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2097"/>
         <source>Waits till the tacho limit of the motor on the given port will reach the value of the &apos;Tacho Limit&apos; parameter.</source>
         <translation>Chờ cho đến khi giá trị giới hạn đếm vòng quay của động cơ tại cổng đã cho đạt đến giá trị tham số &apos;Giới hạn đếm vòng quay&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1691"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2104"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2221"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2285"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2409"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2452"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2514"/>
         <source>Port:</source>
         <translation>Cổng:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1699"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2112"/>
         <source>Tacho Limit:</source>
         <translation>Giới hạn đếm vòng quay:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1707"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2006"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2120"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2175"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2237"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2301"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2468"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2709"/>
         <source>Sign:</source>
         <translation>Giá trị đọc được:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1733"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2040"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2146"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2201"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2265"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2336"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2494"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2734"/>
         <source>Sign</source>
         <translation>Giá trị đã đọc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1779"/>
         <source>B1, B2, B3, B4</source>
         <translation>B1, B2, B3, B4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1790"/>
         <source>TrikV6EngineMovementCommand</source>
         <translation>Khối điều khiển động cơ TRIK v6</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1814"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1869"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1924"/>
         <source>M3, M4</source>
         <translation>M3, M4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1815"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1870"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1925"/>
         <source>100</source>
         <translation>100</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1815"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1870"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1925"/>
         <source>Power (%)</source>
         <translation>Tốc độ (%)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1826"/>
         <source>Motors Backward</source>
         <translation>Động cơ lùi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1828"/>
         <source>Enables motors on the given ports in reverse mode with the given power. Ports are specified in accordance with TRIK controller notations (for example M1, E2) and divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the usual mode.</source>
         <translation>Bật động cơ ở chế độ đảo chiều trên các cổng đã cho với công suất xác định. Các cổng được chỉ định theo ký hiệu của bộ điều khiển TRIK (ví dụ: M1, E2) và phân tách bằng dấu phẩy. Công suất được xác định bằng phần trăm, giá trị từ -100 đến 100; nếu giá trị âm được chỉ định, động cơ sẽ hoạt động ở chế độ bình thường.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1843"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1898"/>
         <source>Power:</source>
         <translation>Tốc độ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1844"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1899"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1881"/>
         <source>Motors Forward</source>
         <translation>Động cơ tiến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1883"/>
         <source>Enables motors on the given ports with the given power. Ports are specified in accordance with TRIK controller notations (for example M1, E2) and divided by commas. The power is specified in percents with the number from -100 to 100, if negative number is specified then the motor is enabled in the reverse mode.</source>
         <translation>Bật động cơ trên các cổng đã cho với công suất xác định. Các cổng được chỉ định theo ký hiệu của bộ điều khiển TRIK (ví dụ: M1, E2) và phân tách bằng dấu phẩy. Công suất được xác định bằng phần trăm, giá trị từ -100 đến 100; nếu giá trị âm được chỉ định, động cơ sẽ hoạt động ở chế độ đảo chiều.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1936"/>
         <source>Stop Motors</source>
         <translation>Dừng động cơ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1938"/>
         <source>Disables motors on the given ports.</source>
         <translation>Tắt động cơ trên các cổng đã cho.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1978"/>
         <source>M1, M2, M3, M4</source>
         <translation>M1, M2, M3, M4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1989"/>
         <source>Wait for Accelerometer</source>
         <translation>Chờ cảm biến gia tốc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1998"/>
         <source>Acceleration:</source>
         <translation>Gia tốc:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2014"/>
         <source>Axis:</source>
         <translation>Trục:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2038"/>
         <source>Acceleration</source>
         <translation>Gia tốc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2039"/>
         <source>Acceleration Axis</source>
         <translation>Trục</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2051"/>
         <source>Wait for Button</source>
         <translation>Chờ nhấn nút</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2053"/>
         <source>Waits for press of a button on a brick.</source>
         <translation>Chờ nhấn nút trên thân robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2060"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2566"/>
         <source>Button:</source>
         <translation>Nút:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2084"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2590"/>
         <source>Button</source>
         <translation>Nút</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2158"/>
         <source>Wait for Gyroscope</source>
         <translation>Chờ cảm biến con quay hồi chuyển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2160"/>
         <source>Waits till the value returned by the gyroscope on the given port will be greater or less than the given in the &apos;Degrees&apos; parameter value.</source>
         <translation>Chờ cho đến khi giá trị trả về từ cảm biến con quay hồi chuyển tại cổng đã cho lớn hơn hoặc nhỏ hơn giá trị tham số &apos;Độ&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2167"/>
         <source>Degrees:</source>
         <translation>Độ:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2200"/>
         <source>Degrees</source>
         <translation>Độ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2212"/>
         <source>Wait for Infrared Distance</source>
         <translation>Chờ cảm biến khoảng cách hồng ngoại</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2214"/>
         <source>Waits till the value returned by the infrared sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value. By default on ports A1 and A2 the distance is specified in centimeters (from 0 to 100). It is not recommended to plug IR sensor into other ports because its raw value will be processed by software on robot with expectation of another sensor type.</source>
         <translation>Chờ cho đến khi giá trị khoảng cách trả về từ cảm biến hồng ngoại không lớn hơn hoặc nhỏ hơn giá trị tham số &apos;Khoảng cách&apos;. Một tham số khác là số cổng mà cảm biến được nối. Tham số khác xác định phép so sánh sẽ dùng để so sánh với khoảng cách nhập vào. Theo mặc định, trên các cổng A1 và A2 khoảng cách được tính bằng cm (từ 0 đến 100), không nên nối cảm biến IR vào các cổng khác vì giá trị thô từ cảm biến sẽ được phần mềm xử lý với giả định loại cảm biến khác.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2229"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2460"/>
         <source>Distance:</source>
         <translation>Khoảng cách:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2263"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2492"/>
         <source>Distance</source>
         <translation>Khoảng cách</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2276"/>
         <source>Wait for Light</source>
         <translation>Chờ cảm biến ánh sáng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2278"/>
         <source>Waits till the value returned by the light sensor on the given port will be greater or less than the given in the &apos;Percents&apos; parameter value (0 to 100).</source>
         <translation>Chờ cho đến khi giá trị trả về từ cảm biến ánh sáng tại cổng đã cho lớn hơn hoặc nhỏ hơn giá trị tham số &apos;Phần trăm&apos; (0 đến 100). Một tham số khác là số cổng mà cảm biến màu được nối. Tham số khác xác định phép so sánh sẽ dùng để so sánh với giá trị tham số &apos;Phần trăm&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2293"/>
         <source>Percents:</source>
         <translation>Phần trăm:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2334"/>
         <source>Percents</source>
         <translation>Phần trăm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2347"/>
         <source>Wait for Message</source>
         <translation>Nhận tin nhắn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2349"/>
         <source>Stores a message from another robot into a given variable. When no incoming messages are present at the moment, a robot will wait for incoming message if &apos;Synchronized&apos; property is true, and empty string will be assigned to a variable otherwise.</source>
         <translation>Lưu tin nhắn từ robot khác vào một biến đã cho. Nếu thuộc tính &quot;Chờ tin nhắn&quot; được bật, robot sẽ chờ khi không có tin nhắn đến; nếu không, biến sẽ được gán giá trị chuỗi rỗng.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2364"/>
         <source>Synchronized:</source>
         <translation>Chờ tin nhắn:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2388"/>
         <source>Synchronized</source>
         <translation>Chờ tin nhắn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2400"/>
         <source>Wait for Motion</source>
         <translation>Chờ cảm biến chuyển động</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2402"/>
         <source>Waits till the motion sensor on the given port is triggered.</source>
         <translation>Chờ cho đến khi cảm biến chuyển động tại cổng đã cho được kích hoạt.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2403"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2443"/>
         <source>Wait for Ultrasonic Distance</source>
         <translation>Chờ cảm biến khoảng cách siêu âm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2445"/>
         <source>Waits till the value returned by the ultrasonic sensor on the given port will be greater or less than the given in the &apos;Distance&apos; parameter value (the distance is specified in centimeters, from 0 to 300).</source>
         <translation>Chờ cho đến khi khoảng cách trả về từ cảm biến siêu âm không lớn hơn hoặc nhỏ hơn giá trị tham số &apos;Khoảng cách&apos; (khoảng cách tính bằng cm, từ 0 đến 300). Một tham số khác là số cổng mà cảm biến khoảng cách được nối. Tham số khác xác định phép so sánh sẽ dùng để so sánh với khoảng cách nhập vào.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2505"/>
         <source>Wait for Touch Sensor</source>
         <translation>Chờ cảm biến chạm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2507"/>
         <source>Waits till the touch sensor is pressed. The only parameter is a sensor`s port number (1, 2, 3 or 4).</source>
         <translation>Chờ cho đến khi cảm biến chạm được nhấn. Tham số là số cổng nối cảm biến. Giá trị hợp lệ: 1, 2, 3, 4.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2550"/>
         <source>Wait Gamepad Button</source>
         <translation>Chờ nút điều khiển từ xa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2552"/>
         <source>Waits for Android gamepad &apos;magic button&apos; press. Buttons are identified by numbers from 1 to 5 (from left to right)</source>
         <translation>Chờ nhấn một trong các &apos;nút ma thuật&apos; trên điều khiển Android. Các nút được xác định bằng số từ 1 đến 5 (từ trái sang phải)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2553"/>
         <source>Wait gamepad button</source>
         <translation>Chờ nút điều khiển từ xa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2601"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2604"/>
         <source>Wait for Gamepad Connect</source>
         <translation>Chờ kết nối điều khiển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2603"/>
         <source>Waits until Android gamepad is connected.</source>
         <translation>Chờ cho đến khi điều khiển Android được kết nối.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2643"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2646"/>
         <source>Wait for Gamepad Disconnect</source>
         <translation>Chờ ngắt kết nối điều khiển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2645"/>
         <source>Waits until Android gamepad is disconnected.</source>
         <translation>Chờ cho đến khi điều khiển Android bị ngắt kết nối.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2685"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2688"/>
         <source>Wait for Gamepad Wheel</source>
         <translation>Chờ &apos;vô lăng&apos; trên điều khiển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2687"/>
         <source>Waits till the value returned by gamepad wheel be greater or less than the given in the &apos;Angle&apos; parameter value. Angle is measured from -100 (max left) to 100 (max right).</source>
         <translation>Chờ cho đến khi giá trị trả về từ &apos;vô lăng&apos; điều khiển Android lớn hơn (hoặc nhỏ hơn) giá trị đã cho. Góc được đo từ -100 (trái cực đại) đến 100 (phải cực đại).</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2733"/>
         <source>Angle</source>
         <translation>Góc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2745"/>
         <source>Wait Pad Press</source>
         <translation>Chờ nhấn vùng điều khiển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2747"/>
         <source>Waits for Android gamepad pad press (left pad has number 1, right pad - number 2).</source>
         <translation>Chờ nhấn vào một trong các vùng cảm ứng trên điều khiển Android. Vùng trái có số 1, vùng phải có số 2.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2748"/>
         <source>Wait pad press</source>
         <translation>Chờ nhấn vùng điều khiển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2761"/>
         <source>Pad:</source>
         <translation>Điều khiển:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2785"/>
         <source>Pad</source>
         <translation>Điều khiển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2796"/>
         <source>Write To File</source>
         <translation>Ghi vào tệp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2798"/>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
         <translation>Ghi giá trị đã cho vào tệp. Đường dẫn tệp có thể là tuyệt đối hoặc tương đối so với thư mục chứa trik-studio.exe.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="160"/>
         <source>RobotsDiagram</source>
         <translation>Biểu đồ hành vi robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="167"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="168"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="169"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="170"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="171"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="172"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="173"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="174"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="175"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="176"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="177"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="178"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="179"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="180"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="181"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="182"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="183"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="184"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="185"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="186"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="187"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="188"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="189"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="190"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="191"/>
         <source>Actions</source>
         <translation>Hành động</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="192"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="193"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="194"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="195"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="196"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="197"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="198"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="199"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="200"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="201"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="202"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="203"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="204"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="205"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="206"/>
         <source>Wait</source>
         <translation>Chờ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="207"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="208"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="209"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="210"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="211"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="212"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="213"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="214"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="215"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="216"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="217"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="218"/>
         <source>Drawing</source>
         <translation>Vẽ</translation>
     </message>
@@ -1264,28 +851,22 @@
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1228"/>
         <source>Hull Number</source>
         <translation>Số thân máy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1229"/>
         <source>Message</source>
         <translation>Tin nhắn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="1734"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2147"/>
         <source>Tacho Limit</source>
         <translation>Giới hạn vòng quay</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2389"/>
         <source>Variable</source>
         <translation>Biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/elements.h" line="2838"/>
         <source>Text</source>
         <translation>Văn bản</translation>
     </message>
@@ -1293,389 +874,302 @@
 <context>
     <name>TrikMetamodelPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="232"/>
         <source>norm</source>
         <translation>bình thường</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="232"/>
         <source>x-axis</source>
         <translation>trục x</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="232"/>
         <source>y-axis</source>
         <translation>trục y</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="232"/>
         <source>z-axis</source>
         <translation>trục z</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="234"/>
         <source>Composite</source>
         <translation>Hợp thể</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="234"/>
         <source>None</source>
         <translation>Không có</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="234"/>
         <source>Shared</source>
         <translation>Chung</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
         <source>black</source>
         <translation>đen</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
         <source>blue</source>
         <translation>xanh dương</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>cyan</source>
         <translation>xanh lơ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark blue</source>
         <translation>xanh dương đậm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark cyan</source>
         <translation>xanh lơ đậm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark gray</source>
         <translation>xám đậm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark green</source>
         <translation>xanh lá đậm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark magenta</source>
         <translation>đỏ tía đậm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark red</source>
         <translation>đỏ đậm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>dark yellow</source>
         <translation>vàng đậm</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>gray</source>
         <translation>xám</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="256"/>
         <source>green</source>
         <translation>xanh lá</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>light gray</source>
         <translation>xám nhạt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
         <source>magenta</source>
         <translation>đỏ tía</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="256"/>
         <source>red</source>
         <translation>đỏ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
         <source>white</source>
         <translation>trắng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="236"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="242"/>
         <source>yellow</source>
         <translation>vàng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="238"/>
         <source>brake</source>
         <translation>phanh</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="238"/>
         <source>float</source>
         <translation>trượt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="240"/>
         <source>Concurrent</source>
         <translation>Đồng thời</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="240"/>
         <source>Guarded</source>
         <translation>Được bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="240"/>
         <source>Sequential</source>
         <translation>Tuần tự</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="244"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="266"/>
         <source>Line sensor</source>
         <translation>Cảm biến đường line</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="244"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="266"/>
         <source>Object sensor</source>
         <translation>Cảm biến vật thể</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="246"/>
         <source>greater</source>
         <translation>lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="246"/>
         <source>less</source>
         <translation>nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="246"/>
         <source>not greater</source>
         <translation>không lớn hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="246"/>
         <source>not less</source>
         <translation>không nhỏ hơn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="248"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="270"/>
         <source>false</source>
         <translation>sai</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="248"/>
         <source>body</source>
         <translation>thân vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="248"/>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="270"/>
         <source>true</source>
         <translation>đúng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="250"/>
         <source>15</source>
         <translation>15</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="250"/>
         <source>30</source>
         <translation>30</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="250"/>
         <source>50</source>
         <translation>50</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="250"/>
         <source>80</source>
         <translation>80</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="252"/>
         <source>In</source>
         <translation>Đầu vào</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="252"/>
         <source>Inout</source>
         <translation>Vào-ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="252"/>
         <source>Out</source>
         <translation>Đầu ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="252"/>
         <source>Return</source>
         <translation>Trả về</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Down</source>
         <translation>Xuống</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Enter</source>
         <translation>Nhập</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Esc</source>
         <translation>Thoát</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Left</source>
         <translation>Trái</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Right</source>
         <translation>Phải</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="254"/>
         <source>Up</source>
         <translation>Lên</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="256"/>
         <source>off</source>
         <translation>tắt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="256"/>
         <source>orange</source>
         <translation>cam</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="258"/>
         <source>E1</source>
         <translation>E1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="258"/>
         <source>E2</source>
         <translation>E2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="258"/>
         <source>E3</source>
         <translation>E3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="258"/>
         <source>E4</source>
         <translation>E4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A5</source>
         <translation>A5</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="260"/>
         <source>A6</source>
         <translation>A6</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="262"/>
         <source>D1</source>
         <translation>D1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="262"/>
         <source>D2</source>
         <translation>D2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="264"/>
         <source>B1</source>
         <translation>B1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="264"/>
         <source>B2</source>
         <translation>B2</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="264"/>
         <source>B3</source>
         <translation>B3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="264"/>
         <source>B4</source>
         <translation>B4</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="266"/>
         <source>Color sensor</source>
         <translation>Cảm biến màu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="268"/>
         <source>Package</source>
         <translation>Gói</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="268"/>
         <source>Private</source>
         <translation>Riêng tư</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="268"/>
         <source>Protected</source>
         <translation>Được bảo vệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/editor/trik/generated/pluginInterface.cpp" line="268"/>
         <source>Public</source>
         <translation>Công khai</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/ev3/ev3GeneratorBase_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/ev3/ev3GeneratorBase_vi.ts
@@ -4,13 +4,10 @@
 <context>
     <name>ev3::Ev3GeneratorFactory</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/sendMailGenerator.cpp" line="35"/>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/receiveMailGenerator.cpp" line="38"/>
         <source>There is already mailbox with same name, but different msg type</source>
         <translation>Đã tồn tại hộp thư với cùng tên nhưng loại tin nhắn khác</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3GeneratorBase/src/simpleGenerators/receiveMailGenerator.cpp" line="42"/>
         <source>There are too many mailboxes, max size is 30</source>
         <translation>Có quá nhiều hộp thư, kích thước tối đa là 30</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/ev3/ev3RbfGenerator_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/ev3/ev3RbfGenerator_vi.ts
@@ -4,22 +4,18 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfMasterGenerator.cpp" line="60"/>
         <source>There is no opened diagram</source>
         <translation>Chưa có sơ đồ nào được mở</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="821"/>
         <source>/* Warning: cast from string to numeric type is not supported */ 0</source>
         <translation>/* Cảnh báo: chuyển đổi kiểu từ chuỗi sang kiểu số chưa được hỗ trợ */ 0</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="825"/>
         <source>/* Warning: autocast from array to other type is not supported */ 0</source>
         <translation>/* Cảnh báo: tự động chuyển kiểu từ mảng sang kiểu khác không được hỗ trợ */ 0</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/lua/ev3LuaPrinter.cpp" line="829"/>
         <source>/* Warning: autocast is supported only for numeric types */ 0</source>
         <translation>/* Cảnh báo: tự động chuyển kiểu chỉ hỗ trợ cho các kiểu số */ 0</translation>
     </message>
@@ -27,92 +23,74 @@
 <context>
     <name>ev3::rbf::Ev3RbfGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="34"/>
         <source>Autonomous mode (USB)</source>
         <translation>Chế độ tự động (USB)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="35"/>
         <source>Autonomous mode (Bluetooth)</source>
         <translation>Chế độ tự động (Bluetooth)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="41"/>
         <source>Generate to Ev3 Robot Byte Code File</source>
         <translation>Tạo thành tệp byte code Ev3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="45"/>
         <source>Upload program</source>
         <translation>Tải chương trình lên</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="56"/>
         <source>Run program</source>
         <translation>Chạy chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="64"/>
         <source>Stop robot</source>
         <translation>Dừng chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="69"/>
         <source>EV3 Source Code language</source>
         <translation>Tệp byte code EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="99"/>
         <source>Generate Ev3 Robot Byte Code File</source>
         <translation>Tạo thành tệp byte code Ev3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="100"/>
         <source>Upload EV3 Program</source>
         <translation>Tải chương trình EV3 lên</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="101"/>
         <source>Run EV3 Program</source>
         <translation>Chạy chương trình trên EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="102"/>
         <source>Stop EV3 Program</source>
         <translation>Dừng chương trình trên EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="141"/>
         <source>Can&apos;t write source code files to disk!</source>
         <translation>Không thể ghi các tệp mã nguồn ra đĩa!</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="147"/>
         <source>Compilation error occured.</source>
         <translation>Đã xảy ra lỗi biên dịch.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="166"/>
         <source>The program has been uploaded</source>
         <translation>Chương trình đã được tải lên thành công</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="167"/>
         <source>Do you want to run it?</source>
         <translation>Bạn có muốn chạy chương trình này không?</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="282"/>
         <source>Could not upload file to robot. Connect to a robot via %1.</source>
         <translation>Không thể tải tệp lên robot. Hãy kết nối robot qua %1.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="283"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/ev3/ev3RbfGenerator/ev3RbfGeneratorPlugin.cpp" line="283"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/generatorBase_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/generatorBase_vi.ts
@@ -4,127 +4,102 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="79"/>
         <source>There is no opened diagram</source>
         <translation>Chưa có sơ đồ nào được mở</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="44"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>Không có gì để tạo, sơ đồ không có khối bắt đầu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="49"/>
         <source>Initial node must not have incoming links</source>
         <translation>Khối &quot;Bắt đầu&quot; không được có liên kết đi vào</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="83"/>
         <source>This element must have exactly ONE outgoing link</source>
         <translation>Phần tử này phải có đúng MỘT liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="93"/>
         <source>Final node must not have outgoing links</source>
         <translation>Khối &quot;Kết thúc&quot; không được có liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="101"/>
         <source>If block must have exactly TWO outgoing links</source>
         <translation>Khối điều kiện phải có đúng HAI liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="116"/>
         <source>Two outgoing links marked with &apos;true&apos; found</source>
         <translation>Tìm thấy hai liên kết đi ra được đánh dấu là &quot;đúng&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="125"/>
         <source>Two outgoing links marked with &apos;false&apos; found</source>
         <translation>Tìm thấy hai liên kết đi ra được đánh dấu là &quot;sai&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="134"/>
         <source>There must be at least one link with &quot;true&quot; or &quot;false&quot; marker on it</source>
         <translation>Phải có ít nhất một liên kết được đánh dấu &quot;đúng&quot; hoặc &quot;sai&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="163"/>
         <source>Loop block must have exactly TWO outgoing links</source>
         <translation>Khối vòng lặp phải có đúng HAI liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="177"/>
         <source>Two outgoing links marked with &quot;body&quot; found</source>
         <translation>Tìm thấy hai liên kết đi ra được đánh dấu là &quot;thân vòng lặp&quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="185"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Phải có một liên kết được đánh dấu &quot;thân vòng lặp&quot; đi ra từ khối vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="195"/>
         <source>Outgoing links from loop block must be connected to different blocks</source>
         <translation>Các liên kết đi ra từ khối vòng lặp phải nối tới các khối khác nhau</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="213"/>
         <source>There must be at list TWO links outgoing from switch block</source>
         <translation>Phải có ít nhất HAI liên kết đi ra từ khối lựa chọn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="223"/>
         <source>There must be exactly one link without marker on it (default branch)</source>
         <translation>Phải có đúng một liên kết không có nhãn (nhánh mặc định)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="230"/>
         <source>Duplicate case branch: &apos;%1&apos;</source>
         <translation>Nhánh case bị trùng: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="239"/>
         <source>There must be a link without marker on it (default branch)</source>
         <translation>Phải có một liên kết không có nhãn (nhánh mặc định)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="246"/>
         <source>Unknown block type</source>
         <translation>Loại khối không xác định</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="252"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Khối nhiệm vụ song song phải có ít nhất HAI liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/primaryControlFlowValidator.cpp" line="278"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được nối tới khối nào</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/parts/subprograms.cpp" line="83"/>
         <source>Graphical diagram instance not found</source>
         <translation>Không tìm thấy mô hình đồ họa của sơ đồ chương trình con</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/parts/subprograms.cpp" line="220"/>
         <source>Please enter valid c-style name for subprogram &quot;</source>
         <translation>Vui lòng nhập tên đúng định dạng C cho chương trình con &quot;</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/parts/subprograms.cpp" line="226"/>
         <source>Subprograms should have unique names, please rename</source>
         <translation>Các chương trình con phải có tên duy nhất, vui lòng đổi tên</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/converters/reservedVariablesConverter.cpp" line="64"/>
         <source>Device on port %1 is not configured. Please select it on the &quot;Configure devices&quot; panel on the right-hand side.</source>
         <translation>Thiết bị ở cổng %1 chưa được cấu hình. Vui lòng chọn loại thiết bị trên bảng &quot;Cấu hình thiết bị&quot; ở phía bên phải.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/converters/reservedVariablesConverter.cpp" line="68"/>
         <source>/* ERROR: SELECT DEVICE TYPE */</source>
         <translation>/* LỖI: CHỌN LOẠI THIẾT BỊ */</translation>
     </message>
@@ -132,17 +107,14 @@
 <context>
     <name>generatorBase::MasterGeneratorBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="119"/>
         <source>This diagram cannot be generated into the structured code. Generating it into the code with &apos;goto&apos; statements.</source>
         <translation>Sơ đồ này không thể được chuyển thành mã có cấu trúc. Đang tạo mã với các lệnh &apos;goto&apos;.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="134"/>
         <source>This diagram cannot be even generated into the code with &apos;goto&apos;statements. Please contact the developers.</source>
         <translation>Sơ đồ này thậm chí không thể được chuyển thành mã với các lệnh &apos;goto&apos;. Vui lòng liên hệ với nhà phát triển.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/generators/generatorBase/src/masterGeneratorBase.cpp" line="136"/>
         <source>This diagram cannot be generated into the structured code.</source>
         <translation>Sơ đồ này không thể được chuyển thành mã có cấu trúc.</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/nxt/nxtOsekCGenerator_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/nxt/nxtOsekCGenerator_vi.ts
@@ -4,132 +4,106 @@
 <context>
     <name>nxt::NxtFlashTool</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="75"/>
         <source>Robot is already being flashed</source>
         <translation>Robot đang được nạp firmware</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="83"/>
         <source>Firmware file not found in nxt-tools directory.</source>
         <translation>Không tìm thấy tệp firmware trong thư mục nxt-tools.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="96"/>
         <source>Flashing robot is possible only by USB. Please switch to USB mode.</source>
         <translation>Việc nạp firmware cho robot chỉ có thể thực hiện qua USB. Vui lòng chuyển sang chế độ USB.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="106"/>
         <source>Firmware flash started. Please don&apos;t disconnect robot during the process</source>
         <translation>Quá trình nạp firmware đã bắt đầu. Vui lòng không ngắt kết nối robot trong quá trình này</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="117"/>
         <source>Could not open %1 for reading.</source>
         <translation>Không thể mở %1 để đọc.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="125"/>
         <source>Firmware file is too large to fit into NXT brick memory.</source>
         <translation>Tệp firmware quá lớn để lưu vào bộ nhớ của NXT.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="135"/>
         <source>Could not write firmware into NXT memory.</source>
         <translation>Không thể ghi firmware vào bộ nhớ NXT.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="142"/>
         <source>Firmware successfully flashed into robot, but starting it failed.</source>
         <translation>Firmware đã được nạp thành công vào robot, nhưng việc khởi động thất bại. Hãy thử khởi động lại robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="148"/>
         <source>Flashing process completed successfully.</source>
         <translation>Quá trình nạp firmware đã hoàn tất thành công.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="154"/>
         <source>Flashing NXT brick...</source>
         <translation>Đang nạp firmware cho robot...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="213"/>
         <source>The program has been uploaded</source>
         <translation>Chương trình đã được tải lên</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="214"/>
         <source>Do you want to run it?</source>
         <translation>Bạn có muốn chạy chương trình này không?</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="220"/>
         <source>Uploading is already running</source>
         <translation>Quá trình tải lên đang diễn ra</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="247"/>
         <source>Uploading program started. Please don&apos;t disconnect robot during the process</source>
         <translation>Quá trình tải chương trình lên robot đã bắt đầu. Vui lòng không ngắt kết nối robot trong quá trình này</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="258"/>
         <source>Uploading failed. Make sure that X-server allows root to run GUI applications</source>
         <translation>Tải chương trình lên thất bại. Hãy đảm bảo rằng TRIKStudio được chạy với quyền phù hợp</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="260"/>
         <source>You need to have superuser privileges to flash NXT robot</source>
         <translation>Việc tải chương trình lên thất bại. Có thể bạn cần thử khởi động lại môi trường với quyền siêu người dùng</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="303"/>
         <source>Compilation error occured. Please check your function blocks syntax. If you sure in their validness contact developers</source>
         <translation>Đã xảy ra lỗi biên dịch. Vui lòng kiểm tra cú pháp các biểu thức trong các khối &quot;Hàm&quot;. Nếu bạn chắc chắn rằng chúng đúng, vui lòng liên hệ với nhà phát triển</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="306"/>
         <source>Could not upload program. Make sure the robot is connected and ON</source>
         <translation>Không thể tải chương trình lên robot. Hãy đảm bảo robot đã được bật và kết nối với máy tính</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="308"/>
         <source>If you are using GNU/Linux visit https://help.trikset.com/nxt/run-upload-programs to get instructions</source>
         <translation>Nếu bạn đang sử dụng GNU/Linux, hãy truy cập https://help.trikset.com/nxt/run-upload-programs để xem hướng dẫn</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="315"/>
         <source>QReal requires superuser privileges to upload programs on NXT robot</source>
         <translation>Để tải chương trình lên robot NXT, cần chạy TRIKStudio với quyền quản trị</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="349"/>
         <source>Error in reading from firmware file: %1</source>
         <translation>Lỗi khi đọc từ tệp firmware: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="572"/>
         <source>Could not find %1. Check your program was compiled and try again.</source>
         <translation>Không tìm thấy %1. Hãy kiểm tra chương trình đã được biên dịch, đường dẫn không chứa khoảng trắng hay ký tự tiếng Nga, rồi thử lại.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="581"/>
         <source>Could not delete old file. Make sure the robot is connected, turned on.</source>
         <translation>Không thể xóa tệp cũ trên robot. Vui lòng kiểm tra robot đã được bật và kết nối với máy tính, rồi thử lại.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="587"/>
         <source>Could not upload program. Make sure the robot is connected, turned on and has enough free memory.</source>
         <translation>Không thể tải chương trình lên. Hãy đảm bảo robot đã được bật, kết nối với máy tính và còn đủ bộ nhớ trống.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="600"/>
         <source>Could not close file on brick. Probably connection to NXT lost at the last stage of uploading</source>
         <translation>Không thể đóng tệp trên robot sau khi ghi dữ liệu. Có thể kết nối với NXT đã bị mất ở giai đoạn cuối của quá trình tải lên</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtFlashTool.cpp" line="606"/>
         <source>Uploading completed successfully</source>
         <translation>Tải chương trình lên thành công</translation>
     </message>
@@ -137,43 +111,34 @@
 <context>
     <name>nxt::osekC::NxtOsekCGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="32"/>
         <source>Generation (NXT OSEK C)</source>
         <translation>Tạo mã (C)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="89"/>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="220"/>
         <source>NXT tools package is not installed</source>
         <translation>Gói công cụ NXT chưa được cài đặt</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="135"/>
         <source>Generate code</source>
         <translation>Tạo mã</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="140"/>
         <source>Flash robot</source>
         <translation>Nạp firmware</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="145"/>
         <source>Upload program</source>
         <translation>Tải chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="155"/>
         <source>Generate NXT OSEK code</source>
         <translation>Tạo mã NXT OSEK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="156"/>
         <source>Upload program to NXT device</source>
         <translation>Tải chương trình lên thiết bị NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/nxt/nxtOsekCGenerator/nxtOsekCGeneratorPlugin.cpp" line="209"/>
         <source>flash.sh not found. Make sure it is present in QReal installation directory</source>
         <translation>Không tìm thấy tập lệnh flash.sh. Hãy đảm bảo gói nxt-tools đã được cài đặt đúng cách</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/pioneer/pioneerLuaGenerator_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/pioneer/pioneerLuaGenerator_vi.ts
@@ -4,27 +4,22 @@
 <context>
     <name>PioneerAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Biểu mẫu</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="35"/>
         <source>Connection Settings</source>
         <translation>Cài đặt kết nối</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="50"/>
         <source>Base station IP:</source>
         <translation>Địa chỉ IP trạm gốc:</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="64"/>
         <source>Base station port:</source>
         <translation>Cổng trạm gốc:</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/widgets/pioneerAdditionalPreferences.ui" line="78"/>
         <source>Base station connection mode:</source>
         <translation>Chế độ kết nối trạm gốc:</translation>
     </message>
@@ -32,28 +27,22 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaMasterGenerator.cpp" line="111"/>
         <source>There is no opened diagram</source>
         <translation>Không có sơ đồ nào được mở</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="121"/>
         <source>Generation internal error, please send bug report to developers.Additional info: zone node %1 can not be used as labeled node.</source>
         <translation>Lỗi nội bộ khi tạo mã, vui lòng gửi báo cáo lỗi cho nhà phát triển. Thông tin bổ sung: nút vùng %1 không thể được sử dụng như nút được gán nhãn.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="159"/>
         <source>Generation internal error, synchronous zone parent is a zone node.</source>
         <translation>Lỗi nội bộ khi tạo mã, nút cha của vùng đồng bộ là một nút vùng.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="165"/>
         <source>Generation internal error, synchronous fragment zone is absent.</source>
         <translation>Lỗi nội bộ khi tạo mã, không tìm thấy vùng cho nút bắt đầu đoạn đồng bộ.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="175"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/semanticTreeManager.cpp" line="283"/>
         <source>Generation internal error, zone contains zone node.</source>
         <translation>Lỗi nội bộ khi tạo mã, vùng chứa nút vùng con trực tiếp.</translation>
     </message>
@@ -61,50 +50,38 @@
 <context>
     <name>pioneer::lua::HttpCommunicator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="60"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="100"/>
         <source>Pioneer base station IP address is not set. It can be set in Settings window.</source>
         <translation>Địa chỉ IP trạm gốc Pioneer chưa được thiết lập. Bạn có thể thiết lập trong cửa sổ Cài đặt -&gt; Robot -&gt; Pioneer.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="66"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="106"/>
         <source>Pioneer base station port is not set. It can be set in Settings window.</source>
         <translation>Cổng trạm gốc Pioneer chưa được thiết lập. Bạn có thể thiết lập trong cửa sổ Cài đặt -&gt; Robot -&gt; Pioneer.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="72"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="81"/>
         <source>Generation failed, upload aborted.</source>
         <translation>Tạo mã thất bại, việc tải lên đã bị hủy.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="87"/>
         <source>Uploading to: %1, please wait...</source>
         <translation>Đang tải lên: %1, vui lòng đợi...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="111"/>
         <source>Starting program. Senging request to: %1, please wait...</source>
         <translation>Đang khởi chạy chương trình. Gửi yêu cầu đến: %1, vui lòng đợi...</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="121"/>
         <source>Stopping program is not supported for HTTP communication mode.</source>
         <translation>Chế độ dừng chương trình không được hỗ trợ trong chế độ truyền HTTP, vui lòng sử dụng công cụ &quot;controller&quot; để kết nối với robot (bật trong cài đặt).</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="134"/>
         <source>Uploading finished.</source>
         <translation>Tải lên hoàn tất.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="142"/>
         <source>Start finished.</source>
         <translation>Khởi chạy hoàn tất.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/communicator/httpCommunicator.cpp" line="153"/>
         <source>Pioneer base station took too long to respond. Request aborted.</source>
         <translation>Trạm gốc Pioneer không phản hồi trong thời gian dài. Yêu cầu đã bị hủy.</translation>
     </message>
@@ -112,62 +89,50 @@
 <context>
     <name>pioneer::lua::PioneerLuaGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="45"/>
         <source>Pioneer model (real copter)</source>
         <translation>Mô hình Pioneer (trực thăng thật)</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="52"/>
         <source>Generate to Pioneer Lua</source>
         <translation>Tạo mã sang Pioneer Lua</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="66"/>
         <source>Upload generated program to Pioneer</source>
         <translation>Tải chương trình đã tạo lên Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="105"/>
         <source>Generate Lua script for Pioneer Quadcopter</source>
         <translation>Tạo kịch bản Lua cho Quadcopter Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="110"/>
         <source>Upload Pioneer program</source>
         <translation>Tải chương trình Pioneer</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="163"/>
         <source>Choose robot`s mode</source>
         <translation>Chọn chế độ của robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="184"/>
         <source>Robot`s IP-address</source>
         <translation>Địa chỉ IP của robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="193"/>
         <source>Robot`s port</source>
         <translation>Cổng của robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="288"/>
         <source>Sorry, but uploading works only on Windows</source>
         <translation>Xin lỗi, chức năng tải lên chỉ hoạt động trên Windows</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="293"/>
         <source>site</source>
         <translation>trang web</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="294"/>
         <source>Please download uploader from </source>
         <translation>Vui lòng tải công cụ tải lên từ </translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaGeneratorPlugin.cpp" line="322"/>
         <source>Exit code </source>
         <translation>Mã thoát </translation>
     </message>
@@ -175,7 +140,6 @@
 <context>
     <name>pioneer::lua::PioneerLuaMasterGenerator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/pioneerLuaMasterGenerator.cpp" line="145"/>
         <source>Generation failed. Possible causes are internal error in generator or too complex program structure.</source>
         <translation>Tạo mã thất bại. Nguyên nhân có thể là lỗi nội bộ trong bộ tạo mã hoặc cấu trúc chương trình quá phức tạp. Vui lòng liên hệ nhà phát triển.</translation>
     </message>
@@ -183,63 +147,50 @@
 <context>
     <name>pioneer::lua::PioneerStateMachineGenerator</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="53"/>
         <source>The diagram must have the same number of &quot;Conditonal&quot; and &quot;End If&quot; blocks.</source>
         <translation>Sơ đồ phải có số lượng khối &quot;Điều kiện&quot; và &quot;Kết thúc điều kiện&quot; bằng nhau.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="152"/>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="237"/>
         <source>&quot;End If&quot; block occurs before &quot;If block&quot;</source>
         <translation>Không được phép sử dụng khối &quot;Kết thúc điều kiện&quot; mà không có khối &quot;Điều kiện&quot; trước đó</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="195"/>
         <source>Generation internal error, failed to create a node.</source>
         <translation>Lỗi nội bộ khi tạo mã, không thể tạo nút.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="308"/>
         <source>Nested If&apos;s constructions is not allowed.</source>
         <translation>Không cho phép các cấu trúc điều kiện lồng nhau.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="373"/>
         <source>Generation internal error, zone node corresponds to a block in a diagram.</source>
         <translation>Lỗi nội bộ khi tạo mã, nút vùng tương ứng với một khối trong sơ đồ. Nút vùng chỉ có thể là một phần của biểu diễn khối.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="388"/>
         <source>Generation internal error, non-zone node is a start of a fragment.</source>
         <translation>Lỗi nội bộ khi tạo mã, đoạn đồng bộ bắt đầu bằng nút không phải vùng.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="440"/>
         <source>Generation internal error, program ends abruptly.</source>
         <translation>Lỗi nội bộ khi tạo mã, chương trình kết thúc đột ngột. Những lỗi này phải được phát hiện trong quá trình kiểm tra sơ bộ.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="467"/>
         <source>Generation internal error, asynchronous node does not have target node.</source>
         <translation>Lỗi nội bộ khi tạo mã, nút bất đồng bộ không có nút đích để chuyển quyền điều khiển sau thao tác bất đồng bộ.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="488"/>
         <source>There is a problem with If construction or with loops (loops without sending requests to the autopilot through &quot;Takeoff&quot;, &quot;Landing&quot;, &quot;Go to local point&quot; blocks are not supported yet).</source>
         <translation>Có lỗi trong cấu trúc điều kiện hoặc vòng lặp (vòng lặp không có thao tác gửi yêu cầu đến bộ điều khiển tự động thông qua các khối &quot;Cất cánh&quot;, &quot;Hạ cánh&quot;, &quot;Bay đến điểm (HT)&quot; hiện chưa được hỗ trợ).</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="529"/>
         <source>The blocks (&quot;Takeoff&quot;, &quot;Landing&quot;, &quot;Go to local point&quot;) which work with autopilot were observed in both (or only in one) conditional branches.</source>
         <translation>Các khối (&quot;Cất cánh&quot;, &quot;Hạ cánh&quot;, &quot;Bay đến điểm (HT)&quot;), tương tác với bộ điều khiển tự động của quadcopter, được phát hiện trong một hoặc nhiều nhánh điều kiện.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="531"/>
         <source>Such blocks must appear and finish both branches (the &quot;End if&quot; block must have two such parents) or not appear at branches at all.</source>
         <translation>Các khối này phải xuất hiện và kết thúc cả hai nhánh (khối &quot;Kết thúc điều kiện&quot; phải có hai cha như vậy) hoặc không xuất hiện trong bất kỳ nhánh nào.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/pioneer/pioneerLuaGenerator/generators/pioneerStateMachineGenerator.cpp" line="533"/>
         <source>Such blocks may appear in each branch several times but one of them must finish it in each branch.</source>
         <translation>Các khối này có thể xuất hiện nhiều lần trong mỗi nhánh, nhưng một trong số chúng phải là khối kết thúc trong mỗi nhánh.</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/trik/trikGeneratorBase_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/trik/trikGeneratorBase_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikGeneratorBase/src/trikBlocksValidator.cpp" line="111"/>
         <source>Property should not be empty.</source>
         <translation>Thuộc tính không được để trống.</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/trik/trikPythonGeneratorLibrary_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/trik/trikPythonGeneratorLibrary_vi.ts
@@ -4,63 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonControlFlowValidator.cpp" line="35"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>Không có gì để tạo, sơ đồ không có nút Bắt đầu</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="141"/>
         <source>Trying to join a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Đang cố kết nối một luồng với mã định danh không xác định. Các nguyên nhân có thể: gọi fork từ một chương trình con hoặc cố gộp hai luồng mà không có khối join</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="148"/>
         <source>Join block must have exactly one outgoing link</source>
         <translation>Khối kết nối phải có đúng một liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="154"/>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="199"/>
         <source>Guard property of a link outgoing from a join must contain an id of one of joined threads</source>
         <translation>Thuộc tính bảo vệ của liên kết đi ra từ khối kết nối phải chứa mã định danh của một trong các luồng đã gộp</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="161"/>
         <source>Joining threads in a loop is forbidden</source>
         <translation>Không được phép gộp các luồng trong vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="223"/>
         <source>Trying to fork from a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Đang cố tạo tiến trình con từ một luồng có mã định danh không xác định. Các nguyên nhân có thể: gọi fork từ một chương trình con hoặc cố gộp hai luồng mà không có khối Join</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="229"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Khối Phân nhánh phải có ít nhất HAI liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="258"/>
         <source>Links outgoing from a fork block must have different thread ids</source>
         <translation>Các liên kết đi ra từ khối Phân nhánh phải có các mã định danh luồng khác nhau</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="273"/>
         <source>Fork block must have a link marked with an id of a thread from which the fork is called, &apos;%1&apos; in this case</source>
         <translation>Khối Phân nhánh phải có một liên kết được đánh dấu bằng mã định danh của luồng mà từ đó fork được gọi, trong trường hợp này là &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="284"/>
         <source>Trying to create a thread with an already occupied id &apos;%1&apos;</source>
         <translation>Đang cố tạo một luồng với mã định danh &apos;%1&apos; đã được sử dụng</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="294"/>
         <source>Creation of threads in a cycle is forbidden, check for links to before a fork</source>
         <translation>Không được phép tạo luồng trong chu kỳ, hãy kiểm tra các liên kết dẫn đến khối trước khối Phân nhánh</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/threadsValidator.cpp" line="330"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được kết nối</translation>
     </message>
@@ -68,57 +55,46 @@
 <context>
     <name>trik::python::TrikPythonGeneratorPluginBase</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="73"/>
         <source>Network operation timed out</source>
         <translation>Hết thời gian kết nối mạng, vui lòng kiểm tra cài đặt và đảm bảo robot đã được bật</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="100"/>
         <source>Casing model mismatch, check TRIK Studio settings, &quot;Robots&quot; page. It seems that TRIK casing version selected in TRIK Studio differs from version on robot.</source>
         <translation>Mô hình vỏ robot không khớp, vui lòng kiểm tra cài đặt trong TRIK Studio, trang &quot;Robot&quot;. Có vẻ như phiên bản vỏ TRIK đã chọn trong TRIK Studio khác với phiên bản trên robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="109"/>
         <source>Generate python code</source>
         <translation>Tạo mã Python</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="116"/>
         <source>Upload program</source>
         <translation>Tải chương trình lên</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="123"/>
         <source>Run program</source>
         <translation>Tải và thực thi chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="130"/>
         <source>Stop robot</source>
         <translation>Dừng robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="146"/>
         <source>Generate Python code</source>
         <translation>Tạo mã cho TRIK bằng QtScript</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="147"/>
         <source>Upload Python program</source>
         <translation>Tải chương trình lên</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="148"/>
         <source>Run Python program</source>
         <translation>Thực thi chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="149"/>
         <source>Stop Python program</source>
         <translation>Dừng thực thi chương trình cho TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikPythonGeneratorLibrary/src/trikPythonGeneratorPluginBase.cpp" line="221"/>
         <source>There are no files to upload. You must open or generate at least one *.js or *.py file.</source>
         <translation>Không có tệp nào để tải lên. Bạn phải mở hoặc tạo ít nhất một tệp *.js hoặc *.py.</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/trik/trikQtsGeneratorLibrary_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/trik/trikQtsGeneratorLibrary_vi.ts
@@ -4,63 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsControlFlowValidator.cpp" line="37"/>
         <source>There is nothing to generate, diagram doesn&apos;t have Initial Node</source>
         <translation>Không có gì để tạo, sơ đồ không có nút Bắt đầu</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="141"/>
         <source>Trying to join a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Đang cố gắng nối vào một luồng với mã định danh không xác định. Các nguyên nhân có thể: gọi fork từ một chương trình con hoặc cố gắng nối hai luồng mà không có khối join</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="148"/>
         <source>Join block must have exactly one outgoing link</source>
         <translation>Khối nối phải có đúng một liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="154"/>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="199"/>
         <source>Guard property of a link outgoing from a join must contain an id of one of joined threads</source>
         <translation>Thuộc tính bảo vệ của liên kết đi ra từ khối nối phải chứa mã định danh của một trong các luồng đã nối</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="161"/>
         <source>Joining threads in a loop is forbidden</source>
         <translation>Không được phép nối các luồng trong vòng lặp</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="223"/>
         <source>Trying to fork from a thread with an unknown id. Possible causes: calling fork from a subprogram or trying to merge two threads without a join</source>
         <translation>Đang cố tạo luồng từ một luồng có mã định danh không xác định. Các nguyên nhân có thể: gọi fork từ một chương trình con hoặc cố nối hai luồng mà không có khối Join</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="229"/>
         <source>Fork block must have at least TWO outgoing links</source>
         <translation>Khối Phân nhánh phải có ít nhất HAI liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="258"/>
         <source>Links outgoing from a fork block must have different thread ids</source>
         <translation>Các liên kết đi ra từ khối Phân nhánh phải có mã định danh luồng khác nhau</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="273"/>
         <source>Fork block must have a link marked with an id of a thread from which the fork is called, &apos;%1&apos; in this case</source>
         <translation>Khối Phân nhánh phải có một liên kết được đánh dấu bằng mã định danh của luồng mà từ đó fork được gọi, trong trường hợp này là &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="284"/>
         <source>Trying to create a thread with an already occupied id &apos;%1&apos;</source>
         <translation>Đang cố tạo một luồng với mã định danh &apos;%1&apos; đã được sử dụng</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="294"/>
         <source>Creation of threads in a cycle is forbidden, check for links to before a fork</source>
         <translation>Không được phép tạo luồng trong chu trình, hãy kiểm tra các liên kết dẫn đến khối trước khối Phân nhánh</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/threadsValidator.cpp" line="330"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được kết nối</translation>
     </message>
@@ -68,57 +55,46 @@
 <context>
     <name>trik::qts::TrikQtsGeneratorPluginBase</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="73"/>
         <source>Network operation timed out</source>
         <translation>Hết thời gian kết nối mạng, hãy kiểm tra cài đặt và đảm bảo robot đã được bật</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="100"/>
         <source>Casing model mismatch, check TRIK Studio settings, &quot;Robots&quot; page. It seems that TRIK casing version selected in TRIK Studio differs from version on robot.</source>
         <translation>Mô hình vỏ robot không khớp, hãy kiểm tra cài đặt trong TRIK Studio, trang &quot;Robot&quot;. Có vẻ như phiên bản vỏ TRIK đã chọn trong TRIK Studio khác với phiên bản trên robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="109"/>
         <source>Generate TRIK code</source>
         <translation>Tạo mã JavaScript</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="116"/>
         <source>Upload program</source>
         <translation>Tải chương trình lên</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="123"/>
         <source>Run program</source>
         <translation>Tải và thực thi chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="130"/>
         <source>Stop robot</source>
         <translation>Dừng robot</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="146"/>
         <source>Generate TRIK Code</source>
         <translation>Tạo mã JavaScript cho TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="147"/>
         <source>Upload TRIK Program</source>
         <translation>Tải chương trình TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="148"/>
         <source>Run TRIK Program</source>
         <translation>Thực thi chương trình TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="149"/>
         <source>Stop TRIK Robot</source>
         <translation>Dừng thực thi chương trình cho TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikQtsGeneratorLibrary/src/trikQtsGeneratorPluginBase.cpp" line="221"/>
         <source>There are no files to upload. You must open or generate at least one *.js or *.py file.</source>
         <translation>Không có tệp nào để tải lên. Bạn phải mở hoặc tạo ít nhất một tệp *.js hoặc *.py.</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/trik/trikV62PythonGenerator_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/trik/trikV62PythonGenerator_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::python::TrikV62PythonGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikV62PythonGenerator/trikV62PythonGeneratorPlugin.cpp" line="29"/>
         <source>Generation (Python)</source>
         <translation>Tạo mã (Python)</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/generators/trik/trikV62QtsGenerator_vi.ts
+++ b/qrtranslations/vi/plugins/robots/generators/trik/trikV62QtsGenerator_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::qts::TrikV62QtsGeneratorPlugin</name>
     <message>
-        <location filename="../../../../../../plugins/robots/generators/trik/trikV62QtsGenerator/trikV62QtsGeneratorPlugin.cpp" line="29"/>
         <source>Generation (Java Script)</source>
         <translation>Tạo mã (JavaScript)</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/interpreters/ev3KitInterpreter_vi.ts
+++ b/qrtranslations/vi/plugins/robots/interpreters/ev3KitInterpreter_vi.ts
@@ -4,48 +4,38 @@
 <context>
     <name>Ev3AdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Cài đặt EV3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="36"/>
         <source>Robot&apos;s Folders</source>
         <translation>Thư mục của Robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="51"/>
         <source>ts</source>
         <translation>ts</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="64"/>
         <source>Common folder:</source>
         <translation>Thư mục chung:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="71"/>
         <source>Use common folder for all projects</source>
         <translation>Sử dụng thư mục chung cho tất cả các dự án</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="81"/>
         <source>Bluetooth Settings</source>
         <translation>Cài đặt Bluetooth</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="87"/>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="104"/>
         <source>COM Port:</source>
         <translation>Cổng COM:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="94"/>
         <source>No COM ports found. If you have a Bluetooth connection with active virtual COM port, please enter its name. Example: COM3</source>
         <translation>Không tìm thấy cổng COM nào. Nếu bạn có kết nối Bluetooth với cổng COM ảo đang hoạt động, vui lòng nhập tên cổng. Ví dụ: COM3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.ui" line="124"/>
         <source>Specify COM port manually</source>
         <translation>Chỉ định cổng COM bằng tay</translation>
     </message>
@@ -53,7 +43,6 @@
 <context>
     <name>Ev3DisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3DisplayWidget.ui" line="435"/>
         <source>tr(Ev3Display)</source>
         <translation>Màn hình EV3</translation>
     </message>
@@ -61,7 +50,6 @@
 <context>
     <name>ev3::Ev3AdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3AdditionalPreferences.cpp" line="29"/>
         <source>2D robot image:</source>
         <translation>Hình ảnh robot 2D:</translation>
     </message>
@@ -69,7 +57,6 @@
 <context>
     <name>ev3::Ev3KitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/ev3KitInterpreterPlugin.cpp" line="108"/>
         <source>Lego EV3</source>
         <translation>Lego EV3</translation>
     </message>
@@ -77,7 +64,6 @@
 <context>
     <name>ev3::robotModel::real::BluetoothRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/bluetoothRealRobotModel.cpp" line="34"/>
         <source>Interpretation (Bluetooth)</source>
         <translation>Chạy chương trình (Bluetooth)</translation>
     </message>
@@ -85,7 +71,6 @@
 <context>
     <name>ev3::robotModel::real::UsbRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/usbRealRobotModel.cpp" line="34"/>
         <source>Interpretation (USB)</source>
         <translation>Chạy chương trình (USB)</translation>
     </message>
@@ -93,7 +78,6 @@
 <context>
     <name>ev3::robotModel::real::parts::RangeSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/ev3KitInterpreter/src/robotModel/real/parts/rangeSensor.h" line="31"/>
         <source>Sonar sensor</source>
         <translation>Cảm biến siêu âm</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/interpreters/interpreterCore_vi.ts
+++ b/qrtranslations/vi/plugins/robots/interpreters/interpreterCore_vi.ts
@@ -4,77 +4,62 @@
 <context>
     <name>PreferencesRobotSettingsPage</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="23"/>
         <source>Graphics Watcher update intervals</source>
         <translation>Khoảng thời gian cập nhật đồ thị</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="35"/>
         <source>Sensors  (ms)</source>
         <translation>Cảm biến (ms)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="63"/>
         <source>Autoscaling  (ms)</source>
         <translation>Tự động điều chỉnh tỷ lệ (ms)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="91"/>
         <source>Text info (ms)</source>
         <translation>Thông tin văn bản (ms)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="223"/>
         <source>Uploading &amp;&amp; Running</source>
         <translation>Đang tải lên và thực thi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="229"/>
         <source>Running after uploading:</source>
         <translation>Thực thi sau khi tải lên:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="237"/>
         <source>Ask</source>
         <translation>Hỏi người dùng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="242"/>
         <source>Always run</source>
         <translation>Luôn thực thi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="247"/>
         <source>Never run</source>
         <translation>Không bao giờ thực thi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="258"/>
         <source>2D-model Editor Settings</source>
         <translation>Cài đặt Trình chỉnh sửa Mô hình 2D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="264"/>
         <source>Enable Region Editor Mode</source>
         <translation>Bật Chế độ Chỉnh sửa Khu vực</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="271"/>
         <source>Advanced settings for creating restrictions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="192"/>
         <source>Sensors Settings</source>
         <translation>Cài đặt cảm biến</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="137"/>
         <source>Robotics construction kit</source>
         <translation>Nền tảng robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.ui" line="151"/>
         <source>Robot model</source>
         <translation>Mô hình robot</translation>
     </message>
@@ -82,107 +67,86 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="27"/>
         <source>TRIK Studio</source>
         <translation>TRIK Studio</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="81"/>
         <source>Subprograms</source>
         <translation>Chương trình con</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/customizer.cpp" line="86"/>
         <source>The list of all declared subprograms in the project</source>
         <translation>Danh sách tất cả các chương trình con đã khai báo trong dự án</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/details/autoconfigurer.cpp" line="60"/>
         <source>%2 has been auto configured to port %1</source>
         <translation>%2 đã được tự động cấu hình vào cổng %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/details/autoconfigurer.cpp" line="64"/>
         <source>Sensor on port %1 does not correspond to blocks on the diagram.</source>
         <translation>Cảm biến ở cổng %1 không phù hợp với các khối trên sơ đồ.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="32"/>
         <source>Run</source>
         <translation>Chạy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="33"/>
         <source>Stop robot</source>
         <translation>Dừng robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="34"/>
         <source>Connect to robot</source>
         <translation>Kết nối với robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="35"/>
         <source>Robot settings</source>
         <translation>Cài đặt</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="36"/>
         <source>Save as task...</source>
         <translation>Lưu dưới dạng bài tập...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="39"/>
         <source>Debug</source>
         <translation>Gỡ lỗi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="43"/>
         <source>Edit</source>
         <translation>Chỉnh sửa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="113"/>
         <source>Switch to edit mode</source>
         <translation>Chuyển sang chế độ chỉnh sửa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="114"/>
         <source>Switch to debug mode</source>
         <translation>Chuyển sang chế độ gỡ lỗi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="115"/>
         <source>Run interpreter</source>
         <translation>Chạy bộ thông dịch</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="116"/>
         <source>Stop interpreter</source>
         <translation>Dừng bộ thông dịch</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="63"/>
         <source>Blocks</source>
         <translation>Khối</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="112"/>
         <source>Configure devices</source>
         <translation>Cấu hình thiết bị</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="126"/>
         <source>Sensors state</source>
         <translation>Đồ thị</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/exerciseExportManager.cpp" line="53"/>
         <source>Select file to export save to</source>
         <translation>Chọn tệp để xuất bài tập</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/exerciseExportManager.cpp" line="55"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Tệp lưu TRIK Studio (*.qrs)</translation>
     </message>
@@ -190,17 +154,14 @@
 <context>
     <name>interpreterCore::ActionsManager</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="45"/>
         <source>To main page</source>
         <translation>Về trang chính</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="291"/>
         <source>Real robot</source>
         <translation>Robot thật</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/actionsManager.cpp" line="292"/>
         <source>2D model</source>
         <translation>Mô hình 2D</translation>
     </message>
@@ -208,7 +169,6 @@
 <context>
     <name>interpreterCore::DefaultRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/defaultRobotModel.cpp" line="31"/>
         <source>Empty model</source>
         <translation>Mô hình trống</translation>
     </message>
@@ -216,27 +176,22 @@
 <context>
     <name>interpreterCore::RobotsPluginFacade</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="159"/>
         <source>Robots</source>
         <translation>Robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="202"/>
         <source>Cannot export exercise to the given location (try to change location)</source>
         <translation>Không thể xuất bài tập đến vị trí đã chọn (hãy thử vị trí khác)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="317"/>
         <source>The specified script file could not be opened for reading </source>
         <translation>Không thể mở tệp kịch bản đã chỉ định để đọc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="329"/>
         <source>No saved code found in the qrs file</source>
         <translation>Không tìm thấy mã đã lưu trong tệp qrs</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/robotsPluginFacade.cpp" line="427"/>
         <source>Toggle robot console panel</source>
         <translation>Bật/tắt bảng điều khiển console robot</translation>
     </message>
@@ -244,37 +199,30 @@
 <context>
     <name>interpreterCore::UiManager</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="60"/>
         <source>Miscellaneous</source>
         <translation>Khác</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="61"/>
         <source>Robot console</source>
         <translation>Console robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="93"/>
         <source>edit mode</source>
         <translation>chế độ chỉnh sửa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="94"/>
         <source>debug mode</source>
         <translation>chế độ gỡ lỗi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="245"/>
         <source>Edit mode</source>
         <translation>Chế độ chỉnh sửa</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="248"/>
         <source>Debug mode</source>
         <translation>Chế độ gỡ lỗi</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/managers/uiManager.cpp" line="394"/>
         <source>Modes</source>
         <translation>Chế độ</translation>
     </message>
@@ -282,38 +230,30 @@
 <context>
     <name>interpreterCore::interpreter::BlockInterpreter</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="92"/>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="166"/>
         <source>No connection to robot</source>
         <translation>Không kết nối được với robot</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="98"/>
         <source>Interpreter is already running</source>
         <translation>Bộ thông dịch đã đang chạy</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="150"/>
         <source>Connected successfully</source>
         <translation>Kết nối thành công</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="154"/>
         <source>Can&apos;t connect to a robot.</source>
         <translation>Không thể kết nối với robot.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="198"/>
         <source>Cannot create new thread with already occupied id %1</source>
         <translation>Không thể tạo luồng mới với ID %1 đã được sử dụng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="212"/>
         <source>Threads limit exceeded. Maximum threads count is %1</source>
         <translation>Vượt quá giới hạn luồng. Số lượng luồng tối đa là %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/interpreter/blockInterpreter.cpp" line="234"/>
         <source>Killing non-existent thread %1</source>
         <translation>Cố gắng kết thúc luồng không tồn tại %1</translation>
     </message>
@@ -321,42 +261,34 @@
 <context>
     <name>interpreterCore::ui::ExerciseExportDialog</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="31"/>
         <source>Select non-modifiable parts of exercize</source>
         <translation>Chọn các phần không thể thay đổi của bài tập</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="33"/>
         <source>2D model world is read-only</source>
         <translation>Mô hình thế giới 2D chỉ được đọc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="34"/>
         <source>Sensors are read-only</source>
         <translation>Cảm biến chỉ được đọc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="35"/>
         <source>2D model robot position is read-only</source>
         <translation>Vị trí robot trong mô hình 2D chỉ được đọc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="36"/>
         <source>Motors to wheels binding is read-only</source>
         <translation>Liên kết động cơ với bánh xe chỉ được đọc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="37"/>
         <source>2D model simulation settings are read-only</source>
         <translation>Cài đặt mô phỏng mô hình 2D chỉ được đọc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="58"/>
         <source>Ok</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/exerciseExportDialog.cpp" line="62"/>
         <source>Cancel</source>
         <translation>Hủy</translation>
     </message>
@@ -364,7 +296,6 @@
 <context>
     <name>interpreterCore::ui::ModeStripe</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/modeStripe.cpp" line="22"/>
         <source>press %2 or click here to switch to %3</source>
         <translation>nhấn %2 hoặc nhấp vào đây để chuyển sang %3</translation>
     </message>
@@ -372,22 +303,18 @@
 <context>
     <name>interpreterCore::ui::RobotsSettingsPage</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="58"/>
         <source>Templates directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="60"/>
         <source>Choose templates directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="94"/>
         <source>No constructor kit plugins loaded</source>
         <translation>Không có plugin nền tảng robot nào được tải</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/interpreterCore/src/ui/robotsSettingsPage.cpp" line="238"/>
         <source>No robot models available for </source>
         <translation>Không có mô hình robot nào khả dụng cho </translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/interpreters/nullKitInterpreter_vi.ts
+++ b/qrtranslations/vi/plugins/robots/interpreters/nullKitInterpreter_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>nullKitInterpreter::NullKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nullKitInterpreter/src/nullKitInterpreterPlugin.cpp" line="33"/>
         <source>Empty Kit</source>
         <translation>Bộ trống</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>nullKitInterpreter::NullRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nullKitInterpreter/src/nullRobotModel.cpp" line="31"/>
         <source>Null model</source>
         <translation>Mô hình rỗng</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/interpreters/nxtKitInterpreter_vi.ts
+++ b/qrtranslations/vi/plugins/robots/interpreters/nxtKitInterpreter_vi.ts
@@ -4,38 +4,30 @@
 <context>
     <name>NxtAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Cài đặt NXT</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="35"/>
         <source>nxtOSEK Generator Settings</source>
         <translation>Cài đặt Generator nxtOSEK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="41"/>
         <source>TextLabel</source>
         <translation>Văn bản nhãn</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="54"/>
         <source>Bluetooth Settings</source>
         <translation>Cài đặt Bluetooth</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="70"/>
         <source>No COM ports found. If you have a Bluetooth connection with active virtual COM port, please enter its name. Example: COM3</source>
         <translation>Không tìm thấy cổng COM nào. Nếu bạn có kết nối Bluetooth với cổng COM ảo đang hoạt động, vui lòng nhập tên cổng. Ví dụ: COM3</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="83"/>
         <source>Specify COM port manually</source>
         <translation>Chỉ định cổng COM theo cách thủ công</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="90"/>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.ui" line="97"/>
         <source>COM Port:</source>
         <translation>Cổng COM:</translation>
     </message>
@@ -43,7 +35,6 @@
 <context>
     <name>NxtDisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtDisplayWidget.ui" line="435"/>
         <source>tr(NxtDisplay)</source>
         <translation>Màn hình NXT</translation>
     </message>
@@ -51,17 +42,14 @@
 <context>
     <name>nxt::NxtAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.cpp" line="33"/>
         <source>2D robot image:</source>
         <translation>Hình ảnh robot 2D:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.cpp" line="36"/>
         <source>Path to arm-none-eabi:</source>
         <translation>Đường dẫn đến arm-none-eabi:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtAdditionalPreferences.cpp" line="61"/>
         <source>WARNING: Current directory doesn&apos;t exist. 
 Open &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;link&lt;/a&gt; for instructions</source>
         <translation>CẢNH BÁO: Thư mục hiện tại không tồn tại. 
@@ -71,7 +59,6 @@ Mở &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;
 <context>
     <name>nxt::NxtKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/nxtKitInterpreterPlugin.cpp" line="107"/>
         <source>Lego NXT</source>
         <translation>Lego NXT</translation>
     </message>
@@ -79,7 +66,6 @@ Mở &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;
 <context>
     <name>nxt::robotModel::real::BluetoothRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/bluetoothRealRobotModel.cpp" line="35"/>
         <source>Interpretation (Bluetooth)</source>
         <translation>Thông dịch (Bluetooth)</translation>
     </message>
@@ -87,7 +73,6 @@ Mở &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;
 <context>
     <name>nxt::robotModel::real::UsbRealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/usbRealRobotModel.cpp" line="34"/>
         <source>Interpretation (USB)</source>
         <translation>Thông dịch (USB)</translation>
     </message>
@@ -95,7 +80,6 @@ Mở &lt;a href=&quot;https://help.trikset.com/nxt/run-upload-programs&quot;&gt;
 <context>
     <name>nxt::robotModel::real::parts::SonarSensor</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/nxtKitInterpreter/src/robotModel/real/parts/sonarSensor.h" line="31"/>
         <source>Sonar sensor</source>
         <translation>Cảm biến siêu âm</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/interpreters/pioneerKitInterpreter_vi.ts
+++ b/qrtranslations/vi/plugins/robots/interpreters/pioneerKitInterpreter_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>pioneerKitInterpreter::PioneerKitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/pioneerKitInterpreter/src/pioneerKitInterpreterPlugin.cpp" line="33"/>
         <source>Pioneer Kit</source>
         <translation>Bộ thiết bị Pioneer</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/interpreters/robotsPlugin_vi.ts
+++ b/qrtranslations/vi/plugins/robots/interpreters/robotsPlugin_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/robotsPlugin/robotsPlugin.cpp" line="51"/>
         <source>Robots</source>
         <translation>Robot</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/interpreters/trikKitInterpreterCommon_vi.ts
+++ b/qrtranslations/vi/plugins/robots/interpreters/trikKitInterpreterCommon_vi.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="166"/>
         <source>Bogus input values</source>
         <translation>Giá trị đầu vào không hợp lệ</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="188"/>
         <source>Error: File %1 couldn&apos;t be opened!</source>
         <translation>Lỗi: Không thể mở tệp %1!</translation>
     </message>
@@ -17,62 +15,50 @@
 <context>
     <name>TrikAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="14"/>
         <source>Form</source>
         <translation>Cài đặt TRIK</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="35"/>
         <source>TCP Settings</source>
         <translation>Thiết lập TCP</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="44"/>
         <source>Enter robot IP-address here</source>
         <translation>Nhập địa chỉ IP của robot vào đây</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="57"/>
         <source>Camera Settings</source>
         <translation>Thiết lập camera</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="72"/>
         <source>Camera:</source>
         <translation>Camera:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="85"/>
         <source>Use real camera</source>
         <translation>Sử dụng camera thật</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="101"/>
         <source>Use images from project</source>
         <translation>Sử dụng ảnh được đóng gói trong dự án</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="108"/>
         <source>Images:</source>
         <translation>Hình ảnh:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="114"/>
         <source>Browse...</source>
         <translation>Duyệt...</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="124"/>
         <source>Pack images to project</source>
         <translation>Đóng gói hình ảnh vào dự án</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="140"/>
         <source>Network Settings</source>
         <translation>Thiết lập mạng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.ui" line="146"/>
         <source>Enable Mailbox</source>
         <translation>Kích hoạt Hộp thư</translation>
     </message>
@@ -80,7 +66,6 @@
 <context>
     <name>TrikDisplayWidget</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikDisplayWidget.ui" line="14"/>
         <source>Trik Display</source>
         <translation>Màn hình TRIK</translation>
     </message>
@@ -88,14 +73,12 @@
 <context>
     <name>TwoDExecutionControl</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp" line="28"/>
         <source>&apos;%1&apos; is disabled
 </source>
         <translation>%1 bị tắt
 </translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/twoDExecutionControl.cpp" line="46"/>
         <source>No cofigured random device</source>
         <translation>Chưa cấu hình thiết bị tạo số ngẫu nhiên</translation>
     </message>
@@ -103,22 +86,18 @@
 <context>
     <name>trik::TrikAdditionalPreferences</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="33"/>
         <source>2D robot image:</source>
         <translation>Hình ảnh robot 2D:</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="51"/>
         <source>Select Directory</source>
         <translation>Chọn thư mục</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="76"/>
         <source>Information</source>
         <translation>Thông tin</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikAdditionalPreferences.cpp" line="76"/>
         <source>You should restart the program to apply changes</source>
         <translation>Bạn nên khởi động lại chương trình để áp dụng các thay đổi</translation>
     </message>
@@ -126,84 +105,66 @@
 <context>
     <name>trik::TrikBrick</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="84"/>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="160"/>
         <source>2d model shell part was not found</source>
         <translation>Không tìm thấy phần giao diện mô hình 2D</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="130"/>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="413"/>
         <source>Trying to read from file %1 failed</source>
         <translation>Thất bại khi cố đọc từ tệp %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="190"/>
         <source>No configured motor on port: %1</source>
         <translation>Không tìm thấy động cơ đã cấu hình tại cổng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="221"/>
         <source>No configured scalar sensor on port: %1</source>
         <translation>Không tìm thấy cảm biến đo lường đã cấu hình tại cổng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="236"/>
         <source>No configured lidar on port: %1</source>
         <translation>Không tìm thấy lidar đã cấu hình tại cổng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="269"/>
         <source>No configured accelerometer</source>
         <translation>Chưa cấu hình cảm biến gia tốc</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="285"/>
         <source>No configured gyroscope</source>
         <translation>Chưa cấu hình con quay hồi chuyển</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="305"/>
         <source>No configured LineSensor on port: %1</source>
         <translation>Không tìm thấy cảm biến đường kẻ đã cấu hình tại cổng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="324"/>
         <source>No configured ColorSensor on port: %1</source>
         <translation>Không tìm thấy cảm biến màu đã cấu hình tại cổng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="334"/>
         <source>Sensor not implemented in simulation mode. Used port: %1</source>
         <translation>Cảm biến không được hỗ trợ trong chế độ mô phỏng. Cổng sử dụng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="344"/>
         <source>No configured encoder on port: %1</source>
         <translation>Không tìm thấy bộ mã hóa đã cấu hình tại cổng: %1</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="365"/>
         <source>No configured led</source>
         <translation>Chưa cấu hình đèn LED</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="384"/>
         <source>Get photo with camera started</source>
         <translation>Bắt đầu quá trình chụp ảnh bằng camera</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="386"/>
         <source>Get photo with camera finished</source>
         <translation>Hoàn thành quá trình chụp ảnh bằng camera</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="388"/>
         <source>Cannot get a photo from camera (possibly because of wrong camera name)</source>
         <translation>Không thể chụp ảnh từ camera (có thể do tên camera không đúng)</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikbrick.cpp" line="395"/>
         <source>Cannot get a photo from folders/project (possibly because of wrong path/empty project)</source>
         <translation>Không thể lấy ảnh từ thư mục/dự án (có thể do đường dẫn sai/dự án trống)</translation>
     </message>
@@ -211,32 +172,26 @@
 <context>
     <name>trik::TrikKitInterpreterPluginBase</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="39"/>
         <source>Start</source>
         <translation>Bắt đầu</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="39"/>
         <source>Stop</source>
         <translation>Dừng</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="100"/>
         <source>TRIK_PYTHONPATH must be set correctly to run Python script.</source>
         <translation>TRIK_PYTHONPATH phải được thiết lập đúng để chạy kịch bản Python.</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="273"/>
         <source>Run program</source>
         <translation>Chạy chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="278"/>
         <source>Stop robot</source>
         <translation>Dừng chương trình</translation>
     </message>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikKitInterpreterPluginBase.cpp" line="477"/>
         <source>Enter robot`s IP-address here...</source>
         <translation>Nhập địa chỉ IP của robot vào đây...</translation>
     </message>
@@ -244,8 +199,6 @@
 <context>
     <name>trik::TrikTextualInterpreter</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="92"/>
-        <location filename="../../../../../plugins/robots/interpreters/trikKitInterpreterCommon/src/trikTextualInterpreter.cpp" line="107"/>
         <source>Unsupported script file type</source>
         <translation>Loại tệp kịch bản không được hỗ trợ</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/interpreters/trikV62KitInterpreter_vi.ts
+++ b/qrtranslations/vi/plugins/robots/interpreters/trikV62KitInterpreter_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>trik::TrikV62KitInterpreterPlugin</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikV62KitInterpreter/src/trikV62KitInterpreterPlugin.cpp" line="47"/>
         <source>TRIK</source>
         <translation>TRIK</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>trik::robotModel::real::RealRobotModel</name>
     <message>
-        <location filename="../../../../../plugins/robots/interpreters/trikV62KitInterpreter/src/robotModel/real/trikV62RealRobotModel.cpp" line="69"/>
         <source>Interpretation (Wi-Fi)</source>
         <translation>Thông dịch (Wi-Fi)</translation>
     </message>

--- a/qrtranslations/vi/plugins/robots/utils_vi.ts
+++ b/qrtranslations/vi/plugins/robots/utils_vi.ts
@@ -4,18 +4,14 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="27"/>
         <source>Current TRIK runtime version can not be received</source>
         <translation>Không thể nhận được phiên bản firmware TRIK hiện tại</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="32"/>
         <source>TRIK runtime version is too old, please update it by pressing &apos;Upload Runtime&apos; button on toolbar</source>
         <translation>Phiên bản phần mềm của robot quá cũ, vui lòng cập nhật bằng cách nhấn nút &apos;Tải phần mềm lên robot&apos; trên thanh công cụ</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="38"/>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/networkCommunicationErrorReporter.cpp" line="43"/>
         <source>From robot: </source>
         <translation>Trên robot: </translation>
     </message>
@@ -23,7 +19,6 @@
 <context>
     <name>SensorsGraph</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.ui" line="25"/>
         <source>SensorsGraph</source>
         <translation>Cảm biến</translation>
     </message>
@@ -31,23 +26,18 @@
 <context>
     <name>trik::UploaderTool</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="131"/>
         <source>WinSCP process failed to launch, check path in settings.</source>
         <translation>Không thể khởi chạy tiến trình WinSCP, hãy kiểm tra đường dẫn trong cài đặt.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="134"/>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="149"/>
         <source>Uploading failed, check connection and try again.</source>
         <translation>Tải lên thất bại, hãy kiểm tra kết nối và thử lại.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="146"/>
         <source>Uploaded successfully!</source>
         <translation>Tải lên thành công!</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/uploaderTool.cpp" line="180"/>
         <source>%1 is not installed. Please install %1 first.</source>
         <translation>%1 chưa được cài đặt. Vui lòng cài đặt %1 trước tiên.</translation>
     </message>
@@ -55,12 +45,10 @@
 <context>
     <name>utils::robotCommunication::TcpRobotCommunicator</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicator.cpp" line="81"/>
         <source>Empty program name, can not upload</source>
         <translation>Tên chương trình trống, không thể tải lên robot</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicator.cpp" line="89"/>
         <source>Can not read generated file, uploading aborted</source>
         <translation>Không thể đọc tệp đã tạo, việc tải lên bị hủy</translation>
     </message>
@@ -68,12 +56,10 @@
 <context>
     <name>utils::robotCommunication::TcpRobotCommunicatorWorker</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicatorWorker.cpp" line="232"/>
         <source>Unable to resolve host.</source>
         <translation>Tên robot đã nhập không xác định.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/robotCommunication/tcpRobotCommunicatorWorker.cpp" line="250"/>
         <source>Connection failed. IP: %1</source>
         <translation>Không thể kết nối với robot. Địa chỉ IP: %1</translation>
     </message>
@@ -81,17 +67,14 @@
 <context>
     <name>utils::sensorsGraph::SensorViewer</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorViewer.cpp" line="109"/>
         <source>Save values history</source>
         <translation>Lưu lịch sử giá trị</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorViewer.cpp" line="109"/>
         <source>Comma-Separated Values Files (*.csv)</source>
         <translation>Tệp giá trị phân tách bằng dấu phẩy (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorViewer.cpp" line="215"/>
         <source>value: </source>
         <translation>giá trị: </translation>
     </message>
@@ -99,32 +82,26 @@
 <context>
     <name>utils::sensorsGraph::SensorsGraph</name>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="141"/>
         <source>Stop tracking</source>
         <translation>Dừng theo dõi</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="145"/>
         <source>Start tracking</source>
         <translation>Bắt đầu theo dõi</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="149"/>
         <source>Reset plot</source>
         <translation>Xóa biểu đồ</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="153"/>
         <source>Zoom In</source>
         <translation>Phóng to</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="157"/>
         <source>Zoom Out</source>
         <translation>Thu nhỏ</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/robots/utils/src/graphicsWatcher/sensorsGraph.cpp" line="161"/>
         <source>Export values...</source>
         <translation>Xuất số liệu...</translation>
     </message>

--- a/qrtranslations/vi/plugins/tools/subprogramsImporterExporter_vi.ts
+++ b/qrtranslations/vi/plugins/tools/subprogramsImporterExporter_vi.ts
@@ -4,17 +4,14 @@
 <context>
     <name>SubprogramsCollectionDialog</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="29"/>
         <source>Subprograms collection manager</source>
         <translation>Quản lý bộ sưu tập các chương trình con</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="41"/>
         <source>Select All</source>
         <translation>Chọn tất cả</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.cpp" line="43"/>
         <source>Deselect All</source>
         <translation>Bỏ chọn tất cả</translation>
     </message>
@@ -22,22 +19,18 @@
 <context>
     <name>subprogramsCollectionDialog</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Hộp thoại</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="20"/>
         <source>Available subprograms:</source>
         <translation>Các chương trình con có sẵn:</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="27"/>
         <source>Select all</source>
         <translation>Chọn tất cả</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsCollectionDialog.ui" line="66"/>
         <source>WARNING: existing subprograms will be overwritten!</source>
         <translation>CẢNH BÁO: các chương trình con hiện có sẽ bị ghi đè!</translation>
     </message>
@@ -45,83 +38,66 @@
 <context>
     <name>subprogramsImporterExporter::SubprogramsImporterExporterPlugin</name>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="38"/>
         <source>Subprograms</source>
         <translation>Chương trình con</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="41"/>
         <source>Import from file...</source>
         <translation>Nhập từ tệp...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="42"/>
         <source>Export to file...</source>
         <translation>Xuất ra tệp...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="43"/>
         <source>Save to collection...</source>
         <translation>Lưu vào bộ sưu tập...</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="44"/>
         <source>Load from collection</source>
         <translation>Tải từ bộ sưu tập</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="45"/>
         <source>Clear collection</source>
         <translation>Xóa bộ sưu tập</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="100"/>
         <source>Select subprograms file (name for new one)</source>
         <translation>Chọn tệp chương trình con (tên cho tệp mới)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="101"/>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="144"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Tệp lưu QReal (*.qrs)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="122"/>
         <source>There are no subprograms in your project.</source>
         <translation>Không có chương trình con nào trong dự án của bạn.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="143"/>
         <source>Select subprograms file</source>
         <translation>Chọn tệp chương trình con</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="200"/>
         <source>There are not subprograms in your project</source>
         <translation>Không có chương trình con nào trong dự án của bạn</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="241"/>
         <source>There are no subprograms in your collection for %1 robot.</source>
         <translation>Không có chương trình con nào trong bộ sưu tập của bạn cho robot %1.</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="288"/>
         <source>Clear the collection</source>
         <translation>Xóa bộ sưu tập</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="289"/>
         <source>Remove all subprograms for all kits from the collection?</source>
         <translation>Xóa tất cả các chương trình con cho mọi bộ linh kiện khỏi bộ sưu tập?</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="300"/>
         <source>There is no opened project</source>
         <translation>Không có dự án nào đang mở</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/subprogramsImporterExporter/subprogramsImporterExporterPlugin.cpp" line="322"/>
         <source>There are different subprograms with the same name in your project. Please make them unique.</source>
         <translation>Có các chương trình con khác nhau cùng tên trong dự án của bạn. Vui lòng đặt tên sao cho chúng là duy nhất.</translation>
     </message>

--- a/qrtranslations/vi/plugins/tools/updatesChecker_vi.ts
+++ b/qrtranslations/vi/plugins/tools/updatesChecker_vi.ts
@@ -4,22 +4,18 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="23"/>
         <source>New updates are available!</source>
         <translation>Các bản cập nhật mới đang khả dụng!</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="24"/>
         <source>Update</source>
         <translation>Cập nhật</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="25"/>
         <source>Later</source>
         <translation>Sau</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updateVersionDialog.cpp" line="27"/>
         <source>Yeah!</source>
         <translation>Tuyệt vời!</translation>
     </message>
@@ -27,27 +23,22 @@
 <context>
     <name>updatesChecker::UpdatesCheckerPlugin</name>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="33"/>
         <source>Check for updates</source>
         <translation>Kiểm tra cập nhật</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="66"/>
         <source>There is some connection problem, may be network is disabled</source>
         <translation>Có sự cố kết nối, có thể mạng đã bị tắt</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="69"/>
         <source>There is some unrecognized error with updating process</source>
         <translation>Có lỗi không xác định trong quá trình cập nhật (vui lòng báo cho nhà phát triển)</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="80"/>
         <source>No updates available</source>
         <translation>Không có bản cập nhật nào khả dụng</translation>
     </message>
     <message>
-        <location filename="../../../../plugins/tools/updatesChecker/updatesCheckerPlugin.cpp" line="91"/>
         <source>Check for updates on start</source>
         <translation>Kiểm tra cập nhật khi khởi động</translation>
     </message>

--- a/qrtranslations/vi/qrgui/dialogs_vi.ts
+++ b/qrtranslations/vi/qrgui/dialogs_vi.ts
@@ -4,27 +4,22 @@
 <context>
     <name>AddNodeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="14"/>
         <source>Node properties</source>
         <translation>Thuộc tính nút</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="29"/>
         <source>name: *</source>
         <translation>tên: *</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="39"/>
         <source>Make it root element of a diagram</source>
         <translation>Đặt làm phần tử gốc của sơ đồ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="58"/>
         <source>* Need to be filled</source>
         <translation>* Cần phải điền</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.ui" line="80"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -32,17 +27,14 @@
 <context>
     <name>ChooseTypeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/chooseTypeDialog.ui" line="14"/>
         <source>Choose element type</source>
         <translation>Chọn loại phần tử</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/chooseTypeDialog.ui" line="59"/>
         <source>Entity</source>
         <translation>Thực thể</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/chooseTypeDialog.ui" line="99"/>
         <source>Relationship</source>
         <translation>Mối quan hệ</translation>
     </message>
@@ -50,37 +42,30 @@
 <context>
     <name>DynamicPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="35"/>
         <source>Dialog</source>
         <translation>Phục hồi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="44"/>
         <source>Subprogram name:</source>
         <translation>Tên chương trình con:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="58"/>
         <source>Subprogram arguments:</source>
         <translation>Đối số chương trình con:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="90"/>
         <source>Add Argument</source>
         <translation>Thêm đối số</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="97"/>
         <source>Subprogram picture:</source>
         <translation>Hình ảnh:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="104"/>
         <source>Subprogram picture background:</source>
         <translation>Màu nền:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.ui" line="111"/>
         <source>Save All</source>
         <translation>Lưu tất cả</translation>
     </message>
@@ -88,118 +73,90 @@
 <context>
     <name>EdgePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="14"/>
         <source>Edge properties</source>
         <translation>Thuộc tính liên kết</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="30"/>
         <source>name: *</source>
         <translation>tên: *</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="40"/>
         <source>Text</source>
         <translation>Nhãn</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="52"/>
         <source>labelText:</source>
         <translation>Nhãn văn bản:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="68"/>
         <source>labelType:</source>
         <translation>Loại nhãn:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="76"/>
         <source>Dynamic text</source>
         <translation>Nhãn động</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="81"/>
         <source>Static text</source>
         <translation>Nhãn tĩnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="97"/>
         <source>* Need to be filled</source>
         <translation>* Cần phải điền</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="111"/>
         <source>Line</source>
         <translation>Đường</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="123"/>
         <source>lineType:</source>
         <translation>Loại đường:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="131"/>
         <source>solidLine</source>
         <translation>Liền nét</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="136"/>
         <source>dashLine</source>
         <translation>Nét đứt</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="141"/>
         <source>dotLine</source>
         <translation>Nét chấm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="155"/>
         <source>beginType:</source>
         <translation>Hình dạng đầu đường:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="172"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="252"/>
         <source>no_arrow</source>
         <translation>không_mũi_tên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="181"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="261"/>
         <source>open_arrow</source>
         <translation>mũi_tên_mở</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="190"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="270"/>
         <source>empty_arrow</source>
         <translation>mũi_tên_trống</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="199"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="279"/>
         <source>filled_arrow</source>
         <translation>mũi_tên_được_điền_đầy</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="208"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="288"/>
         <source>empty_rhomb</source>
         <translation>hình_thoi_trống</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="217"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="297"/>
         <source>filled_rhomb</source>
         <translation>hình_thoi_được_điền_đầy</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="235"/>
         <source>endType:</source>
         <translation>Hình dạng cuối đường:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.ui" line="327"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -207,32 +164,26 @@
 <context>
     <name>EditPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Phục hồi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="28"/>
         <source>name: *</source>
         <translation>tên: *</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="44"/>
         <source>attributeType: *</source>
         <translation>Loại: *</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="60"/>
         <source>defaultValue: </source>
         <translation>Giá trị:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="84"/>
         <source>* Need to be filled</source>
         <translation>* Cần phải điền</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.ui" line="91"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -240,67 +191,54 @@
 <context>
     <name>FindReplaceDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Phục hồi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="28"/>
         <source>Find what:</source>
         <translation>Tìm kiếm:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="35"/>
         <source>Replace with:</source>
         <translation>Thay thế bằng:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="56"/>
         <source>Find</source>
         <translation>Tìm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="63"/>
         <source>Replace</source>
         <translation>Thay thế</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="74"/>
         <source>by name</source>
         <translation>theo tên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="81"/>
         <source>by type</source>
         <translation>theo loại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="88"/>
         <source>by property</source>
         <translation>theo thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="95"/>
         <source>by property content</source>
         <translation>theo nội dung thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="109"/>
         <source>by regular expression</source>
         <translation>sử dụng biểu thức chính quy</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.ui" line="116"/>
         <source>case sensitivity</source>
         <translation>phân biệt chữ hoa chữ thường</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.cpp" line="43"/>
         <source>Search</source>
         <translation>Tìm kiếm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/findReplaceDialog.cpp" line="118"/>
         <source> / </source>
         <translation> / </translation>
     </message>
@@ -308,27 +246,22 @@
 <context>
     <name>PropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Phục hồi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="23"/>
         <source>Close</source>
         <translation>Đóng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="30"/>
         <source>Add</source>
         <translation>Thêm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="37"/>
         <source>Change</source>
         <translation>Thay đổi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.ui" line="44"/>
         <source>Delete</source>
         <translation>Xóa</translation>
     </message>
@@ -336,9 +269,6 @@
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="123"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="47"/>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="47"/>
         <source>Close</source>
         <translation>Đóng</translation>
     </message>
@@ -346,22 +276,18 @@
 <context>
     <name>RestoreElementDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Phục hồi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="20"/>
         <source>In earlier language versions already used the elements with the same name:</source>
         <translation>Trong các phiên bản ngôn ngữ trước đó đã sử dụng các phần tử cùng tên:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="30"/>
         <source>Restore</source>
         <translation>Phục hồi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.ui" line="37"/>
         <source>Create New</source>
         <translation>Tạo mới</translation>
     </message>
@@ -369,22 +295,18 @@
 <context>
     <name>RestorePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Phục hồi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="20"/>
         <source>In earlier language versions already used the properties with the same name:</source>
         <translation>Trong các phiên bản ngôn ngữ trước đó đã sử dụng các thuộc tính cùng tên:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="34"/>
         <source>Restore</source>
         <translation>Phục hồi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.ui" line="41"/>
         <source>Create New</source>
         <translation>Tạo mới</translation>
     </message>
@@ -392,47 +314,38 @@
 <context>
     <name>qReal::EditPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="103"/>
         <source>Warning:</source>
         <translation>Cảnh báo:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="104"/>
         <source>You changed the type of property. In case of incorrect conversion it may result in resetting of the existing property value.</source>
         <translation>Bạn đã thay đổi loại thuộc tính. Nếu chuyển đổi không chính xác, có thể dẫn đến việc đặt lại giá trị thuộc tính hiện có.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="107"/>
         <source>Proceed anyway</source>
         <translation>Tiếp tục dù vậy</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="108"/>
         <source>Cancel the type conversion</source>
         <translation>Hủy bỏ chuyển đổi loại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="122"/>
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="122"/>
         <source>All required properties should be filled</source>
         <translation>Tất cả các thuộc tính bắt buộc phải được điền</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="132"/>
         <source>Restore properties</source>
         <translation>Phục hồi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="158"/>
         <source>Add new property</source>
         <translation>Thêm thuộc tính mới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/editPropertiesDialog.cpp" line="161"/>
         <source>Properties editor: </source>
         <translation>Trình soạn thảo thuộc tính: </translation>
     </message>
@@ -440,7 +353,6 @@
 <context>
     <name>qReal::ProgressDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/progressDialog/progressDialog.cpp" line="26"/>
         <source>Please wait...</source>
         <translation>Vui lòng đợi...</translation>
     </message>
@@ -448,27 +360,22 @@
 <context>
     <name>qReal::RestoreElementDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="48"/>
         <source>Existed</source>
         <translation>Đã tồn tại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="50"/>
         <source>Deleted</source>
         <translation>Đã xóa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="74"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="74"/>
         <source>Type</source>
         <translation>Loại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restoreElementDialog.cpp" line="74"/>
         <source>Value</source>
         <translation>Giá trị</translation>
     </message>
@@ -476,32 +383,26 @@
 <context>
     <name>qReal::RestorePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="29"/>
         <source>Property name</source>
         <translation>Tên thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="31"/>
         <source>State</source>
         <translation>Trạng thái</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="33"/>
         <source>Type</source>
         <translation>Loại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="35"/>
         <source>Default value</source>
         <translation>Giá trị</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="68"/>
         <source>Deleted</source>
         <translation>Đã xóa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/restorePropertiesDialog.cpp" line="71"/>
         <source>Existed</source>
         <translation>Đã tồn tại</translation>
     </message>
@@ -509,7 +410,6 @@
 <context>
     <name>qReal::SuggestToCreateDiagramDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramDialog.cpp" line="32"/>
         <source>Create diagram</source>
         <translation>Tạo sơ đồ</translation>
     </message>
@@ -517,12 +417,10 @@
 <context>
     <name>qReal::SuggestToCreateDiagramWidget</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramWidget.cpp" line="47"/>
         <source>editor: </source>
         <translation>trình soạn thảo: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateDiagramWidget.cpp" line="47"/>
         <source>, diagram: </source>
         <translation>, sơ đồ: </translation>
     </message>
@@ -530,7 +428,6 @@
 <context>
     <name>qReal::SuggestToCreateProjectDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/projectManagement/suggestToCreateProjectDialog.cpp" line="33"/>
         <source>Create project</source>
         <translation>Tạo dự án</translation>
     </message>
@@ -538,12 +435,10 @@
 <context>
     <name>qReal::gui::AddNodeDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="46"/>
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/addNodeDialog.cpp" line="46"/>
         <source>All required properties should be filled</source>
         <translation>Tất cả các thuộc tính bắt buộc phải được điền</translation>
     </message>
@@ -551,64 +446,50 @@
 <context>
     <name>qReal::gui::DynamicPropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="49"/>
         <source>Properties</source>
         <translation>Thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="51"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="51"/>
         <source>Type</source>
         <translation>Loại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="51"/>
         <source>Value</source>
         <translation>Giá trị</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="118"/>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="395"/>
         <source>Delete</source>
         <translation>Xóa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="155"/>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="170"/>
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="170"/>
         <source>There is already a subprogram with that name</source>
         <translation>Đã tồn tại chương trình con với tên này</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="357"/>
         <source>Name is not filled in row %1</source>
         <translation>Tên tham số %1 chưa được điền</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="361"/>
         <source>Name should start with a letter(row %1)</source>
         <translation>Tên đối số phải bắt đầu bằng chữ cái (dòng %1)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="372"/>
         <source>Value in row %1 is not integer</source>
         <translation>Giá trị tham số %1 không phải số nguyên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="377"/>
         <source>Value in row %1 is not float</source>
         <translation>Giá trị tham số %1 không phải số</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/subprogram/dynamicPropertiesDialog.cpp" line="387"/>
         <source>Duplicate names</source>
         <translation>Tên trùng lặp</translation>
     </message>
@@ -616,12 +497,10 @@
 <context>
     <name>qReal::gui::EdgePropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="46"/>
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/edgePropertiesDialog.cpp" line="46"/>
         <source>All required properties should be filled</source>
         <translation>Tất cả các thuộc tính bắt buộc phải được điền</translation>
     </message>
@@ -629,7 +508,6 @@
 <context>
     <name>qReal::gui::PropertiesDialog</name>
     <message>
-        <location filename="../../../qrgui/dialogs/metamodelingOnFly/propertiesDialog.cpp" line="41"/>
         <source>Properties: </source>
         <translation>Thuộc tính: </translation>
     </message>

--- a/qrtranslations/vi/qrgui/editor_vi.ts
+++ b/qrtranslations/vi/qrgui/editor_vi.ts
@@ -4,32 +4,26 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="23"/>
         <source>Add connection</source>
         <translation>Thêm kết nối</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="24"/>
         <source>Connect to other</source>
         <translation>Kết nối với đối tượng khác</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="25"/>
         <source>Disconnect</source>
         <translation>Ngắt kết nối</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="26"/>
         <source>Go to connected element</source>
         <translation>Đi đến phần tử đã kết nối</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="28"/>
         <source>Expand explosion</source>
         <translation>Mở rộng bản vẽ phân rã</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/sceneCustomizer.cpp" line="29"/>
         <source>Collapse explosion</source>
         <translation>Thu gọn bản vẽ phân rã</translation>
     </message>
@@ -37,17 +31,14 @@
 <context>
     <name>qReal::gui::editor::BrokenLine</name>
     <message>
-        <location filename="../../../qrgui/editor/private/brokenLine.cpp" line="24"/>
         <source>Delete point</source>
         <translation>Xóa điểm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/brokenLine.cpp" line="25"/>
         <source>Delete segment</source>
         <translation>Xóa đoạn</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/brokenLine.cpp" line="26"/>
         <source>Remove all points</source>
         <translation>Xóa tất cả các điểm</translation>
     </message>
@@ -55,12 +46,10 @@
 <context>
     <name>qReal::gui::editor::EdgeElement</name>
     <message>
-        <location filename="../../../qrgui/editor/edgeElement.cpp" line="62"/>
         <source>Reverse</source>
         <translation>Đảo ngược</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/edgeElement.cpp" line="63"/>
         <source>Change shape type</source>
         <translation>Thay đổi kiểu hình dạng</translation>
     </message>
@@ -68,28 +57,22 @@
 <context>
     <name>qReal::gui::editor::EditorViewScene</name>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="294"/>
         <source>Create new element</source>
         <translation>Tạo phần tử mới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="358"/>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="367"/>
         <source>Connect with the current item</source>
         <translation>Kết nối với mục hiện tại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="695"/>
         <source>Replace by...</source>
         <translation>Thay thế bằng...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="927"/>
         <source>Add child</source>
         <translation>Thêm phần tử con</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/editorViewScene.cpp" line="1419"/>
         <source>Delete</source>
         <translation>Xóa</translation>
     </message>
@@ -97,17 +80,14 @@
 <context>
     <name>qReal::gui::editor::LineFactory</name>
     <message>
-        <location filename="../../../qrgui/editor/private/lineFactory.cpp" line="49"/>
         <source>Broken</source>
         <translation>Đường gãy</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/lineFactory.cpp" line="52"/>
         <source>Square</source>
         <translation>Hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/lineFactory.cpp" line="55"/>
         <source>Curve</source>
         <translation>Đường cong</translation>
     </message>
@@ -115,7 +95,6 @@
 <context>
     <name>qReal::gui::editor::NodeElement</name>
     <message>
-        <location filename="../../../qrgui/editor/nodeElement.cpp" line="53"/>
         <source>Switch on grid</source>
         <translation>Bật lưới</translation>
     </message>
@@ -123,12 +102,10 @@
 <context>
     <name>qReal::gui::editor::PropertyEditorView</name>
     <message>
-        <location filename="../../../qrgui/editor/propertyEditorView.cpp" line="305"/>
         <source>Specify directory:</source>
         <translation>Chọn thư mục:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/propertyEditorView.cpp" line="312"/>
         <source>Select file:</source>
         <translation>Chọn tệp:</translation>
     </message>
@@ -136,7 +113,6 @@
 <context>
     <name>qReal::gui::editor::PushButtonPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/editor/private/pushButtonProperty.cpp" line="38"/>
         <source>Click to choose</source>
         <translation>Nhấp để chọn</translation>
     </message>
@@ -144,7 +120,6 @@
 <context>
     <name>qReal::gui::editor::SquareLine</name>
     <message>
-        <location filename="../../../qrgui/editor/private/squareLine.cpp" line="27"/>
         <source>Lay out</source>
         <translation>Sắp xếp lại</translation>
     </message>
@@ -152,24 +127,18 @@
 <context>
     <name>qReal::gui::editor::view::details::ExploserView</name>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="80"/>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="191"/>
         <source>New </source>
         <translation>Mới </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="130"/>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="144"/>
         <source>Change Properties</source>
         <translation>Thay đổi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="133"/>
         <source>Change Appearance</source>
         <translation>Thay đổi kiểu hiển thị</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/editor/private/exploserView.cpp" line="137"/>
         <source>Add element to palette</source>
         <translation>Thêm phần tử vào bảng màu</translation>
     </message>

--- a/qrtranslations/vi/qrgui/hotKeyManager_vi.ts
+++ b/qrtranslations/vi/qrgui/hotKeyManager_vi.ts
@@ -4,12 +4,10 @@
 <context>
     <name>PreferencesHotKeyManagerPage</name>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.cpp" line="98"/>
         <source>Question</source>
         <translation>Câu hỏi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.cpp" line="98"/>
         <source>This will clear all current shortcuts. Are you sure?</source>
         <translation>Thao tác này sẽ xóa tất cả các phím tắt hiện tại. Bạn có chắc chắn không?</translation>
     </message>
@@ -17,67 +15,54 @@
 <context>
     <name>hotKeyManagerPage</name>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="14"/>
         <source>Form</source>
         <translation>Biểu mẫu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="20"/>
         <source>Keyboard Shortcuts</source>
         <translation>Phím tắt Bàn phím</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="39"/>
         <source>Import...</source>
         <translation>Nhập...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="46"/>
         <source>Export...</source>
         <translation>Xuất...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="108"/>
         <source>Command</source>
         <translation>Lệnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="113"/>
         <source>Label</source>
         <translation>Mô tả</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="118"/>
         <source>Shortcut 1</source>
         <translation>Tổ hợp 1</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="123"/>
         <source>Shortcut 2</source>
         <translation>Tổ hợp 2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="128"/>
         <source>Shortcut 3</source>
         <translation>Tổ hợp 3</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="136"/>
         <source>Reset All</source>
         <translation>Đặt lại tất cả</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="146"/>
         <source>Shortcut</source>
         <translation>Tổ hợp phím</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="152"/>
         <source>Reset</source>
         <translation>Đặt lại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/hotKeyManager/hotKeyManagerPage.ui" line="175"/>
         <source>Key sequence</source>
         <translation>Nhập tổ hợp phím...</translation>
     </message>

--- a/qrtranslations/vi/qrgui/mainWindow_vi.ts
+++ b/qrtranslations/vi/qrgui/mainWindow_vi.ts
@@ -4,12 +4,10 @@
 <context>
     <name>ErrorListWidget</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorListWidget.cpp" line="60"/>
         <source>Clear</source>
         <translation>Xóa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorListWidget.cpp" line="61"/>
         <source>Copy</source>
         <translation>Sao chép</translation>
     </message>
@@ -17,52 +15,34 @@
 <context>
     <name>FindManager</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="39"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="81"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="82"/>
         <source>by name</source>
         <translation>theo tên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="41"/>
         <source>by type</source>
         <translation>theo loại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="43"/>
         <source>by property</source>
         <translation>theo thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="45"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="90"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="91"/>
         <source>by property content</source>
         <translation>theo nội dung thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="55"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="59"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="83"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="92"/>
         <source>case sensitivity</source>
         <translation>phân biệt chữ hoa/thường</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="56"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="59"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="84"/>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="93"/>
         <source>by regular expression</source>
         <translation>sử dụng biểu thức chính quy</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="64"/>
         <source>, </source>
         <translation>, </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/findManager.cpp" line="67"/>
         <source>   :: </source>
         <translation>   ::    </translation>
     </message>
@@ -70,445 +50,354 @@
 <context>
     <name>MainWindowUi</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="14"/>
         <source>QReal</source>
         <translation>QReal</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="49"/>
         <source>&amp;File</source>
         <translation>&amp;Tệp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="66"/>
         <source>&amp;View</source>
         <translation>&amp;Xem</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="70"/>
         <source>Panels</source>
         <translation>Bảng điều khiển</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="83"/>
         <source>&amp;Help</source>
         <translation>&amp;Trợ giúp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="93"/>
         <source>&amp;Settings</source>
         <translation>&amp;Thiết lập</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="106"/>
         <source>&amp;Tools</source>
         <translation>&amp;Công cụ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="112"/>
         <source>&amp;Edit</source>
         <translation>&amp;Chỉnh sửa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="134"/>
         <source>File Toolbar</source>
         <translation>Thanh công cụ Tệp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="164"/>
         <source>Mini Map</source>
         <translation>Bản đồ nhỏ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="213"/>
         <source>Palette</source>
         <translation>Bảng màu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="250"/>
         <source>Edit Toolbar</source>
         <translation>Thanh công cụ Chỉnh sửa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="263"/>
         <source>View Toolbar</source>
         <translation>Thanh công cụ Xem</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="281"/>
         <source>Logical Model Explorer</source>
         <translation>Trình duyệt mô hình logic</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="333"/>
         <source>Errors</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="355"/>
         <source>Graphical Model Explorer</source>
         <translation>Trình duyệt mô hình đồ họa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="389"/>
         <source>Property Editor</source>
         <translation>Trình soạn thảo thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="426"/>
         <source>Interpreter Toolbar</source>
         <translation>Thanh công cụ Trình thông dịch</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="437"/>
         <source>Generators Toolbar</source>
         <translation>Thanh công cụ Trình tạo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="451"/>
         <source>&amp;Quit</source>
         <translation>&amp;Thoát</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="460"/>
         <source>Zoom In</source>
         <translation>Phóng to</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="463"/>
         <source>Ctrl++</source>
         <translation>Ctrl++</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="472"/>
         <source>Zoom Out</source>
         <translation>Phóng nhỏ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="475"/>
         <source>Ctrl+-</source>
         <translation>Ctrl+-</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="486"/>
         <source>Antialiasing</source>
         <translation>Khử răng cưa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="494"/>
         <source>OpenGL Renderer</source>
         <translation>Bộ hiển thị OpenGL</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="503"/>
         <source>Print</source>
         <translation>In</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="508"/>
         <source>Export to SVG</source>
         <translation>Xuất sang SVG</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="513"/>
         <source>Open in new tab</source>
         <translation>Mở trong tab mới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="518"/>
         <source>Small Help</source>
         <translation>Trợ giúp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="521"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="526"/>
         <source>Open Logs</source>
         <translation>Mở tệp nhật ký</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="531"/>
         <source>About </source>
         <translation>Giới thiệu </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="536"/>
         <source>About Qt...</source>
         <translation>Giới thiệu về Qt...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="545"/>
         <source>Save</source>
         <translation>Lưu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="548"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="553"/>
         <source>Save as...</source>
         <translation>Lưu dưới dạng...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="556"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="565"/>
         <source>Open...</source>
         <translation>Mở...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="568"/>
         <source>Open</source>
         <translation>Mở</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="571"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="582"/>
         <source>Show grid</source>
         <translation>Hiển thị lưới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="590"/>
         <source>Switch on grid</source>
         <translation>Bật lưới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="595"/>
         <source>Mouse gestures</source>
         <translation>Thao tác chuột</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="600"/>
         <source>Preferences...</source>
         <translation>Tùy chọn...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="611"/>
         <source>Switch on alignment</source>
         <translation>Bật căn chỉnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="622"/>
         <source>Show alignment</source>
         <translation>Hiển thị đường căn chỉnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="627"/>
         <source>Debug</source>
         <translation>Gỡ lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="630"/>
         <source>F9</source>
         <translation>F9</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="639"/>
         <source>Generate and build</source>
         <translation>Tạo và biên dịch</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="642"/>
         <source>Ctrl+F9</source>
         <translation>Ctrl+F9</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="647"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="650"/>
         <source>Set breakpoints</source>
         <translation>Thiết lập điểm ngắt</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="653"/>
         <source>Ctrl+F3</source>
         <translation>Ctrl+F3</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="658"/>
         <source>Cont</source>
         <translation>Tiếp tục</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="661"/>
         <source>Ctrl+F6</source>
         <translation>Ctrl+F6</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="666"/>
         <source>Configure</source>
         <translation>Cấu hình</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="669"/>
         <source>Ctrl+F2</source>
         <translation>Ctrl+F2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="678"/>
         <source>New Diagram</source>
         <translation>Sơ đồ mới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="681"/>
         <source>Create new diagram in a current model</source>
         <translation>Tạo sơ đồ mới trong mô hình hiện tại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="690"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="693"/>
         <source>Fullscreen Mode</source>
         <translation>Chế độ toàn màn hình</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="696"/>
         <source>Ctrl+Shift+F</source>
         <translation>Ctrl+Shift+F</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="705"/>
         <source>New Project</source>
         <translation>Dự án mới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="708"/>
         <source>Ctrl+Shift+N</source>
         <translation>Ctrl+Shift+N</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="713"/>
         <source>Import...</source>
         <translation>Nhập...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="716"/>
         <source>Import QReal project into current.</source>
         <translation>Nhập dự án QReal vào dự án hiện tại.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="721"/>
         <source>Save diagram as a picture...</source>
         <translation>Lưu sơ đồ dưới dạng hình ảnh...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="726"/>
         <source>Close project</source>
         <translation>Đóng dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="731"/>
         <source>Find...</source>
         <translation>Tìm...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="736"/>
         <source>Find and replace</source>
         <translation>Tìm và thay thế</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="741"/>
         <source>Replace by...</source>
         <translation>Thay thế bằng...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="750"/>
         <source>Undo</source>
         <translation>Hoàn tác</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="753"/>
         <source>Ctrl+Z</source>
         <translation>Ctrl+Z</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="762"/>
         <source>Redo</source>
         <translation>Làm lại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="765"/>
         <source>Ctrl+Shift+Z</source>
         <translation>Ctrl+Shift+Z</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="770"/>
         <source>Export to XML</source>
         <translation>Xuất sang XML</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="778"/>
         <source>Show all text</source>
         <translation>Hiển thị toàn bộ văn bản</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="781"/>
         <source>Ctrl+Shift+T</source>
         <translation>Ctrl+Shift+T</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="786"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="789"/>
         <source>Hide bottom docks</source>
         <translation>Ẩn các bảng ở dưới cùng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="792"/>
         <source>Esc</source>
         <translation>Esc</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="801"/>
         <source>Copy</source>
         <translation>Sao chép</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="804"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="813"/>
         <source>Paste</source>
         <translation>Dán</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="816"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="825"/>
         <source>Cut</source>
         <translation>Cắt</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="828"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="833"/>
         <source>Restore default settings and Quit</source>
         <translation>Khôi phục cài đặt mặc định và thoát</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="842"/>
         <source>Open Examples...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.ui" line="845"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
@@ -516,7 +405,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="160"/>
         <source>Can`t open project file</source>
         <translation>Không thể mở tệp dự án</translation>
     </message>
@@ -524,7 +412,6 @@
 <context>
     <name>ReferenceList</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/referenceList.ui" line="14"/>
         <source>Choose a reference value</source>
         <translation>Chọn một giá trị tham chiếu</translation>
     </message>
@@ -532,165 +419,130 @@
 <context>
     <name>ShapeEdit</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="14"/>
         <source>Form</source>
         <translation>Trình soạn thảo hình dạng biểu tượng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="23"/>
         <source>Save</source>
         <translation>Lưu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="30"/>
         <source>Open</source>
         <translation>Mở</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="43"/>
         <source>Draw ellipse</source>
         <translation>Vẽ hình elip</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="84"/>
         <source>Add static text</source>
         <translation>Thêm văn bản tĩnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="125"/>
         <source>Add dynamic text</source>
         <translation>Thêm văn bản động</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="160"/>
         <source>Save as picture</source>
         <translation>Lưu dưới dạng hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="176"/>
         <source>Draw curve</source>
         <translation>Vẽ đường cong</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="211"/>
         <source>Save to Xml</source>
         <translation>Lưu vào Xml</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="245"/>
         <source>Font</source>
         <translation>Phông chữ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="272"/>
         <source>Family</source>
         <translation>Họ phông</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="321"/>
         <source>Size</source>
         <translation>Cỡ chữ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="363"/>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="796"/>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="935"/>
         <source>Color</source>
         <translation>Màu sắc</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="384"/>
         <source>Text format</source>
         <translation>Định dạng văn bản</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="396"/>
         <source>Italic</source>
         <translation>Nghiêng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="409"/>
         <source> Bold</source>
         <translation> Đậm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="422"/>
         <source>Underline</source>
         <translation>Gạch chân</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="444"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="470"/>
         <source>Stylus</source>
         <translation>Bút cảm ứng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="511"/>
         <source>Add line port</source>
         <translation>Thêm cổng dạng đường thẳng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="558"/>
         <source>Add point port</source>
         <translation>Thêm cổng dạng điểm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="599"/>
         <source>Add picture text</source>
         <translation>Thêm văn bản hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="637"/>
         <source>Draw rectangle</source>
         <translation>Vẽ hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="708"/>
         <source>Pen</source>
         <translation>Bút vẽ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="748"/>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="893"/>
         <source>Style</source>
         <translation>Kiểu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="838"/>
         <source>Width</source>
         <translation>Độ rộng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="856"/>
         <source>Brush</source>
         <translation>Cọ vẽ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="957"/>
         <source>Image</source>
         <translation>Hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="976"/>
         <source>Draw line</source>
         <translation>Vẽ đường thẳng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="1011"/>
         <source>VisibilityConditions</source>
         <translation>Điều kiện hiển thị</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="1024"/>
         <source>Clear</source>
         <translation>Xóa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.ui" line="1053"/>
         <source>Delete Item</source>
         <translation>Xóa mục</translation>
     </message>
@@ -698,7 +550,6 @@
 <context>
     <name>VisibilityConditionsDialog</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/visibilityConditionsDialog.ui" line="14"/>
         <source>Specify conditions in which choosen element must be shown</source>
         <translation>Chỉ định các điều kiện mà phần tử đã chọn phải được hiển thị</translation>
     </message>
@@ -706,12 +557,10 @@
 <context>
     <name>qReal::MainWindow</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="198"/>
         <source>Restore default settings</source>
         <translation>Khôi phục cài đặt mặc định</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="199"/>
         <source>Do you realy want to restore default settings?
 WARNING: Settings restoring cannot be undone
 WARNING: The settings will be restored after application restart</source>
@@ -720,165 +569,130 @@ CẢNH BÁO: Việc khôi phục cài đặt không thể hoàn tác
 CẢNH BÁO: Cài đặt sẽ được khôi phục sau khi khởi động lại ứng dụng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="676"/>
         <source>Could not save file, try to save it to another place</source>
         <translation>Không thể lưu tệp, hãy thử lưu vào vị trí khác</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="974"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="985"/>
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="974"/>
         <source>Plugin unloading failed: </source>
         <translation>Dỡ plugin thất bại: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="985"/>
         <source>Plugin loading failed: </source>
         <translation>Tải plugin thất bại: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1095"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1111"/>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1134"/>
         <source>Shape Editor</source>
         <translation>Trình soạn thảo hình dạng biểu tượng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1127"/>
         <source>Text Editor</source>
         <translation>Trình soạn thảo văn bản</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1347"/>
         <source>New diagram</source>
         <translation>Tạo sơ đồ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1351"/>
         <source>Open project</source>
         <translation>Mở dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1352"/>
         <source>Open examples</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1353"/>
         <source>Save project</source>
         <translation>Lưu dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1354"/>
         <source>Save project as</source>
         <translation>Lưu dự án dưới dạng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1355"/>
         <source>New project</source>
         <translation>Tạo dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1356"/>
         <source>Undo</source>
         <translation>Hoàn tác</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1357"/>
         <source>Redo</source>
         <translation>Làm lại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1358"/>
         <source>Zoom In</source>
         <translation>Phóng to</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1359"/>
         <source>Zoom Out</source>
         <translation>Phóng nhỏ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1360"/>
         <source>Close current tab</source>
         <translation>Đóng tab hiện tại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1361"/>
         <source>Close all tabs</source>
         <translation>Đóng tất cả các tab</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1362"/>
         <source>Print</source>
         <translation>In</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1363"/>
         <source>Find</source>
         <translation>Tìm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1364"/>
         <source>Find and replace</source>
         <translation>Tìm và thay thế</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1365"/>
         <source>Show all text</source>
         <translation>Hiển thị toàn bộ văn bản</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1366"/>
         <source>Toggle errors panel</source>
         <translation>Bật/tắt bảng lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1568"/>
         <source>Gestures Show</source>
         <translation>Thao tác chuột</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1908"/>
         <source>Shortcuts</source>
         <translation>Phím tắt</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="1978"/>
         <source>External tools</source>
         <translation>Công cụ bên ngoài</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2028"/>
         <source>Failed to open %1</source>
         <translation>Không thể mở %1</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2223"/>
         <source>Recent projects</source>
         <translation>Dự án gần đây</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2227"/>
         <source>Recent files</source>
         <translation>Tệp gần đây</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2258"/>
         <source>Save File</source>
         <translation>Lưu tệp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2258"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Hình ảnh (*.png *.jpg)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/mainWindow.cpp" line="2419"/>
         <source>Getting Started</source>
         <translation>Chào mừng!</translation>
     </message>
@@ -886,57 +700,46 @@ CẢNH BÁO: Cài đặt sẽ được khôi phục sau khi khởi động lại
 <context>
     <name>qReal::ProjectManagerWrapper</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="71"/>
         <source>Save</source>
         <translation>Lưu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="72"/>
         <source>&amp;Save</source>
         <translation>&amp;Lưu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="73"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Hủy</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="74"/>
         <source>&amp;Discard</source>
         <translation>&amp;Không lưu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="75"/>
         <source>Do you want to save current project?</source>
         <translation>Bạn có muốn lưu dự án hiện tại không?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="205"/>
         <source>Unsaved project</source>
         <translation>Dự án chưa được lưu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="214"/>
         <source> [modified]</source>
         <translation> [đã thay đổi]</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="304"/>
         <source>Select file to save current metamodel to</source>
         <translation>Chọn tệp để lưu siêu mô hình hiện tại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="321"/>
         <source>QReal Save File (*.qrs)</source>
         <translation>Tệp lưu QReal (*.qrs)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="324"/>
         <source>All files (*.*)</source>
         <translation>Tất cả các tệp (*.*)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/projectManager/projectManagerWrapper.cpp" line="360"/>
         <source>QReal Save File(*.qrs)</source>
         <translation>Tệp lưu QReal (*.qrs)</translation>
     </message>
@@ -944,7 +747,6 @@ CẢNH BÁO: Cài đặt sẽ được khôi phục sau khi khởi động lại
 <context>
     <name>qReal::ShapeEdit</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/shapeEdit/shapeEdit.cpp" line="352"/>
         <source>Saving</source>
         <translation>Đang lưu</translation>
     </message>
@@ -952,47 +754,38 @@ CẢNH BÁO: Cài đặt sẽ được khôi phục sau khi khởi động lại
 <context>
     <name>qReal::StartWidget</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="124"/>
         <source>Open project</source>
         <translation>Mở dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="135"/>
         <source>New project</source>
         <translation>Tạo dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="182"/>
         <source>Recent projects</source>
         <translation>Dự án gần đây</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="271"/>
         <source>Create </source>
         <translation>Tạo </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="275"/>
         <source>Editor: </source>
         <translation>Trình soạn thảo: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="275"/>
         <source>; Diagram: </source>
         <translation>; Sơ đồ: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="287"/>
         <source>Select file with metamodel to open</source>
         <translation>Chọn tệp siêu mô hình để mở</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="336"/>
         <source>Enter the diagram name:</source>
         <translation>Nhập tên sơ đồ:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/startWidget/startWidget.cpp" line="336"/>
         <source>diagram name:</source>
         <translation>tên sơ đồ:</translation>
     </message>
@@ -1000,79 +793,58 @@ CẢNH BÁO: Cài đặt sẽ được khôi phục sau khi khởi động lại
 <context>
     <name>qReal::gui::DraggableElement</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="89"/>
         <source>Mouse gesture</source>
         <translation>Thao tác chuột</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="182"/>
         <source>Deleting an element: </source>
         <translation>Đang xóa một phần tử: </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="183"/>
         <source>Do you really want to delete this item and all its graphicalrepresentation from the scene and from the palette?</source>
         <translation>Bạn có thực sự muốn xóa mục này và tất cả các biểu diễn đồ họa của nó khỏi khung cảnh và bảng màu không?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="191"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="231"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="269"/>
         <source>Yes</source>
         <translation>Có</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="192"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="232"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="270"/>
         <source>No</source>
         <translation>Không</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="222"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="255"/>
         <source>Warning</source>
         <translation>Cảnh báo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="223"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="256"/>
         <source>The deleted element </source>
         <translation>Phần tử bị xóa </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="224"/>
         <source> is the element of root digram. Continue to delete?</source>
         <translation> là phần tử của sơ đồ gốc. Tiếp tục xóa?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="258"/>
         <source> has inheritors:</source>
         <translation> có các lớp kế thừa:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="261"/>
         <source>If you delete it, its properties will be removed fromthe elements-inheritors. Continue to delete?</source>
         <translation>Nếu bạn xóa nó, các thuộc tính của nó sẽ bị xóa khỏi các phần tử kế thừa. Tiếp tục xóa?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="336"/>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="365"/>
         <source>Change Properties</source>
         <translation>Thay đổi thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="341"/>
         <source>Change Appearance</source>
         <translation>Thay đổi giao diện</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="346"/>
         <source>Delete Element</source>
         <translation>Xóa phần tử</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/draggableElement.cpp" line="370"/>
         <source>Delete</source>
         <translation>Xóa</translation>
     </message>
@@ -1080,22 +852,18 @@ CẢNH BÁO: Cài đặt sẽ được khôi phục sau khi khởi động lại
 <context>
     <name>qReal::gui::ErrorReporter</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="215"/>
         <source>INFORMATION:</source>
         <translation>THÔNG TIN:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="217"/>
         <source>WARNING:</source>
         <translation>CẢNH BÁO:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="219"/>
         <source>ERROR:</source>
         <translation>LỖI:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/errorReporter.cpp" line="221"/>
         <source>CRITICAL:</source>
         <translation>LỖI NGHIÊM TRỌNG:</translation>
     </message>
@@ -1103,7 +871,6 @@ CẢNH BÁO: Cài đặt sẽ được khôi phục sau khi khởi động lại
 <context>
     <name>qReal::gui::ModelExplorer</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/modelExplorer.cpp" line="35"/>
         <source>Delete</source>
         <translation>Xóa</translation>
     </message>
@@ -1111,12 +878,10 @@ CẢNH BÁO: Cài đặt sẽ được khôi phục sau khi khởi động lại
 <context>
     <name>qReal::gui::PaletteTreeWidget</name>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="157"/>
         <source>Add Entity</source>
         <translation>Thêm thực thể</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mainWindow/palette/paletteTreeWidget.cpp" line="158"/>
         <source>Add Relastionship</source>
         <translation>Thêm mối quan hệ</translation>
     </message>

--- a/qrtranslations/vi/qrgui/models_vi.ts
+++ b/qrtranslations/vi/qrgui/models_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>qReal::gui::RenameDialog</name>
     <message>
-        <location filename="../../../qrgui/models/details/renameDialog.cpp" line="26"/>
         <source>Enter new name</source>
         <translation>Nhập tên mới</translation>
     </message>
@@ -12,7 +11,6 @@
 <context>
     <name>qReal::models::details::modelsImplementation::AbstractModel</name>
     <message>
-        <location filename="../../../qrgui/models/details/modelsImplementation/abstractModel.cpp" line="45"/>
         <source>name</source>
         <translation>tên</translation>
     </message>

--- a/qrtranslations/vi/qrgui/mouseGestures_vi.ts
+++ b/qrtranslations/vi/qrgui/mouseGestures_vi.ts
@@ -4,17 +4,14 @@
 <context>
     <name>GesturesWidget</name>
     <message>
-        <location filename="../../../qrgui/mouseGestures/gesturesWidget.ui" line="20"/>
         <source>Form</source>
         <translation>Tư thế</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mouseGestures/gesturesWidget.ui" line="36"/>
         <source>List of mouse gestures</source>
         <translation>Danh sách các cử chỉ chuột</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/mouseGestures/gesturesWidget.ui" line="49"/>
         <source>Click to see how to draw it:</source>
         <translation>Nhấp để xem cách vẽ:</translation>
     </message>

--- a/qrtranslations/vi/qrgui/plugins/metaMetaModel_vi.ts
+++ b/qrtranslations/vi/qrgui/plugins/metaMetaModel_vi.ts
@@ -4,7 +4,6 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/metaMetaModel/src/metamodel.cpp" line="74"/>
         <source>Unknown element %1</source>
         <translation>Phần tử không xác định %1</translation>
     </message>

--- a/qrtranslations/vi/qrgui/plugins/pluginManager_vi.ts
+++ b/qrtranslations/vi/qrgui/plugins/pluginManager_vi.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="598"/>
         <source>Root node for diagram %1 (which is %2) does not exist!</source>
         <translation>Nút gốc cho sơ đồ %1 (là %2) không tồn tại!</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="612"/>
         <source>Name should contain only latin letters, digits, spaces and underscores and should start with latin letter or underscore</source>
         <translation>Tên chỉ nên chứa các chữ cái Latin, chữ số, khoảng trắng và dấu gạch dưới, và phải bắt đầu bằng chữ cái Latin hoặc dấu gạch dưới</translation>
     </message>
@@ -17,32 +15,26 @@
 <context>
     <name>qReal::QrsMetamodelLoader</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="174"/>
         <source>Incorrect label type</source>
         <translation>Loại nhãn không đúng</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="607"/>
         <source>Name should not be empty</source>
         <translation>Tên không được để trống</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="631"/>
         <source>Port type %1 not declared in metamodel</source>
         <translation>Loại cổng %1 chưa được khai báo trong siêu mô hình</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="665"/>
         <source>Unknown link style type %1</source>
         <translation>Loại kiểu liên kết %1 không xác định</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="679"/>
         <source>Unknown link shape type %1</source>
         <translation>Loại hình dạng liên kết %1 không xác định</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelLoader.cpp" line="688"/>
         <source>%1 is not a valid integer number</source>
         <translation>%1 không phải là một số nguyên hợp lệ</translation>
     </message>
@@ -50,12 +42,10 @@
 <context>
     <name>qReal::QrsMetamodelSaver</name>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelSaver.cpp" line="389"/>
         <source>Unknown link style type %1</source>
         <translation>Loại kiểu liên kết %1 không xác định</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/pluginManager/qrsMetamodelSaver.cpp" line="405"/>
         <source>Unknown link shape type %1</source>
         <translation>Loại hình dạng liên kết %1 không xác định</translation>
     </message>

--- a/qrtranslations/vi/qrgui/plugins/toolPluginInterface_vi.ts
+++ b/qrtranslations/vi/qrgui/plugins/toolPluginInterface_vi.ts
@@ -4,12 +4,10 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../../qrgui/plugins/toolPluginInterface/customizer.h" line="113"/>
         <source>Existing connections</source>
         <translation>Các kết nối hiện có</translation>
     </message>
     <message>
-        <location filename="../../../../qrgui/plugins/toolPluginInterface/customizer.h" line="118"/>
         <source>Elements from this group exist for reusing all created connections</source>
         <translation>Các phần tử từ nhóm này dùng để tái sử dụng tất cả các kết nối đã tạo trong dự án</translation>
     </message>

--- a/qrtranslations/vi/qrgui/preferencesDialog_vi.ts
+++ b/qrtranslations/vi/qrgui/preferencesDialog_vi.ts
@@ -4,72 +4,58 @@
 <context>
     <name>PreferencesBehaviourPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="23"/>
         <source>User Interface</source>
         <translation>Giao diện người dùng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="39"/>
         <source>Language</source>
         <translation>Ngôn ngữ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="52"/>
         <source>Automatics</source>
         <translation>Tự động hóa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="84"/>
         <source>Palette tab switching</source>
         <translation>Chuyển đổi tab trong bảng màu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="91"/>
         <source>msec</source>
         <translation>mili giây</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="98"/>
         <source>Autosave</source>
         <translation>Tự động lưu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="108"/>
         <source>sec</source>
         <translation>giây</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="131"/>
         <source>Delay after gesture</source>
         <translation>Độ trễ sau cử chỉ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="138"/>
         <source>Gestures</source>
         <translation>Cử chỉ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="148"/>
         <source>Touch</source>
         <translation>Cảm ứng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="164"/>
         <source>Touch Mode</source>
         <translation>Chế độ làm việc trên màn hình cảm ứng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="174"/>
         <source>Widgets</source>
         <translation>Thành phần giao diện</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.ui" line="190"/>
         <source>Dockable mode</source>
         <translation>Chế độ cửa sổ nổi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/behaviourPage.cpp" line="117"/>
         <source>&lt;System Language&gt;</source>
         <translation>&lt;Ngôn ngữ hệ thống&gt;</translation>
     </message>
@@ -77,17 +63,14 @@
 <context>
     <name>PreferencesDebuggerPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/debuggerPage.ui" line="9"/>
         <source>Presentation</source>
         <translation>Cấu hình</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/debuggerPage.ui" line="25"/>
         <source>Debug timeout (ms):</source>
         <translation>Thời gian chờ khi gỡ lỗi (ms):</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/debuggerPage.ui" line="35"/>
         <source>Color of highlighting:</source>
         <translation>Màu sắc làm nổi bật:</translation>
     </message>
@@ -95,32 +78,26 @@
 <context>
     <name>PreferencesDialog</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="32"/>
         <source>Preferences</source>
         <translation>Tùy chọn</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="42"/>
         <source>OK</source>
         <translation>Đồng ý</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="49"/>
         <source>Cancel</source>
         <translation>Hủy</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="56"/>
         <source>Apply</source>
         <translation>Áp dụng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="143"/>
         <source>Export</source>
         <translation>Xuất</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.ui" line="150"/>
         <source>Import</source>
         <translation>Nhập</translation>
     </message>
@@ -128,132 +105,106 @@
 <context>
     <name>PreferencesEditorPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="24"/>
         <source>Font</source>
         <translation>Phông chữ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="61"/>
         <source>Use some of system fonts</source>
         <translation>Sử dụng phông chữ hệ thống</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="74"/>
         <source>Choose Font</source>
         <translation>Chọn phông chữ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="84"/>
         <source>Grid</source>
         <translation>Lưới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="106"/>
         <source>Show grid</source>
         <translation>Hiển thị lưới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="122"/>
         <source>Activate grid</source>
         <translation>Canh chỉnh theo lưới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="138"/>
         <source>Show alignment</source>
         <translation>Hiển thị các đường dẫn</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="167"/>
         <source>Activate alignment</source>
         <translation>Canh chỉnh theo đường dẫn</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="190"/>
         <source>Width</source>
         <translation>Độ dày lưới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="222"/>
         <source>Cell size</source>
         <translation>Kích thước ô lưới</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="260"/>
         <source>Node Elements</source>
         <translation>Các phần tử</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="292"/>
         <source>Drag area</source>
         <translation>Kích thước vùng thu phóng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="302"/>
         <source>Edge</source>
         <translation>Liên kết</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="344"/>
         <source>broken</source>
         <translation>Đường gãy khúc</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="349"/>
         <source>square</source>
         <translation>Đường hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="354"/>
         <source>curve</source>
         <translation>Đường cong Bézier</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="362"/>
         <source>Line mode</source>
         <translation>Kiểu liên kết</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="375"/>
         <source>Loop edges indent</source>
         <translation>Khoảng lùi của liên kết vòng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="413"/>
         <source>Embedded Linkers</source>
         <translation>Bộ liên kết tích hợp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="455"/>
         <source>Size</source>
         <translation>Kích thước thanh công cụ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="462"/>
         <source>Indent</source>
         <translation>Khoảng lùi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="472"/>
         <source>Palette</source>
         <translation>Bảng màu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="488"/>
         <source>   Representation   </source>
         <translation>Hiển thị</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="495"/>
         <source>   Count of items in a row </source>
         <translation>Số biểu tượng trên một hàng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="515"/>
         <source>Icons  and names</source>
         <translation>Biểu tượng và tên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/editorPage.ui" line="520"/>
         <source>Icons</source>
         <translation>Biểu tượng</translation>
     </message>
@@ -261,33 +212,26 @@
 <context>
     <name>PreferencesFeaturesPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="23"/>
         <source>Element controls</source>
         <translation>Điều khiển phần tử</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="39"/>
         <source>Gestures</source>
         <translation>Cử chỉ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="46"/>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="53"/>
         <source>fast linking with mouse</source>
         <translation>Liên kết nhanh bằng chuột</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="60"/>
         <source>Embedded Linkers</source>
         <translation>Bộ liên kết tích hợp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="67"/>
         <source>fast property editing</source>
         <translation>Chỉnh sửa thuộc tính nhanh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/featuresPage.ui" line="74"/>
         <source>Embedded Controls</source>
         <translation>Điều khiển tích hợp</translation>
     </message>
@@ -295,52 +239,42 @@
 <context>
     <name>PreferencesMiscellaneousPage</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="24"/>
         <source>Antialiasing</source>
         <translation>Khử răng cưa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="43"/>
         <source>Show splashscreen</source>
         <translation>Hiển thị màn hình khởi động</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="64"/>
         <source>Limit recent projects list</source>
         <translation>Giới hạn số lượng dự án gần đây</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="95"/>
         <source>Toolbars</source>
         <translation>Thanh công cụ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="102"/>
         <source>Images</source>
         <translation>Hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="109"/>
         <source>Graphics</source>
         <translation>Đồ họa</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="125"/>
         <source>Browse</source>
         <translation>Duyệt</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="151"/>
         <source>Other</source>
         <translation>Khác</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.ui" line="167"/>
         <source>Size</source>
         <translation>Kích thước thanh công cụ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesPages/miscellaneousPage.cpp" line="57"/>
         <source>Open Directory</source>
         <translation>Chọn thư mục</translation>
     </message>
@@ -348,43 +282,34 @@
 <context>
     <name>qReal::gui::PreferencesDialog</name>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="58"/>
         <source>Behaviour</source>
         <translation>Hành vi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="59"/>
         <source>Miscellaneous</source>
         <translation>Khác</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="60"/>
         <source>Editor</source>
         <translation>Trình soạn thảo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="80"/>
         <source>Information</source>
         <translation>Thông tin</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="80"/>
         <source>You should restart the program to apply changes</source>
         <translation>Bạn cần khởi động lại chương trình để áp dụng các thay đổi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="157"/>
         <source>Save File</source>
         <translation>Lưu tệp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="157"/>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="168"/>
         <source>*.ini</source>
         <translation>*.ini</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/preferencesDialog/preferencesDialog.cpp" line="168"/>
         <source>Open File</source>
         <translation>Mở tệp</translation>
     </message>

--- a/qrtranslations/vi/qrgui/systemFacade_vi.ts
+++ b/qrtranslations/vi/qrgui/systemFacade_vi.ts
@@ -4,62 +4,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="26"/>
         <source>Information:</source>
         <translation>Thông tin:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="33"/>
         <source>Warning:</source>
         <translation>Cảnh báo:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="40"/>
         <source>Error:</source>
         <translation>Lỗi:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="48"/>
         <source>Critical:</source>
         <translation>Quan trọng:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/consoleErrorReporter.cpp" line="62"/>
         <source>Bubble:</source>
         <translation>Bong bóng:</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="256"/>
         <source>Can`t open project file</source>
         <translation>Không thể mở tệp dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="114"/>
         <source>Project was automaticly converted from version %1 to version %2. Please check its contents.</source>
         <translation>Dự án đã được tự động chuyển đổi từ phiên bản %1 sang phiên bản %2. Vui lòng kiểm tra nội dung của nó.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="125"/>
         <source>The attempt to automaticly convert this project to the current enviroment version failed and thus save file can`t be opened. </source>
         <translation>Việc cố gắng tự động chuyển đổi dự án này sang phiên bản môi trường hiện tại đã thất bại và do đó tệp lưu không thể được mở. </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="135"/>
         <source>This project was created by version %1 of the editor.</source>
         <translation>Dự án này được tạo bởi phiên bản %1 của trình soạn thảo.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="136"/>
         <source>This project was created by too old version of the editor.</source>
         <translation>Dự án này được tạo bởi phiên bản trình soạn thảo quá cũ.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="138"/>
         <source> It is now considered outdated and cannot be opened.</source>
         <translation> Nó hiện được coi là lỗi thời và không thể mở.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/versionsConverterManager.cpp" line="145"/>
         <source>The save you are trying to open is made by version %1 of editor, whitch is newer than currently installed enviroment. Update your version before opening this save.</source>
         <translation>Tệp lưu bạn đang cố mở được tạo bởi phiên bản %1 của trình soạn thảo, mới hơn phiên bản môi trường hiện tại. Hãy cập nhật phiên bản của bạn trước khi mở tệp này.</translation>
     </message>
@@ -67,18 +55,14 @@
 <context>
     <name>qReal::Autosaver</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="145"/>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="159"/>
         <source>Question</source>
         <translation>Câu hỏi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="169"/>
         <source>More recent autosaved version of this file was found. Do you wish to open it instead?</source>
         <translation>Đã tìm thấy phiên bản tự động lưu mới hơn của tệp này. Bạn có muốn mở phiên bản đó không?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/autosaver.cpp" line="175"/>
         <source>It seems like the last application session was terminated in an unusual way. Do you wish to recover unsaved project?</source>
         <translation>Có vẻ như phiên làm việc trước đó đã kết thúc bất thường. Bạn có muốn khôi phục dự án chưa lưu không?</translation>
     </message>
@@ -86,61 +70,48 @@
 <context>
     <name>qReal::ProjectManager</name>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="76"/>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="90"/>
         <source>Open project</source>
         <translation>Mở dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="150"/>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="157"/>
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="150"/>
         <source>Cannot open file, please try with another one.</source>
         <translation>Không thể mở tệp, vui lòng thử một tệp khác.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="185"/>
         <source>Select file with a save to import</source>
         <translation>Chọn tệp để nhập dữ liệu lưu</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="219"/>
         <source>There are missing plugins</source>
         <translation>Thiếu một số tiện ích bổ sung</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="220"/>
         <source>These plugins are not present, but needed to load the save:
 </source>
         <translation>Các tiện ích bổ sung này không có mặt nhưng cần thiết để tải tệp lưu:
 </translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="271"/>
         <source>This project contains unknown element %1 and thus can`t be opened. Probably it was created by old or incorrectly working version of QReal.</source>
         <translation>Dự án này chứa phần tử không xác định %1 và do đó không thể mở. Có thể nó được tạo bởi phiên bản cũ hoặc phiên bản QReal hoạt động không chính xác.</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="273"/>
         <source>Can`t open project file</source>
         <translation>Không thể mở tệp dự án</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="352"/>
         <source>Select file to save current model to</source>
         <translation>Chọn tệp để lưu mô hình hiện tại</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="403"/>
         <source>File not found</source>
         <translation>Không tìm thấy tệp</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/systemFacade/components/projectManager.cpp" line="403"/>
         <source>File %1 not found. Try again</source>
         <translation>Không tìm thấy tệp %1. Hãy thử lại</translation>
     </message>

--- a/qrtranslations/vi/qrgui/textEditor_vi.ts
+++ b/qrtranslations/vi/qrgui/textEditor_vi.ts
@@ -4,47 +4,38 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="91"/>
         <source>Text File</source>
         <translation>Tệp văn bản</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="108"/>
         <source>C Language Source File</source>
         <translation>Tệp nguồn ngôn ngữ C</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="125"/>
         <source>Russian Algorithmic Language Source File</source>
         <translation>Tệp nguồn ngôn ngữ thuật toán Nga</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="143"/>
         <source>Python Source File</source>
         <translation>Tệp nguồn Python</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="160"/>
         <source>Java Script Language Source File</source>
         <translation>Tệp nguồn ngôn ngữ JavaScript</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="177"/>
         <source>QtScript Language Source File</source>
         <translation>Tệp nguồn ngôn ngữ QtScript</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="194"/>
         <source>F# Language Source File</source>
         <translation>Tệp nguồn ngôn ngữ F#</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="212"/>
         <source>PascalABC Language Source File</source>
         <translation>Tệp nguồn ngôn ngữ PascalABC</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/languageInfo.h" line="229"/>
         <source>Lua Language Source File</source>
         <translation>Tệp nguồn ngôn ngữ Lua</translation>
     </message>
@@ -52,22 +43,18 @@
 <context>
     <name>qReal::text::TextManager</name>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="86"/>
         <source>Confirmation</source>
         <translation>Xác nhận</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="87"/>
         <source>Save before closing?</source>
         <translation>Lưu trước khi đóng?</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="280"/>
         <source>All files (*)</source>
         <translation>Tất cả các tệp (*)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/textEditor/textManager.cpp" line="284"/>
         <source>Save generated code</source>
         <translation>Lưu mã đã tạo</translation>
     </message>

--- a/qrtranslations/vi/qrgui/thirdparty_vi.ts
+++ b/qrtranslations/vi/qrgui/thirdparty_vi.ts
@@ -4,15 +4,10 @@
 <context>
     <name>QtBoolEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="233"/>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="243"/>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="268"/>
         <source>true</source>
         <translation>đúng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="243"/>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="268"/>
         <source>false</source>
         <translation>sai</translation>
     </message>
@@ -20,12 +15,10 @@
 <context>
     <name>QtBoolPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="1696"/>
         <source>true</source>
         <translation>đúng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="1697"/>
         <source>false</source>
         <translation>sai</translation>
     </message>
@@ -33,7 +26,6 @@
 <context>
     <name>QtCharEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="1700"/>
         <source>Clear Char</source>
         <translation>Xóa ký tự</translation>
     </message>
@@ -41,7 +33,6 @@
 <context>
     <name>QtColorEditWidget</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="2368"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -49,22 +40,18 @@
 <context>
     <name>QtColorPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6496"/>
         <source>Red</source>
         <translation>Đỏ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6504"/>
         <source>Green</source>
         <translation>Xanh lá</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6512"/>
         <source>Blue</source>
         <translation>Xanh dương</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6520"/>
         <source>Alpha</source>
         <translation>Độ trong suốt (Alpha)</translation>
     </message>
@@ -72,97 +59,78 @@
 <context>
     <name>QtCursorDatabase</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="58"/>
         <source>Arrow</source>
         <translation>Mũi tên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="60"/>
         <source>Up Arrow</source>
         <translation>Mũi tên lên</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="62"/>
         <source>Cross</source>
         <translation>Dấu cộng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="64"/>
         <source>Wait</source>
         <translation>Chờ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="66"/>
         <source>IBeam</source>
         <translation>Con trỏ hình chữ I</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="68"/>
         <source>Size Vertical</source>
         <translation>Thay đổi kích thước theo chiều dọc</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="70"/>
         <source>Size Horizontal</source>
         <translation>Thay đổi kích thước theo chiều ngang</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="72"/>
         <source>Size Backslash</source>
         <translation>Thay đổi kích thước theo đường chéo ngược</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="74"/>
         <source>Size Slash</source>
         <translation>Thay đổi kích thước theo đường chéo</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="76"/>
         <source>Size All</source>
         <translation>Thay đổi kích thước mọi hướng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="78"/>
         <source>Blank</source>
         <translation>Trống</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="80"/>
         <source>Split Vertical</source>
         <translation>Chia dọc</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="82"/>
         <source>Split Horizontal</source>
         <translation>Chia ngang</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="84"/>
         <source>Pointing Hand</source>
         <translation>Con trỏ hình bàn tay chỉ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="86"/>
         <source>Forbidden</source>
         <translation>Cấm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="88"/>
         <source>Open Hand</source>
         <translation>Bàn tay mở</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="90"/>
         <source>Closed Hand</source>
         <translation>Bàn tay nắm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="92"/>
         <source>What&apos;s This</source>
         <translation>Cái này là gì</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="94"/>
         <source>Busy</source>
         <translation>Đang bận</translation>
     </message>
@@ -170,12 +138,10 @@
 <context>
     <name>QtFontEditWidget</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="2577"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qteditorfactory.cpp" line="2597"/>
         <source>Select Font</source>
         <translation>Chọn phông chữ</translation>
     </message>
@@ -183,37 +149,30 @@
 <context>
     <name>QtFontPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6170"/>
         <source>Family</source>
         <translation>Họ phông</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6183"/>
         <source>Point Size</source>
         <translation>Cỡ chữ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6191"/>
         <source>Bold</source>
         <translation>Đậm</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6198"/>
         <source>Italic</source>
         <translation>Nghiêng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6205"/>
         <source>Underline</source>
         <translation>Gạch chân</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6212"/>
         <source>Strikeout</source>
         <translation>Gạch ngang</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="6219"/>
         <source>Kerning</source>
         <translation>Khoảng cách ký tự</translation>
     </message>
@@ -221,7 +180,6 @@
 <context>
     <name>QtKeySequenceEdit</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="328"/>
         <source>Clear Shortcut</source>
         <translation>Xóa phím tắt</translation>
     </message>
@@ -229,17 +187,14 @@
 <context>
     <name>QtLocalePropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2611"/>
         <source>%1, %2</source>
         <translation>%1, %2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2664"/>
         <source>Language</source>
         <translation>Ngôn ngữ</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2672"/>
         <source>Country</source>
         <translation>Quốc gia</translation>
     </message>
@@ -247,17 +202,14 @@
 <context>
     <name>QtPointFPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3081"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3152"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3160"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -265,17 +217,14 @@
 <context>
     <name>QtPointPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2841"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2878"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="2885"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -283,12 +232,10 @@
 <context>
     <name>QtPropertyBrowserUtils</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="187"/>
         <source>[%1, %2, %3] (%4)</source>
         <translation>[%1, %2, %3] (%4)</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="214"/>
         <source>[%1, %2]</source>
         <translation>[%1, %2]</translation>
     </message>
@@ -296,27 +243,22 @@
 <context>
     <name>QtRectFPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4586"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4742"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4750"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4758"/>
         <source>Width</source>
         <translation>Chiều rộng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4767"/>
         <source>Height</source>
         <translation>Chiều cao</translation>
     </message>
@@ -324,27 +266,22 @@
 <context>
     <name>QtRectPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4156"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4276"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4283"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4290"/>
         <source>Width</source>
         <translation>Chiều rộng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="4298"/>
         <source>Height</source>
         <translation>Chiều cao</translation>
     </message>
@@ -352,17 +289,14 @@
 <context>
     <name>QtSizeFPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3764"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3894"/>
         <source>Width</source>
         <translation>Chiều rộng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3903"/>
         <source>Height</source>
         <translation>Chiều cao</translation>
     </message>
@@ -370,33 +304,26 @@
 <context>
     <name>QtSizePolicyPropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5682"/>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5683"/>
         <source>&lt;Invalid&gt;</source>
         <translation>&lt;Giá trị không hợp lệ&gt;</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5684"/>
         <source>[%1, %2, %3, %4]</source>
         <translation>[%1, %2, %3, %4]</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5729"/>
         <source>Horizontal Policy</source>
         <translation>Chính sách ngang</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5738"/>
         <source>Vertical Policy</source>
         <translation>Chính sách dọc</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5747"/>
         <source>Horizontal Stretch</source>
         <translation>Độ co giãn ngang</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="5755"/>
         <source>Vertical Stretch</source>
         <translation>Độ co giãn dọc</translation>
     </message>
@@ -404,17 +331,14 @@
 <context>
     <name>QtSizePropertyManager</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3400"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3496"/>
         <source>Width</source>
         <translation>Chiều rộng</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qtpropertymanager.cpp" line="3504"/>
         <source>Height</source>
         <translation>Chiều cao</translation>
     </message>
@@ -422,12 +346,10 @@
 <context>
     <name>QtTreePropertyBrowser</name>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="478"/>
         <source>Property</source>
         <translation>Thuộc tính</translation>
     </message>
     <message>
-        <location filename="../../../qrgui/thirdparty/qt-solutions/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="479"/>
         <source>Value</source>
         <translation>Giá trị</translation>
     </message>

--- a/qrtranslations/vi/qrmc_vi.ts
+++ b/qrtranslations/vi/qrmc_vi.ts
@@ -4,19 +4,16 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrmc/main.cpp" line="26"/>
         <source>QReal Metamodel Compiler. It takes .qrs file with QReal metamodel created by metaeditor and generates Qt project with editor plugin for that metamodel. Project is ready to be built with qmake, but it actively uses QReal sources and build system, so it can not be built alone. Example of command line:
 </source>
         <translation>Trình biên dịch Siêu mô hình QReal. Nó nhận tệp .qrs chứa siêu mô hình QReal được tạo bởi metaeditor và sinh dự án Qt kèm plugin soạn thảo cho siêu mô hình đó. Dự án đã sẵn sàng để biên dịch bằng qmake, nhưng nó sử dụng chủ yếu mã nguồn và hệ thống xây dựng của QReal, do đó không thể biên dịch độc lập. Ví dụ về dòng lệnh:
 </translation>
     </message>
     <message>
-        <location filename="../../qrmc/main.cpp" line="75"/>
         <source>Metamodel file to be processed.</source>
         <translation>Tệp siêu mô hình cần xử lý.</translation>
     </message>
     <message>
-        <location filename="../../qrmc/main.cpp" line="77"/>
         <source>Directory to which source code of the editor plugin shall be generated.</source>
         <translation>Thư mục mà mã nguồn của plugin soạn thảo sẽ được sinh vào.</translation>
     </message>

--- a/qrtranslations/vi/qrtext_vi.ts
+++ b/qrtranslations/vi/qrtext_vi.ts
@@ -4,269 +4,206 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/lexer/lexer.h" line="60"/>
         <source>Invalid regexp: </source>
         <translation>Biểu thức chính quy không hợp lệ: </translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/lexer/lexer.h" line="171"/>
         <source>Unknown sequence of symbols: </source>
         <translation>Dãy ký hiệu không xác định: </translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/parser.h" line="54"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="57"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/concatenationParser.h" line="72"/>
         <source>Unexpected token</source>
         <translation>Token không mong đợi</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/tokenStream.h" line="62"/>
         <source>Expected &quot;%1&quot;, got &quot;%2&quot;</source>
         <translation>Mong đợi &quot;%1&quot;, nhận được &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/tokenParser.h" line="52"/>
         <source>Semantic action incorrectly discarded node in TokenParser</source>
         <translation>Hành động ngữ nghĩa loại bỏ nút không đúng trong TokenParser</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/simpleParser.h" line="51"/>
         <source>Semantic action incorrectly discarded node in SimpleParser</source>
         <translation>Hành động ngữ nghĩa loại bỏ nút không đúng trong SimpleParser</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="40"/>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/concatenationParser.h" line="43"/>
         <source>Unexpected end of input</source>
         <translation>Kết thúc dữ liệu đầu vào không mong đợi</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/alternativeParser.h" line="46"/>
         <source>Parser can not decide which alternative to use on </source>
         <translation>Bộ phân tích cú pháp không thể quyết định dùng phương án nào tại </translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/expressionParser.h" line="94"/>
         <source>Binary operator in expression is of the wrong type</source>
         <translation>Toán tử hai ngôi trong biểu thức có kiểu không đúng</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/parser/operators/expressionParser.h" line="102"/>
         <source>Right operand required</source>
         <translation>Cần có toán hạng bên phải</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/core/types/any.h" line="28"/>
         <source>any</source>
         <translation>bất kỳ</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/boolean.h" line="28"/>
         <source>boolean</source>
         <translation>kiểu luận lý</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/float.h" line="28"/>
         <source>float</source>
         <translation>số thực</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/integer.h" line="28"/>
         <source>integer</source>
         <translation>số nguyên</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/nil.h" line="28"/>
         <source>nil</source>
         <translation>rỗng</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/number.h" line="28"/>
         <source>number</source>
         <translation>số</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/string.h" line="28"/>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="100"/>
         <source>string</source>
         <translation>chuỗi</translation>
     </message>
     <message>
-        <location filename="../../qrtext/include/qrtext/lua/types/table.h" line="44"/>
         <source>table[%1]</source>
         <translation>bảng[%1]</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="68"/>
         <source>Type mismatch</source>
         <translation>Kiểu không tương thích</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="73"/>
         <source>Can not deduce type, expression can be of following types: %1</source>
         <translation>Không thể suy ra kiểu, biểu thức có thể thuộc các kiểu sau: %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="172"/>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="193"/>
         <source>This construction is not supported by semantic analysis</source>
         <translation>Cấu trúc này không được phân tích ngữ nghĩa hỗ trợ</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/core/semantics/semanticAnalyzer.cpp" line="178"/>
         <source>Type mismatch.</source>
         <translation>Kiểu không tương thích.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="107"/>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="387"/>
         <source>Variable %1 is read-only</source>
         <translation>Biến %1 chỉ được phép đọc</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="119"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="158"/>
         <source>This construction is not supported by interpreter</source>
         <translation>Cấu trúc này không được trình thông dịch hỗ trợ</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="130"/>
         <source>Seems like accessing an uninitialized variable %1</source>
         <translation>Có vẻ như đang truy cập biến chưa được khởi tạo %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="263"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="273"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="286"/>
         <source>Division by zero</source>
         <translation>Chia cho số 0</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="360"/>
         <source>Currently interpreter allows only tables denoted by identifier and by integer expression index, as in &apos;a[1 + 2][3]&apos;</source>
         <translation>Hiện tại trình thông dịch chỉ cho phép các bảng được ký hiệu bằng định danh và chỉ số là biểu thức nguyên, ví dụ như &apos;a[1 + 2][3]&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="391"/>
         <source>Tables denoted by something other than identifier (like f(x)[0]) are not allowed</source>
         <translation>Không cho phép bảng được ký hiệu bằng thứ khác định danh (ví dụ như f(x)[0])</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="417"/>
         <source>Explicit table indexes of non-integer type are not supported</source>
         <translation>Không hỗ trợ chỉ số bảng kiểu không phải số nguyên được chỉ định rõ</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="452"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="469"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="523"/>
-        <location filename="../../qrtext/src/lua/luaInterpreter.cpp" line="537"/>
         <source>Negative index for a table</source>
         <translation>Chỉ số âm khi truy cập bảng</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="30"/>
         <source>whitespace</source>
         <translation>khoảng trắng</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="31"/>
         <source>newline</source>
         <translation>dòng mới</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="34"/>
         <source>identifier</source>
         <translation>định danh</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="105"/>
         <source>integer literal</source>
         <translation>hằng số nguyên</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="119"/>
         <source>float literal</source>
         <translation>hằng số thực</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaLexer.cpp" line="122"/>
         <source>comment</source>
         <translation>chú thích</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="158"/>
         <source>node in &apos;stat&apos; semantic action is of unexpected type</source>
         <translation>nút trong hành động ngữ nghĩa &apos;stat&apos; có kiểu không mong đợi</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="165"/>
         <source>Number of variables in assignment shall be equal to the number of assigned values</source>
         <translation>Số lượng biến trong phép gán phải bằng số lượng giá trị được gán</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="177"/>
         <source>Assignment to function call is impossible</source>
         <translation>Không thể gán vào lời gọi hàm</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="304"/>
         <source>In &apos;args&apos; semantic action node is of incorrect type</source>
         <translation>Nút trong hành động ngữ nghĩa &apos;args&apos; có kiểu không đúng</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="321"/>
         <source>In &apos;table constructor&apos; semantic action fieldList is of incorrect type</source>
         <translation>fieldList trong hành động ngữ nghĩa &apos;table constructor&apos; có kiểu không đúng</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaParser.cpp" line="364"/>
         <source>In &apos;field&apos; semantic action node is of incorrect type</source>
         <translation>Nút trong hành động ngữ nghĩa &apos;field&apos; có kiểu không đúng</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="113"/>
         <source>Intrinsic function used as an identifier</source>
         <translation>Hàm nội tại không được dùng như một định danh</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="280"/>
         <source>Incorrect assignment, only variables and tables can be assigned to.</source>
         <translation>Phép gán không đúng, chỉ có thể gán cho biến và bảng.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="295"/>
         <source>Left and right operand have mismatched types.</source>
         <translation>Toán hạng trái và phải có kiểu không khớp.</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="301"/>
         <source>An attempt will be made to implicitly cast the right operand to the type &apos;%1&apos;</source>
         <translation>Sẽ có cố gắng ép kiểu ngầm định toán hạng phải sang kiểu &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="334"/>
         <source>Indirect function calls are not supported</source>
         <translation>Không hỗ trợ lời gọi hàm gián tiếp</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="342"/>
         <source>Unknown function</source>
         <translation>Hàm không xác định</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="354"/>
         <source>Too many parameters, %1 expected</source>
         <translation>Quá nhiều tham số, chỉ cần %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="357"/>
         <source>Not enough parameters, %1 expected</source>
         <translation>Thiếu tham số, cần %1</translation>
     </message>
     <message>
-        <location filename="../../qrtext/src/lua/luaSemanticAnalyzer.cpp" line="377"/>
         <source>Undeclared identifier: %1</source>
         <translation>Định danh chưa khai báo: %1</translation>
     </message>

--- a/qrtranslations/vi/qrutils_vi.ts
+++ b/qrtranslations/vi/qrutils_vi.ts
@@ -4,72 +4,58 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="642"/>
         <source>Unexpected end of stream at %1. Mb you forget &apos;;&apos;?</source>
         <translation>Kết thúc bất ngờ tại vị trí %1. Có thể bạn quên &apos;;&apos;?</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="647"/>
         <source>Unexpected symbol at %1 : expected %2, got %3</source>
         <translation>Ký hiệu không mong đợi tại %1: mong đợi %2, nhận được %3</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="651"/>
         <source>Types mismatch at %1: %2 = %3. Possible loss of data</source>
         <translation>Kiểu không khớp tại %1: %2 = %3. Có thể mất dữ liệu</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="656"/>
         <source>Unknown identifier at %1 &apos; %2 &apos;</source>
         <translation>Định danh không xác định tại %1: &apos;%2&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="659"/>
         <source>Empty process is unnecessary</source>
         <translation>Biểu thức trống</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="663"/>
         <source>Condition can&apos;t be empty</source>
         <translation>Điều kiện không thể để trống</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="667"/>
         <source>Using reserved variable %1</source>
         <translation>Sử dụng từ khóa dành riêng làm định danh (%1)</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="671"/>
         <source>No value of expression</source>
         <translation>Thiếu giá trị biểu thức</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="674"/>
         <source>Incorrect variable declaration: use function block for it</source>
         <translation>Khai báo biến không đúng: hãy sử dụng khối &quot;Hàm&quot; để thực hiện</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="679"/>
         <source>Unexpected symbol after the end of expression</source>
         <translation>Ký hiệu không mong đợi sau cuối biểu thức</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="683"/>
         <source>Unknown element property used</source>
         <translation>Thuộc tính phần tử không xác định được sử dụng</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="687"/>
         <source>Unknown element name used</source>
         <translation>Tên phần tử không xác định được sử dụng</translation>
     </message>
     <message>
-        <location filename="../../qrutils/expressionsParser/expressionsParser.cpp" line="691"/>
         <source>Integer division by zero</source>
         <translation>Chia số nguyên cho 0</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphicsUtils/abstractItem.cpp" line="696"/>
         <source>Remove</source>
         <translation>Xóa</translation>
     </message>
@@ -77,23 +63,18 @@
 <context>
     <name>qReal::BaseGraphTransformationUnit</name>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="48"/>
         <source>no current diagram</source>
         <translation>Hãy mở một sơ đồ</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="75"/>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="123"/>
         <source>Rule &apos;</source>
         <translation>Quy tắc &apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="76"/>
         <source>&apos; has not any appropriate nodes</source>
         <translation>&apos; không có nút phù hợp nào</translation>
     </message>
     <message>
-        <location filename="../../qrutils/graphUtils/baseGraphTransformationUnit.cpp" line="123"/>
         <source>&apos; has unconnected link</source>
         <translation>&apos; chứa liên kết chưa kết nối</translation>
     </message>
@@ -101,28 +82,22 @@
 <context>
     <name>qReal::interpretation::Block</name>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="60"/>
         <source>Control flow break detected, stopping</source>
         <translation>Phát hiện ngắt dòng điều khiển, dừng thực thi</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="65"/>
-        <location filename="../../qrutils/interpreter/block.cpp" line="158"/>
         <source>Block has disappeared!</source>
         <translation>Khối đã biến mất!</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="80"/>
         <source>Too many outgoing links</source>
         <translation>Quá nhiều liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="85"/>
         <source>No outgoing links, please connect this block to something or use Final Node to end program</source>
         <translation>Không có liên kết đi ra. Vui lòng nối khối này với một khối khác hoặc dùng khối &quot;Kết thúc&quot; để kết thúc chương trình</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/block.cpp" line="92"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được nối đến đâu</translation>
     </message>
@@ -130,22 +105,18 @@
 <context>
     <name>qReal::interpretation::Interpreter</name>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="55"/>
         <source>Interpreter is already running</source>
         <translation>Chương trình đang chạy</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="97"/>
         <source>Cannot create new thread with already occupied id %1</source>
         <translation>Không thể tạo tác vụ mới với mã định danh %1 đã được sử dụng</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="109"/>
         <source>Threads limit exceeded. Maximum threads count is %1</source>
         <translation>Vượt quá giới hạn số lượng tác vụ. Tối đa %1 tác vụ</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/interpreter.cpp" line="131"/>
         <source>Killing non-existent thread %1</source>
         <translation>Cố gắng kết thúc tác vụ không tồn tại %1</translation>
     </message>
@@ -153,17 +124,14 @@
 <context>
     <name>qReal::interpretation::Thread</name>
     <message>
-        <location filename="../../qrutils/interpreter/thread.cpp" line="117"/>
         <source>No entry point found, please add Initial Node to a diagram</source>
         <translation>Không tìm thấy điểm bắt đầu. Vui lòng thêm khối &quot;Bắt đầu&quot; vào sơ đồ</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/thread.cpp" line="122"/>
         <source>Stack overflow</source>
         <translation>Tràn ngăn xếp</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/thread.cpp" line="181"/>
         <source>Block has disappeared!</source>
         <translation>Khối đã biến mất!</translation>
     </message>
@@ -171,7 +139,6 @@
 <context>
     <name>qReal::interpretation::blocks::CommentBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/commentBlock.cpp" line="28"/>
         <source>The comment block with incoming links detected!</source>
         <translation>Khối &quot;Ghi chú&quot; không được có liên kết đi vào!</translation>
     </message>
@@ -179,22 +146,18 @@
 <context>
     <name>qReal::interpretation::blocks::ForkBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="36"/>
         <source>There must be at least two outgoing links</source>
         <translation>Phải có ít nhất hai liên kết đi ra</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="43"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được nối đến đâu</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="55"/>
         <source>Cannot create two threads with the same id %1</source>
         <translation>Không thể tạo hai tác vụ cùng mã định danh %1</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/forkBlock.cpp" line="69"/>
         <source>There must be a link that has its &apos;Guard&apos; property set to the current thread id %1</source>
         <translation>Phải có một liên kết có thuộc tính &apos;Guard&apos; đặt thành mã định danh tác vụ hiện tại %1</translation>
     </message>
@@ -202,27 +165,22 @@
 <context>
     <name>qReal::interpretation::blocks::IfBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="36"/>
         <source>There must be exactly TWO links outgoing from if block</source>
         <translation>Phải có đúng HAI liên kết đi ra từ khối điều kiện</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="43"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được nối đến đâu</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="52"/>
         <source>Two links marked with &apos;true&apos; found</source>
         <translation>Phát hiện cả hai liên kết đều được đánh dấu &apos;Đúng&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="59"/>
         <source>Two links marked with &apos;false&apos; found</source>
         <translation>Cả hai liên kết đều được đánh dấu &apos;Sai&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/ifBlock.cpp" line="66"/>
         <source>There must be at least one link with &quot;true&quot; or &quot;false&quot; marker on it</source>
         <translation>Phải có ít nhất một liên kết được đánh dấu &quot;đúng&quot; hoặc &quot;sai&quot;</translation>
     </message>
@@ -230,54 +188,42 @@
 <context>
     <name>qReal::interpretation::blocks::InputBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="27"/>
         <source>Input</source>
         <translation>Nhập</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="36"/>
         <source>Input value for %1:</source>
         <translation>Nhập giá trị cho %1:</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="56"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được nối đến đâu</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="61"/>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="65"/>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="72"/>
         <source>cancel</source>
         <translation>hủy</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="65"/>
         <source>Only one link with &quot;%1&quot; is allowed</source>
         <translation>Chỉ cho phép một liên kết với &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="72"/>
         <source>One of the outgoing links must be marked with &quot;%1&quot;</source>
         <translation>Một trong các liên kết đi ra phải được đánh dấu là &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="79"/>
         <source>Link to the next statement is missing</source>
         <translation>Thiếu liên kết đến câu lệnh tiếp theo</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="105"/>
         <source>You must input some value!</source>
         <translation>Bạn phải nhập một giá trị!</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="115"/>
         <source>No outgoing links, please connect this block to something or use Final Node to end program</source>
         <translation>Không có liên kết đi ra. Vui lòng nối khối này với một khối khác hoặc dùng khối &quot;Kết thúc&quot; để kết thúc chương trình</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/inputBlock.cpp" line="119"/>
         <source>There should be a maximum of TWO links outgoing from input block</source>
         <translation>Từ khối nhập liệu chỉ được phép có tối đa HAI liên kết đi ra</translation>
     </message>
@@ -285,7 +231,6 @@
 <context>
     <name>qReal::interpretation::blocks::JoinBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/joinBlock.cpp" line="32"/>
         <source>Link outgoing from join block must have surviving thread id in its &apos;Guard&apos; property</source>
         <translation>Liên kết đi ra từ khối &quot;Hợp nhất tác vụ&quot; phải có mã định danh tác vụ tiếp tục trong thuộc tính &apos;Guard&apos;</translation>
     </message>
@@ -293,7 +238,6 @@
 <context>
     <name>qReal::interpretation::blocks::KillThreadBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/killThreadBlock.cpp" line="24"/>
         <source>Need to specify a thread to be stopped</source>
         <translation>Cần chỉ định tác vụ cần dừng</translation>
     </message>
@@ -301,22 +245,18 @@
 <context>
     <name>qReal::interpretation::blocks::LoopBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="43"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Phải có một liên kết đi ra từ khối &quot;Vòng lặp&quot; được đánh dấu &quot;thân vòng lặp&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="47"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được nối đến đâu</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="56"/>
         <source>Two links marked as &quot;body&quot; found</source>
         <translation>Tìm thấy hai liên kết được đánh dấu là &quot;thân vòng lặp&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/loopBlock.cpp" line="76"/>
         <source>There must be a non-marked outgoing link</source>
         <translation>Phải có một liên kết đi ra không được đánh dấu</translation>
     </message>
@@ -324,23 +264,18 @@
 <context>
     <name>qReal::interpretation::blocks::PreconditionalLoopBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="41"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được nối đến đâu</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="51"/>
         <source>Two links marked as &quot;body&quot; found</source>
         <translation>Tìm thấy hai liên kết được đánh dấu là &quot;thân vòng lặp&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="59"/>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="66"/>
         <source>There must be a link with &quot;body&quot; marker on it</source>
         <translation>Phải có một liên kết đi ra từ khối &quot;Vòng lặp&quot; được đánh dấu &quot;thân vòng lặp&quot;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/preconditionalLoopBlock.cpp" line="71"/>
         <source>There must be a non-marked outgoing link</source>
         <translation>Phải có một liên kết đi ra không được đánh dấu</translation>
     </message>
@@ -348,7 +283,6 @@
 <context>
     <name>qReal::interpretation::blocks::ReceiveThreadMessageBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/receiveThreadMessageBlock.cpp" line="25"/>
         <source>Need to specify variable which will contain received message</source>
         <translation>Cần chỉ định biến sẽ chứa thông điệp nhận được</translation>
     </message>
@@ -356,7 +290,6 @@
 <context>
     <name>qReal::interpretation::blocks::SendThreadMessageBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/sendThreadMessageBlock.cpp" line="23"/>
         <source>Need to specify a receiving thread in &apos;Thread&apos; property</source>
         <translation>Cần chỉ định tác vụ nhận thông điệp trong thuộc tính &apos;Thread&apos;</translation>
     </message>
@@ -364,7 +297,6 @@
 <context>
     <name>qReal::interpretation::blocks::SubprogramBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/subprogramBlock.cpp" line="35"/>
         <source>Please enter valid c-style name for subprogram &quot;</source>
         <translation>Vui lòng nhập tên hợp lệ kiểu C cho chương trình con</translation>
     </message>
@@ -372,27 +304,22 @@
 <context>
     <name>qReal::interpretation::blocks::SwitchBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="36"/>
         <source>There must be at list TWO links outgoing from switch block</source>
         <translation>Phải có ít nhất HAI liên kết đi ra từ khối lựa chọn</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="43"/>
         <source>Outgoing link is not connected</source>
         <translation>Liên kết đi ra chưa được nối đến đâu</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="52"/>
         <source>There must be exactly one link without marker on it (default branch)</source>
         <translation>Phải có đúng một liên kết không đánh dấu (nhánh mặc định)</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="57"/>
         <source>Duplicate case branch: &apos;%1&apos;</source>
         <translation>Phát hiện nhiều nhánh &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/switchBlock.cpp" line="66"/>
         <source>There must be a link without marker on it (default branch)</source>
         <translation>Phải có một liên kết không đánh dấu (nhánh mặc định)</translation>
     </message>
@@ -400,7 +327,6 @@
 <context>
     <name>qReal::interpretation::blocks::UnsupportedBlock</name>
     <message>
-        <location filename="../../qrutils/interpreter/blocks/unsupportedBlock.cpp" line="21"/>
         <source>Block of a type which is unsupported by an interpreter</source>
         <translation>Khối có kiểu không được trình thông dịch hỗ trợ</translation>
     </message>
@@ -408,12 +334,10 @@
 <context>
     <name>qReal::ui::ColorDialog</name>
     <message>
-        <location filename="../../qrutils/widgets/colorDialog.cpp" line="34"/>
         <source>Select background color in the 2D-model editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/colorDialog.cpp" line="75"/>
         <source>Select the background color of the scene</source>
         <translation type="unfinished"></translation>
     </message>
@@ -421,7 +345,6 @@
 <context>
     <name>qReal::ui::ConsoleDock</name>
     <message>
-        <location filename="../../qrutils/widgets/consoleDock.cpp" line="50"/>
         <source>Reset shell</source>
         <translation>Xóa bảng điều khiển</translation>
     </message>
@@ -429,7 +352,6 @@
 <context>
     <name>qReal::ui::DirPicker</name>
     <message>
-        <location filename="../../qrutils/widgets/dirPicker.cpp" line="33"/>
         <source>Browse...</source>
         <translation>Duyệt...</translation>
     </message>
@@ -441,17 +363,14 @@
 <context>
     <name>qReal::ui::ImagePicker</name>
     <message>
-        <location filename="../../qrutils/widgets/imagePicker.cpp" line="35"/>
         <source>Browse...</source>
         <translation>Duyệt...</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/imagePicker.cpp" line="70"/>
         <source>Select image</source>
         <translation>Chọn hình ảnh</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/imagePicker.cpp" line="72"/>
         <source>Images (*.png *.svg *.jpg *.gif *.bmp);;All files (*.*)</source>
         <translation>Hình ảnh (*.png *.svg *.jpg *.gif *.bmp);;Tất cả các tệp (*.*)</translation>
     </message>
@@ -459,27 +378,22 @@
 <context>
     <name>qReal::ui::SearchLineEdit</name>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="31"/>
         <source>Clear text</source>
         <translation>Xóa văn bản</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="32"/>
         <source>Case insensitive</source>
         <translation>Không phân biệt chữ hoa/thường</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="33"/>
         <source>Case sensitive</source>
         <translation>Phân biệt chữ hoa/thường</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="34"/>
         <source>Regular expression</source>
         <translation>Biểu thức chính quy</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLineEdit.cpp" line="43"/>
         <source>Enter search text...</source>
         <translation>Nhập văn bản tìm kiếm...</translation>
     </message>
@@ -487,13 +401,10 @@
 <context>
     <name>qReal::ui::SearchLinePanel</name>
     <message>
-        <location filename="../../qrutils/widgets/searchLinePanel.cpp" line="134"/>
-        <location filename="../../qrutils/widgets/searchLinePanel.cpp" line="144"/>
         <source>Enter search text...</source>
         <translation>Nhập văn bản tìm kiếm...</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/searchLinePanel.cpp" line="155"/>
         <source>&lt;line&gt;:&lt;column&gt;</source>
         <translation>&lt;dòng&gt;:&lt;cột&gt;</translation>
     </message>
@@ -501,22 +412,18 @@
 <context>
     <name>utils::MetamodelGeneratorSupport</name>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="72"/>
         <source>Please, fill compiler settings</source>
         <translation>Vui lòng điền vào cài đặt trình biên dịch trong phần thiết lập</translation>
     </message>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="92"/>
         <source>Cannot unload plugin</source>
         <translation>Không thể gỡ bỏ tiện ích bổ sung</translation>
     </message>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="115"/>
         <source>Cannot load new editor</source>
         <translation>Không thể tải trình soạn thảo mới</translation>
     </message>
     <message>
-        <location filename="../../qrutils/metamodelGeneratorSupport.cpp" line="121"/>
         <source>Cannot build new editor</source>
         <translation>Không thể biên dịch trình soạn thảo mới. Vui lòng kiểm tra tên các phần tử</translation>
     </message>
@@ -524,97 +431,78 @@
 <context>
     <name>utils::QRealMessageBox</name>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="30"/>
         <source>Ok</source>
         <translation>Đồng ý</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="31"/>
         <source>Open</source>
         <translation>Mở</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="32"/>
         <source>Save</source>
         <translation>Lưu</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="33"/>
         <source>Cancel</source>
         <translation>Hủy</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="34"/>
         <source>Close</source>
         <translation>Đóng</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="35"/>
         <source>Discard</source>
         <translation>Bỏ qua</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="36"/>
         <source>Apply</source>
         <translation>Áp dụng</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="37"/>
         <source>Reset</source>
         <translation>Đặt lại</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="38"/>
         <source>Help</source>
         <translation>Trợ giúp</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="39"/>
         <source>Save All</source>
         <translation>Lưu tất cả</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="40"/>
         <source>Yes</source>
         <translation>Có</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="41"/>
         <source>Yes To All</source>
         <translation>Có cho tất cả</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="42"/>
         <source>No</source>
         <translation>Không</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="43"/>
         <source>No To All</source>
         <translation>Không cho tất cả</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="44"/>
         <source>Abort</source>
         <translation>Hủy bỏ</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="45"/>
         <source>Retry</source>
         <translation>Thử lại</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="46"/>
         <source>Ignore</source>
         <translation>Bỏ qua</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="47"/>
         <source>NoButton</source>
         <translation>Không phải nút</translation>
     </message>
     <message>
-        <location filename="../../qrutils/widgets/qRealMessageBox.cpp" line="49"/>
         <source>Restore Defaults</source>
         <translation>Khôi phục mặc định</translation>
     </message>
@@ -622,17 +510,14 @@
 <context>
     <name>watchListWindow</name>
     <message>
-        <location filename="../../qrutils/watchListWindow.ui" line="41"/>
         <source>Watch List</source>
         <translation>Biến</translation>
     </message>
     <message>
-        <location filename="../../qrutils/watchListWindow.ui" line="100"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../../qrutils/watchListWindow.ui" line="105"/>
         <source>Value</source>
         <translation>Giá trị</translation>
     </message>


### PR DESCRIPTION
Remove the location tag from generated ts files, which are useless in most contexts. Also, this should simplify the process of updating translations in case there are no new files in the change request.