### PR TITLE
Add automatic graph normalization after diagram element removal

### DIFF
--- a/qrgui/editor/commands/removeAndUpdateCommand.cpp
+++ b/qrgui/editor/commands/removeAndUpdateCommand.cpp
@@ -37,7 +37,7 @@ RemoveAndUpdateCommand::RemoveAndUpdateCommand(EditorViewScene &scene
 // connections to nodes outside the set are ignored.
 QHash<qReal::Id, QList<qReal::Id>> RemoveAndUpdateCommand::buildAdjacency(const QSet<Id> &nodesSet)
 {
-	auto &&repo = mLogicalApi.logicalRepoApi();
+	auto &&repo = mGraphicalApi.graphicalRepoApi();
 	QHash<Id, QList<Id>> adjacency;
 
 	for (auto &&node : nodesSet) {
@@ -53,13 +53,14 @@ QHash<qReal::Id, QList<qReal::Id>> RemoveAndUpdateCommand::buildAdjacency(const 
 		}
 	}
 
-    return adjacency;
+	return adjacency;
 }
 
 // Finds connected components in the adjacency graph using breadth-first search.
 // Each BFS traversal starting from an unvisited node produces one connected
 // component.
-QList<QList<qReal::Id>> RemoveAndUpdateCommand::findComponents(const QSet<Id> &nodesSet, const QHash<Id, QList<Id>> &adjacency)
+QList<QList<qReal::Id>> RemoveAndUpdateCommand::findComponents(const QSet<Id> &nodesSet,
+									const QHash<Id, QList<Id>> &adjacency)
 {
 	QList<QList<Id>> components;
 	QSet<Id> visited;
@@ -119,10 +120,9 @@ void RemoveAndUpdateCommand::postprocessCollectedItems(QList<ElementInfo> &nodes
 void RemoveAndUpdateCommand::reconnectComponent(const Id &incomingEdge, const Id &outgoingEdge,
 						QList<ElementInfo> &nodes, QList<ElementInfo> &edges)
 {
-	auto &&repo = mLogicalApi.logicalRepoApi();
+	auto &&repo = mGraphicalApi.graphicalRepoApi();
 	auto &&from = repo.from(incomingEdge);
 	auto &&to = repo.to(outgoingEdge);
-
 	appendGraphicalDelete(outgoingEdge, nodes, edges);
 
 	auto &&reshapeCmd = new ReshapeEdgeCommand(&mScene, incomingEdge);
@@ -141,65 +141,65 @@ void RemoveAndUpdateCommand::reconnectComponent(const Id &incomingEdge, const Id
 	addPreAction(reshapeCmd);
 }
 
-// Processes a connected component of nodes selected for removal.
-//
-// The selected nodes may consist of several independent parts, so they are
-// split into connected components beforehand. A component can be collapsed only
-// if it has a single entry point and a single exit point:
-//   - exactly one incoming edge from outside the component
-//   - exactly one outgoing edge to outside the component
-//
-// In this case the component is removed and the incoming edge is reconnected
-// directly to the original destination of the outgoing edge.
-//
-// Example:
-//
-// Delete {B, C, D, F}
-//
-// Before:
-//
-//          B
-//         / \
-// A ---- C   D ---- E
-//         \ /
-//          F
-//
-// After:
-//
-// A ----------------> E
-//
-// A component with multiple external connections cannot be collapsed safely.
-//
-// Example:
-//
-// Delete {B, C, D}
-//
-// Before:
-//
-//       A
-//       |
-//       v
-// X --> B ----> E
-//       |
-//       v
-//       C ----> F
-//       |
-//       v
-//       D
-//
-// Incoming edges:
-//   A -> B
-//   X -> B
-//
-// Outgoing edges:
-//   B -> E
-//   C -> F
-//
-// Since the component has multiple entry/exit points, it is skipped.
+/// Processes a connected component of nodes selected for removal.
+///
+/// The selected nodes may consist of several independent parts, so they are
+/// split into connected components beforehand. A component can be collapsed only
+/// if it has a single entry point and a single exit point:
+///   - exactly one incoming edge from outside the component
+///   - exactly one outgoing edge to outside the component
+///
+/// In this case the component is removed and the incoming edge is reconnected
+/// directly to the original destination of the outgoing edge.
+///
+/// Example:
+///
+/// Delete {B, C, D, F}
+///
+/// Before:
+///
+///          B
+///         / \
+/// A ---- C   D ---- E
+///         \ /
+///          F
+///
+/// After:
+///
+/// A ----------------> E
+///
+/// A component with multiple external connections cannot be collapsed safely.
+///
+/// Example:
+///
+/// Delete {B, C, D}
+///
+/// Before:
+///
+///       A
+///       |
+///       v
+/// X --> B ----> E
+///       |
+///       v
+///       C ----> F
+///       |
+///       v
+///       D
+///
+/// Incoming edges:
+///   A -> B
+///   X -> B
+///
+/// Outgoing edges:
+///   B -> E
+///   C -> F
+///
+/// Since the component has multiple entry/exit points, it is skipped.
 void RemoveAndUpdateCommand::processComponent(const QList<Id> &component, const QSet<Id> &nodesSet,
 							QList<ElementInfo> &nodes, QList<ElementInfo> &edges)
 {
-	auto &&repo = mLogicalApi.logicalRepoApi();
+	auto &&repo = mGraphicalApi.graphicalRepoApi();
 
 	Id incomingEdge;
 	Id outgoingEdge;

--- a/qrgui/editor/commands/removeAndUpdateCommand.cpp
+++ b/qrgui/editor/commands/removeAndUpdateCommand.cpp
@@ -89,7 +89,7 @@ QList<QList<qReal::Id>> RemoveAndUpdateCommand::findComponents(const QSet<Id> &n
 			}
 		}
 
-		components.append(std::move(component));
+		components.append(component);
 	}
 
 	return components;

--- a/qrgui/editor/commands/removeAndUpdateCommand.cpp
+++ b/qrgui/editor/commands/removeAndUpdateCommand.cpp
@@ -15,10 +15,12 @@
 #include "removeAndUpdateCommand.h"
 
 #include <models/models.h>
+#include <QQueue>
 
 #include "editor/editorViewScene.h"
 #include "editor/commands/arrangeLinksCommand.h"
 #include "editor/commands/updateElementCommand.h"
+#include "editor/commands/reshapeEdgeCommand.h"
 
 using namespace qReal::commands;
 using namespace qReal::gui::editor::commands;
@@ -28,6 +30,217 @@ RemoveAndUpdateCommand::RemoveAndUpdateCommand(EditorViewScene &scene
 	: RemoveElementsCommand(models)
 	, mScene(scene)
 {
+}
+
+// Builds an adjacency list for the subgraph induced by nodesSet.
+// Only edges connecting two nodes from nodesSet are included;
+// connections to nodes outside the set are ignored.
+QHash<qReal::Id, QList<qReal::Id>> RemoveAndUpdateCommand::buildAdjacency(const QSet<Id> &nodesSet)
+{
+	auto &&repo = mLogicalApi.logicalRepoApi();
+	QHash<Id, QList<Id>> adjacency;
+
+	for (auto &&node : nodesSet) {
+		auto &&neighbors = adjacency[node];
+		auto &&links = repo.links(node);
+
+		for (auto &&link : links) {
+			auto &&other = repo.otherEntityFromLink(link, node);
+
+			if (nodesSet.contains(other)) {
+				neighbors.append(other);
+			}
+		}
+	}
+
+    return adjacency;
+}
+
+// Finds connected components in the adjacency graph using breadth-first search.
+// Each BFS traversal starting from an unvisited node produces one connected
+// component.
+QList<QList<qReal::Id>> RemoveAndUpdateCommand::findComponents(const QSet<Id> &nodesSet, const QHash<Id, QList<Id>> &adjacency)
+{
+	QList<QList<Id>> components;
+	QSet<Id> visited;
+	visited.reserve(nodesSet.size());
+
+	for (auto &&start: nodesSet) {
+		if (visited.contains(start)) {
+			continue;
+		}
+
+		QList<Id> component;
+		QQueue<Id> queue;
+
+		queue.enqueue(start);
+		visited.insert(start);
+
+		while (!queue.isEmpty()) {
+			auto &&current = queue.dequeue();
+			component.append(current);
+
+			for (auto &&neighbor : adjacency.value(current)) {
+				if (!visited.contains(neighbor)) {
+					visited.insert(neighbor);
+					queue.enqueue(neighbor);
+				}
+			}
+		}
+
+		components.append(std::move(component));
+	}
+
+	return components;
+}
+
+void RemoveAndUpdateCommand::postprocessCollectedItems(QList<ElementInfo> &nodes, QList<ElementInfo> &edges)
+{
+	QSet<Id> nodesSet;
+	nodesSet.reserve(nodes.size());
+
+	for (auto &&info : nodes) {
+		nodesSet.insert(info.id());
+	}
+
+	auto &&adjacency = buildAdjacency(nodesSet);
+	auto &&components = findComponents(nodesSet, adjacency);
+
+	for (auto &&component: components) {
+		processComponent(component, nodesSet, nodes, edges);
+	}
+}
+
+// Collapses a connected component by removing its outgoing edge and updating
+// the incoming edge to bypass the component and point directly to the original
+// destination node of the removed edge.
+// Before: A ->(1) [ component ] ->(2) B
+// After: A ->(1)-> B
+void RemoveAndUpdateCommand::reconnectComponent(const Id &incomingEdge, const Id &outgoingEdge,
+						QList<ElementInfo> &nodes, QList<ElementInfo> &edges)
+{
+	auto &&repo = mLogicalApi.logicalRepoApi();
+	auto &&from = repo.from(incomingEdge);
+	auto &&to = repo.to(outgoingEdge);
+
+	appendGraphicalDelete(outgoingEdge, nodes, edges);
+
+	auto &&reshapeCmd = new ReshapeEdgeCommand(&mScene, incomingEdge);
+	reshapeCmd->startTracking();
+
+	auto &&edge = mScene.getEdgeById(incomingEdge);
+	auto &&startNode = mScene.getNodeById(from);
+	auto &&endNode = mScene.getNodeById(to);
+
+	if (edge && startNode && endNode) {
+		edge->connectToPort(startNode, endNode);
+		edge->layOut();
+	}
+
+	reshapeCmd->stopTracking();
+	addPreAction(reshapeCmd);
+}
+
+// Processes a connected component of nodes selected for removal.
+//
+// The selected nodes may consist of several independent parts, so they are
+// split into connected components beforehand. A component can be collapsed only
+// if it has a single entry point and a single exit point:
+//   - exactly one incoming edge from outside the component
+//   - exactly one outgoing edge to outside the component
+//
+// In this case the component is removed and the incoming edge is reconnected
+// directly to the original destination of the outgoing edge.
+//
+// Example:
+//
+// Delete {B, C, D, F}
+//
+// Before:
+//
+//          B
+//         / \
+// A ---- C   D ---- E
+//         \ /
+//          F
+//
+// After:
+//
+// A ----------------> E
+//
+// A component with multiple external connections cannot be collapsed safely.
+//
+// Example:
+//
+// Delete {B, C, D}
+//
+// Before:
+//
+//       A
+//       |
+//       v
+// X --> B ----> E
+//       |
+//       v
+//       C ----> F
+//       |
+//       v
+//       D
+//
+// Incoming edges:
+//   A -> B
+//   X -> B
+//
+// Outgoing edges:
+//   B -> E
+//   C -> F
+//
+// Since the component has multiple entry/exit points, it is skipped.
+void RemoveAndUpdateCommand::processComponent(const QList<Id> &component, const QSet<Id> &nodesSet,
+							QList<ElementInfo> &nodes, QList<ElementInfo> &edges)
+{
+	auto &&repo = mLogicalApi.logicalRepoApi();
+
+	Id incomingEdge;
+	Id outgoingEdge;
+
+	for (auto &&node : component) {
+		auto &&links = repo.links(node);
+		for (auto &&link: links) {
+			auto &&from = repo.from(link);
+			auto &&to = repo.to(link);
+			// This node cannot be located in another component.
+			const auto fromInComponent = nodesSet.contains(from);
+			const auto toInComponent = nodesSet.contains(to);
+
+			// Internal edge, nothing to process.
+			if (fromInComponent && toInComponent) {
+				continue;
+			}
+
+			if (!fromInComponent) {
+				if (!incomingEdge.isNull()) {
+					return;
+				}
+
+				incomingEdge = link;
+			}
+
+			if (!toInComponent) {
+				if (!outgoingEdge.isNull()) {
+					return;
+				}
+
+				outgoingEdge = link;
+			}
+		}
+	}
+
+	if (incomingEdge.isNull() || outgoingEdge.isNull()) {
+		return;
+	}
+
+	reconnectComponent(incomingEdge, outgoingEdge, nodes, edges);
 }
 
 void RemoveAndUpdateCommand::appendGraphicalDelete(const Id &id

--- a/qrgui/editor/commands/removeAndUpdateCommand.h
+++ b/qrgui/editor/commands/removeAndUpdateCommand.h
@@ -31,8 +31,14 @@ public:
 	RemoveAndUpdateCommand(EditorViewScene &scene, const models::Models &models);
 
 	void appendGraphicalDelete(const Id &id, QList<ElementInfo> &nodes, QList<ElementInfo> &edges) override;
-
+	void postprocessCollectedItems(QList<ElementInfo> &nodes, QList<ElementInfo> &edges) override;
 private:
+	QHash<qReal::Id, QList<qReal::Id>> buildAdjacency(const QSet<Id> &nodesSet);
+	QList<QList<Id>> findComponents(const QSet<Id> &nodesSet, const QHash<Id, QList<Id>> &adj);
+	void processComponent(const QList<Id> &component, const QSet<Id> &nodesSet,
+					QList<ElementInfo> &nodes,  QList<ElementInfo> &edges);
+	void reconnectComponent(const Id &incomingEdge, const Id &outgoingEdge,
+					QList<ElementInfo> &nodes, QList<ElementInfo> &edges);
 	EditorViewScene &mScene;
 };
 

--- a/qrgui/models/commands/removeElementsCommand.cpp
+++ b/qrgui/models/commands/removeElementsCommand.cpp
@@ -40,6 +40,7 @@ RemoveElementsCommand *RemoveElementsCommand::withItemsToDelete(const IdList &it
 		}
 	}
 
+	postprocessCollectedItems(nodes, edges);
 	// ElementInfos must be given into implementation in reverse order (in order they will be created during undo).
 	appendHangingEdges(nodes, edges);
 	mExploser.handleRemoveCommand(mExplosionSources, this);
@@ -95,6 +96,10 @@ void RemoveElementsCommand::appendLogicalDelete(const Id &id, QList<ElementInfo>
 	if (graphicalIds.size() != 1) { // else it was done in graphicalDeleteCommand()
 		appendExplosionsCommands(id, nodes, edges);
 	}
+}
+
+void RemoveElementsCommand::postprocessCollectedItems(QList<ElementInfo> &nodes, QList<ElementInfo> &edges)
+{
 }
 
 void RemoveElementsCommand::appendGraphicalDelete(const Id &id, QList<ElementInfo> &nodes, QList<ElementInfo> &edges)

--- a/qrgui/models/commands/removeElementsCommand.cpp
+++ b/qrgui/models/commands/removeElementsCommand.cpp
@@ -100,6 +100,8 @@ void RemoveElementsCommand::appendLogicalDelete(const Id &id, QList<ElementInfo>
 
 void RemoveElementsCommand::postprocessCollectedItems(QList<ElementInfo> &nodes, QList<ElementInfo> &edges)
 {
+	Q_UNUSED(nodes)
+	Q_UNUSED(edges)
 }
 
 void RemoveElementsCommand::appendGraphicalDelete(const Id &id, QList<ElementInfo> &nodes, QList<ElementInfo> &edges)

--- a/qrgui/models/commands/removeElementsCommand.h
+++ b/qrgui/models/commands/removeElementsCommand.h
@@ -54,6 +54,8 @@ public:
 	/// Appends to \a nodes and \a edges a list of element infos to remove the graphical \a id.
 	virtual void appendGraphicalDelete(const Id &id, QList<ElementInfo> &nodes, QList<ElementInfo> &edges);
 
+	virtual void postprocessCollectedItems(QList<ElementInfo> &nodes, QList<ElementInfo> &edges);
+
 	/// Returns information about all elements removed by this command.
 	const QList<ElementInfo> &results() const;
 


### PR DESCRIPTION
The editor now collapses removable linear sections into direct connections, making diagram editing more convenient while preserving complex graph structures.