### PR TITLE
Add support for clang-format +precommit autoformat, +CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,155 @@
+Language:        Cpp
+IndentWidth:     8
+TabWidth:        8
+UseTab:		AlignWithSpaces
+ColumnLimit:     120
+SortIncludes:    false
+AccessModifierOffset: -8
+ReflowComments:  false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+AllowShortFunctionsOnASingleLine: None
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterExternBlock: true
+    AfterClass: true
+    AfterFunction: true
+    AfterNamespace: false
+    AfterEnum: false
+    AfterCaseLabel: false  
+    AfterControlStatement: Never
+    AfterStruct:     false
+    AfterUnion:      false
+    BeforeLambdaBody: false
+    BeforeElse: false
+    BeforeCatch:     false
+    BeforeWhile:     false
+    IndentBraces:    false
+    SplitEmptyFunction: true
+    SplitEmptyRecord: false
+    SplitEmptyNamespace: true
+FixNamespaceComments: false
+IndentPPDirectives: AfterHash
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+#SpacesBeforeTrailingComments: -1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+IndentCaseBlocks: false
+IndentCaseLabels: false
+AlignAfterOpenBracket: DontAlign
+BreakConstructorInitializers: BeforeComma
+AlwaysBreakTemplateDeclarations: true
+NamespaceIndentation: None
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: true
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   Align
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: After
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: Always
+BreakBeforeTernaryOperators: true
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+CompactNamespaces: false
+Cpp11BracedListStyle: true
+PointerAlignment: Right
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Leave
+MaxEmptyLinesToKeep: 1
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+  
+IndentAccessModifiers: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentRequiresClause: true
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: OuterScope
+PackConstructorInitializers: BinPack
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortUsingDeclarations: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: "v20.1.0"
+    hooks:
+      - id: clang-format
+
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: mixed-line-ending

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -xeuo pipefail
+which -a clang-format > /dev/null \
+	||  (echo -e "20.0.0\n$(clang-format${1+-$1} --version | grep -Eo '([0-9]+\.[0-9]+\.[0-9]+)')" | sort -CV ) \
+		|| { echo "use '${0} <clang-format-version-not-less-than-15>' to call exact proper version" ; exit 1 ; }
+
+IGNORED_DIRS=(
+    "./plugins/robots/thirdparty"
+    "./qrgui/thirdparty"
+    "./buildScripts"
+    "./thirdparty"
+    "./installer"
+)
+
+IGNORE_CMD=""
+
+for DIR in "${IGNORED_DIRS[@]}"; do
+    IGNORE_CMD+=" -path $DIR -o"
+done
+
+IGNORE_CMD=${IGNORE_CMD% -o}
+
+find . \( $IGNORE_CMD \) -prune -o -name '*.cpp' -print0 -o -name '*.h' -print0 | xargs -0 clang-format${1+-$1} --style=file -i


### PR DESCRIPTION
Add support for clang-format, support for checking clang-format in CI, and a precommit hook for automatic refactoring before committing