### PR TITLE
Rename main executable to trik-studio.bin to avoid issues with direct startup

### DIFF
--- a/buildScripts/github/install_installer.sh
+++ b/buildScripts/github/install_installer.sh
@@ -46,7 +46,8 @@ install_installer(){
 }
 
 prepare_environment_variable_and_check_tools(){  
-  EXT=""   
+  EXT=""
+  TS_EXT=""
   case "$(uname)" in
     Darwin)
       PREFIX="/Applications"
@@ -62,6 +63,7 @@ prepare_environment_variable_and_check_tools(){
       PREFIX="/C"
       LIB_DIR="$PREFIX/TRIKStudio"
       EXT=".exe"
+      TS_EXT=".bin"
       ;;
     *) exit 1 ;; 
   esac
@@ -70,7 +72,7 @@ prepare_environment_variable_and_check_tools(){
   
   TWOD_EXEC_NAME=$(find "$APP_DIR" -name "2D-model$EXT" -print -quit)
   PATCHER_NAME=$(find "$APP_DIR" -name "patcher$EXT" -print -quit)
-  TRIK_STUDIO_NAME=$(find "$APP_DIR" -name "trik-studio$EXT" -print -quit)
+  TRIK_STUDIO_NAME=$(find "$APP_DIR" -name "trik-studio$TS_EXT" -print -quit)
   MAINTENANCE=$(find "$APP_DIR" -name "maintenance$EXT" -print -quit)
   
   env DYLD_LIBRARY_PATH="$LIB_DIR" LD_LIBRARY_PATH="$LIB_DIR" "$TWOD_EXEC_NAME" --version

--- a/installer/packages/qreal-base/ru.qreal.root/meta/prebuild-win32.sh
+++ b/installer/packages/qreal-base/ru.qreal.root/meta/prebuild-win32.sh
@@ -29,7 +29,7 @@ rsync -a "$BIN_DIR"/qrgui-tool-plugin-interface.dll                      "$PWD"/
 rsync -a "$BIN_DIR"/qrgui-facade.dll                                     "$PWD"/../data
 rsync -a "$BIN_DIR/patcher.exe"                                          "$PWD/../data"
 rsync -a "$BIN_DIR/checkapp.exe"                                         "$PWD/../data"
-rsync -a "$BIN_DIR"/trik-studio.exe                                      "$PWD/../data/$PRODUCT.exe"
+rsync -a "$BIN_DIR"/trik-studio.exe                                      "$PWD/../data/$PRODUCT.bin"
 rsync -a "$INSTALLER_ROOT/platform/$PRODUCT-safe.cmd"                    "$PWD"/../data/
 rsync -a "$INSTALLER_ROOT/platform/$PRODUCT.vbs"                         "$PWD/../data/"
 rsync -a "$INSTALLER_ROOT/images/trik-studio.ico"                        "$PWD/../data/"

--- a/installer/platform/trik-studio-safe.cmd
+++ b/installer/platform/trik-studio-safe.cmd
@@ -4,4 +4,4 @@ IF ERRORLEVEL 1 ECHO Failed to enable extensions
 TITLE TRIK Studio Safe Mode
 SET "PATH=%SystemRoot%;%SystemRoot%\system32"
 PATH
-%~dp0trik-studio.exe "%*"
+%~dp0trik-studio.bin "%*"

--- a/qrtranslations/fr/plugins/robots/editor/trik_fr.ts
+++ b/qrtranslations/fr/plugins/robots/editor/trik_fr.ts
@@ -829,7 +829,7 @@
     </message>
     <message>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
-        <translation>Écrit la valeur indiquée dans un fichier. Le chemin du fichier peut être absolu ou relatif au dossier contenant trik-studio.exe.</translation>
+        <translation>Écrit la valeur indiquée dans un fichier. Le chemin du fichier peut être absolu ou relatif au dossier contenant trik-studio.bin.</translation>
     </message>
     <message>
         <source>RobotsDiagram</source>

--- a/qrtranslations/ru/plugins/robots/editor/common_ru.ts
+++ b/qrtranslations/ru/plugins/robots/editor/common_ru.ts
@@ -1129,7 +1129,7 @@
     </message>
     <message>
         <source>Removes a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
-        <translation type="vanished">Удаляет файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
+        <translation type="vanished">Удаляет файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.bin.</translation>
     </message>
     <message>
         <source>File</source>
@@ -1357,7 +1357,7 @@
     </message>
     <message>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
-        <translation type="vanished">Записывает заданное значение в файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
+        <translation type="vanished">Записывает заданное значение в файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.bin.</translation>
     </message>
     <message>
         <source>Variable Initialization</source>
@@ -2651,7 +2651,7 @@
     </message>
     <message>
         <source>Removes a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
-        <translation type="vanished">Удаляет файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
+        <translation type="vanished">Удаляет файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.bin.</translation>
     </message>
     <message>
         <source>Synthesizes the given phrase and plays it on the robot. If &apos;Evaluate&apos; property is set to true then the value of &apos;Text&apos; property is interpreted as a formula, otherwise it is interpreted as plain string.</source>
@@ -2703,7 +2703,7 @@
     </message>
     <message>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
-        <translation type="vanished">Записывает заданное значение в файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
+        <translation type="vanished">Записывает заданное значение в файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.bin.</translation>
     </message>
     <message>
         <source>Assigns a given value to a given variable.</source>

--- a/qrtranslations/ru/plugins/robots/editor/trik_ru.ts
+++ b/qrtranslations/ru/plugins/robots/editor/trik_ru.ts
@@ -357,7 +357,7 @@
     </message>
     <message>
         <source>Removes a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
-        <translation>Удаляет файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
+        <translation>Удаляет файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.bin.</translation>
     </message>
     <message>
         <source>File:</source>
@@ -853,7 +853,7 @@
     </message>
     <message>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
-        <translation>Записывает заданное значение в файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.exe.</translation>
+        <translation>Записывает заданное значение в файл. Путь до файла может быть абсолютным или относительно папки с trik-studio.bin.</translation>
     </message>
     <message>
         <source>RobotsDiagram</source>

--- a/qrtranslations/vi/plugins/robots/editor/trik_vi.ts
+++ b/qrtranslations/vi/plugins/robots/editor/trik_vi.ts
@@ -829,7 +829,7 @@
     </message>
     <message>
         <source>Writes a given message to a file. File path may be absolute or relative to a directory containing TRIK Studio executable.</source>
-        <translation>Ghi giá trị đã cho vào tệp. Đường dẫn tệp có thể là tuyệt đối hoặc tương đối so với thư mục chứa trik-studio.exe.</translation>
+        <translation>Ghi giá trị đã cho vào tệp. Đường dẫn tệp có thể là tuyệt đối hoặc tương đối so với thư mục chứa trik-studio.bin.</translation>
     </message>
     <message>
         <source>RobotsDiagram</source>


### PR DESCRIPTION
Renames the main Windows executable from `trik-studio.exe` to `trik-studio.bin` during the build/installer process.

Currently, users can directly execute `trik-studio.exe` (e.g., from the installation folder or a portable zip), which bypasses the environment setup handled by `trik-studio-safe.cmd`. This can lead to potential runtime issues (DLL-hell, or something lighter like missing DLLs, incorrect working directories, etc.). 

By renaming the binary to a non-executable extension (`.bin`), we prevent direct execution by double-click and force the application to be launched via the `trik-studio-safe.cmd` or `trik-studio.vbs`, ensuring a properly configured startup.
